### PR TITLE
[feat]: enable integer overflow protection on release builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,4 @@ split-debuginfo = "unpacked"
 [profile.release]
 lto = "thin"
 codegen-units = 16
+overflow-checks = true


### PR DESCRIPTION
## Description

Changes rust compiler config to enable integer overflow checks in release builds

Closes: #1173

## Changes

Changes rust compiler config to enable integer overflow checks in release builds

## Testing Information

No new functionality so no new tests needed

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
