### PR TITLE
[chore]: import audits to cargo vet

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1142,15 +1142,6 @@ criteria = "safe-to-deploy"
 version = "0.5.1"
 criteria = "safe-to-deploy"
 
-<<<<<<< HEAD
-[[exemptions.p256k1]]
-version = "7.2.1"
-=======
-[[exemptions.overload]]
-version = "0.1.1"
->>>>>>> main
-criteria = "safe-to-deploy"
-
 [[exemptions.parity-scale-codec]]
 version = "3.6.12"
 criteria = "safe-to-deploy"
@@ -1639,10 +1630,6 @@ criteria = "safe-to-deploy"
 version = "2.9.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.smallvec]]
-version = "1.13.2"
-criteria = "safe-to-deploy"
-
 [[exemptions.snow]]
 version = "0.9.6"
 criteria = "safe-to-deploy"
@@ -1681,10 +1668,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.sqlx-postgres]]
 version = "0.8.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.stable_deref_trait]]
-version = "1.2.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.stacker]]
@@ -2225,10 +2208,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.ws2_32-sys]]
 version = "0.2.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.wsts]]
-version = "10.0.0@git:a7bf38bd54cddf0b78c0f7c521a5ed1537a684fa"
 criteria = "safe-to-deploy"
 
 [[exemptions.wyz]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -979,6 +979,19 @@ version = "0.10.5"
 notes = "Reviewed on https://fxrev.dev/712371."
 aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.smallvec]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.13.2"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.stable_deref_trait]]
+who = "Manish Goregaokar <manishearth@google.com>"
+criteria = "safe-to-deploy"
+version = "1.2.0"
+notes = "Purely a trait, crates using this should be carefully vetted since self-referential stuff can be super tricky around various unsafe rust edges."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.strsim]]
 who = "danakj@chromium.org"
 criteria = "safe-to-deploy"
@@ -1262,7 +1275,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2024-05-03"
+end = "2026-02-01"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 


### PR DESCRIPTION
## Description

I did some googling and found that `cargo vet` do not automatically do any auditing. Instead, on `cargo vet init` it marks all dependencies as "exempted". To shrink size of "exempted" set and move crates to "audited" status there are basically two ways:
- Do audit by ourselves
- Import audits

In this PR I import audits provided by some big parties like Google, Mozilla, Bytecode Alliance, etc. (Actually I just copied imports used in `cargo vet` github repo. This change moves around 100 dependencies from "exempted" to "audited" status. 

However, there is still 600 exempted dependencies. We can add some more audit imports, and shrink this size, but I don't believe we can push it down to zero. And I don't think we need to do this, security is never about "build 100% secure code". It always about "let's add some more 9s to our 99.9999% secure code".

## Changes

Adds audit imports to `cargo vet` and updates `cargo vet` lockfile.

## Testing Information

No testing needed, once CI is green it's fine.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
