### PR TITLE
feat: validate coordinator proposed bitcoin fees

### DIFF
--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -316,7 +316,7 @@ impl SbtcRequests {
 ///
 /// RBF: https://bitcoinops.org/en/topics/replace-by-fee/
 /// BIP-125: https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#implementation-details
-fn compute_transaction_fee(tx_vsize: f64, fee_rate: f64, last_fees: Option<Fees>) -> u64 {
+pub fn compute_transaction_fee(tx_vsize: f64, fee_rate: f64, last_fees: Option<Fees>) -> u64 {
     match last_fees {
         Some(Fees { total, rate }) => {
             // The requirement for an RBF transaction is that the new fee

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -10,16 +10,14 @@ use std::collections::HashSet;
 use std::time::Duration;
 
 use blockstack_lib::chainstate::stacks::StacksTransaction;
-use futures::future::try_join_all;
 use futures::Stream;
 use futures::StreamExt as _;
 use sha2::Digest;
 
+use crate::bitcoin::rpc::assess_mempool_sweep_transaction_fees;
 use crate::bitcoin::utxo;
-use crate::bitcoin::utxo::Fees;
 use crate::bitcoin::utxo::UnsignedMockTransaction;
 use crate::bitcoin::BitcoinInteract;
-use crate::bitcoin::TransactionLookupHint;
 use crate::context::Context;
 use crate::context::P2PEvent;
 use crate::context::RequestDeciderEvent;
@@ -1830,7 +1828,7 @@ where
             .await?
             .ok_or(Error::MissingSignerUtxo)?;
 
-        let last_fees = self.assess_mempool_sweep_transaction_fees(&utxo).await?;
+        let last_fees = assess_mempool_sweep_transaction_fees(&bitcoin_client, &utxo).await?;
 
         Ok(utxo::SignerBtcState {
             fee_rate,
@@ -2337,109 +2335,6 @@ where
     /// Helper method to get this signer's public key from its private key.
     fn signer_public_key(&self) -> PublicKey {
         PublicKey::from_private_key(&self.private_key)
-    }
-
-    /// Assesses the total fees paid for any outstanding sweep transactions in
-    /// the mempool which may need to be RBF'd. If there are no sweep
-    /// transactions which are spending the signer's UTXO, then this function
-    /// will return [`None`].
-    ///
-    /// TODO: This method currently blindly assumes that the mempool transactions
-    /// are correct. Maybe we need some validation?
-    #[tracing::instrument(skip_all, fields(signer_utxo = %signer_utxo.outpoint))]
-    pub async fn assess_mempool_sweep_transaction_fees(
-        &self,
-        signer_utxo: &utxo::SignerUtxo,
-    ) -> Result<Option<Fees>, Error> {
-        let bitcoin_client = self.context.get_bitcoin_client();
-
-        // Find the mempool transactions that are spending the provided UTXO.
-        let mempool_txs_spending_utxo = bitcoin_client
-            .find_mempool_transactions_spending_output(&signer_utxo.outpoint)
-            .await?;
-
-        // If no transactions are found, we have nothing to do.
-        if mempool_txs_spending_utxo.is_empty() {
-            tracing::debug!(
-                outpoint = %signer_utxo.outpoint,
-                "no mempool transactions found spending signer output; nothing to do"
-            );
-            return Ok(None);
-        }
-
-        tracing::debug!(
-            outpoint = %signer_utxo.outpoint,
-            "found mempool transactions spending signer output; assessing fees"
-        );
-
-        // If we have some transactions, we need to find the one that pays the
-        // highest fee. This is the transaction that we will use as the root of
-        // the sweep package. Note that even if only one transaction was
-        // returned above, we still need to get the fee for it, which is why
-        // there's no special logic for one vs multiple.
-        //
-        // This can technically error if the mempool transactions are not found,
-        // but it shouldn't happen since we got the transaction ids from
-        // bitcoin-core itself.
-        let best_sweep_root = try_join_all(mempool_txs_spending_utxo.iter().map(|txid| {
-            let bitcoin_client = bitcoin_client.clone();
-            async move {
-                bitcoin_client
-                    .get_transaction_fee(txid, Some(TransactionLookupHint::Mempool))
-                    .await
-                    .map(|fee| (txid, fee))
-            }
-        }))
-        .await?
-        .into_iter()
-        .max_by_key(|(_, fees)| fees.fee);
-
-        // Since we got the transaction ids from bitcoin-core, these should
-        // not be missing, but we double-check here just in case (it could
-        // happen that the client has failed-over to the next node which isn't
-        // in sync with the previous one, for example).
-        let Some((best_sweep_root_txid, fees)) = best_sweep_root else {
-            tracing::warn!(
-                outpoint = %signer_utxo.outpoint,
-                "no fees found for mempool transactions spending signer output"
-            );
-            return Ok(None);
-        };
-
-        // Retrieve all descendant transactions of the best sweep root.
-        let descendant_txids = bitcoin_client
-            .find_mempool_descendants(best_sweep_root_txid)
-            .await?;
-
-        // Retrieve fees for all descendant transactions. If there were no
-        // descendants then this will just result in an empty list.
-        let descendant_fees = try_join_all(descendant_txids.iter().map(|txid| {
-            let bitcoin_client = bitcoin_client.clone();
-            async move {
-                bitcoin_client
-                    .get_transaction_fee(txid, Some(TransactionLookupHint::Mempool))
-                    .await
-            }
-        }))
-        .await?;
-
-        // Sum the fees of the best sweep root and its descendants, while also
-        // summing the vsize of the transactions for fee-rate calculation later.
-        // If there were no descendants then this will just be the fee and size
-        // from the best root sweep transaction.
-        let (total_fees, total_vsize) = descendant_fees
-            .into_iter()
-            .fold((fees.fee, fees.vsize), |acc, fees| {
-                (acc.0 + fees.fee, acc.1 + fees.vsize)
-            });
-
-        // Calculate the fee rate based on the total fees and vsizes of the
-        // transactions which we've found. Since this is returning transactions
-        // from bitcoin-core, we should have valid fees and sizes, so we don't
-        // need to check for division by zero.
-        let rate = total_fees as f64 / total_vsize as f64;
-
-        Ok(Some(Fees { total: total_fees, rate }))
     }
 }
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -11,6 +11,7 @@ use std::time::Duration;
 
 use crate::bitcoin::utxo::UnsignedMockTransaction;
 use crate::bitcoin::validation::BitcoinTxContext;
+use crate::bitcoin::BitcoinInteract;
 use crate::context::Context;
 use crate::context::P2PEvent;
 use crate::context::SignerCommand;
@@ -399,12 +400,18 @@ where
                     .aggregate_key
             }
         };
+        let estimated_fee_rate = self
+            .context
+            .get_bitcoin_client()
+            .estimate_fee_rate()
+            .await?;
 
         let btc_ctx = BitcoinTxContext {
             chain_tip: chain_tip.block_hash,
             chain_tip_height: chain_tip.block_height,
             signer_public_key: self.signer_public_key(),
             aggregate_key,
+            estimated_fee_rate,
         };
 
         tracing::debug!("validating bitcoin transaction pre-sign");

--- a/signer/tests/integration/bitcoin_validation.rs
+++ b/signer/tests/integration/bitcoin_validation.rs
@@ -142,6 +142,7 @@ async fn one_tx_per_request_set() {
         chain_tip_height: chain_tip_block.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -247,6 +248,7 @@ async fn one_invalid_deposit_invalidates_tx() {
         chain_tip_height: chain_tip_block.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -300,6 +302,96 @@ async fn one_invalid_deposit_invalidates_tx() {
     assert_eq!(deposit2.prevout_output_index, outpoint.vout);
     assert!(!deposit2.will_sign);
     assert!(!deposit2.is_valid_tx);
+
+    testing::storage::drop_db(db).await;
+}
+
+#[test_case(5.0, true; "coordinator-txn-fee-is-valid")]
+#[test_case(5.1, false; "coordinator-txn-fee-is-too-high")]
+#[tokio::test]
+async fn transaction_is_rejected_if_fee_provided_by_coordinator_is_too_high(
+    times_larger_fee: f64,
+    should_sign: bool,
+) {
+    let db = testing::storage::new_test_database().await;
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (rpc, faucet) = regtest::initialize_blockchain();
+
+    let ctx = TestContext::builder()
+        .with_storage(db.clone())
+        .with_first_bitcoin_core_client()
+        .with_mocked_stacks_client()
+        .with_mocked_emily_client()
+        .build();
+    ctx.state().update_current_limits(SbtcLimits::unlimited());
+
+    let signers = TestSignerSet::new(&mut rng);
+    let amounts = [SweepAmounts {
+        amount: 1_000_000,
+        max_fee: 500_000,
+        is_deposit: true,
+    }];
+
+    let mut setup = TestSweepSetup2::new_setup(signers, &faucet, &amounts);
+    setup.deposits.sort_by_key(|(x, _, _)| x.outpoint);
+    backfill_bitcoin_blocks(&db, rpc, &setup.deposit_block_hash).await;
+
+    setup.store_stacks_genesis_block(&db).await;
+    setup.store_dkg_shares(&db).await;
+    setup.store_donation(&db).await;
+    setup.store_deposit_txs(&db).await;
+    setup.store_deposit_request(&db).await;
+    setup.store_deposit_decisions(&db).await;
+
+    let chain_tip_block = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+
+    let aggregate_key = setup.signers.signer.keypair.public_key().into();
+
+    let request = BitcoinPreSignRequest {
+        request_package: vec![TxRequestIds {
+            deposits: setup.deposit_outpoints(),
+            withdrawals: Vec::new(),
+        }],
+        fee_rate: TEST_FEE_RATE * times_larger_fee,
+        last_fees: None,
+    };
+
+    let btc_ctx = BitcoinTxContext {
+        chain_tip: chain_tip_block.block_hash,
+        chain_tip_height: chain_tip_block.block_height,
+        signer_public_key: setup.signers.keys[0],
+        aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
+    };
+
+    let validation_data = request
+        .construct_package_sighashes(&ctx, &btc_ctx)
+        .await
+        .unwrap();
+    // There are a few invariants that we uphold for our validation data.
+    // These are things like "the transaction ID per package must be the
+    // same", we check for them here.
+    validation_data.assert_invariants();
+    // We only had a package with one set of requests that were being
+    // handled.
+    assert_eq!(validation_data.len(), 1);
+
+    // We didn't give any withdrawals so the outputs vector should be
+    // empty (it only has signer outputs).
+    let set = &validation_data[0];
+    assert!(set.to_withdrawal_rows().is_empty());
+
+    // This transaction package
+    let input_rows = set.to_input_rows();
+    let [signer, deposit] = input_rows.last_chunk().unwrap();
+    assert_eq!(signer.will_sign, should_sign);
+    assert_eq!(signer.is_valid_tx, should_sign);
+    assert_eq!(deposit.will_sign, should_sign);
+    assert_eq!(deposit.is_valid_tx, should_sign);
 
     testing::storage::drop_db(db).await;
 }
@@ -413,6 +505,7 @@ async fn withdrawals_and_deposits_can_pass_validation(amounts: Vec<SweepAmounts>
         chain_tip_height: chain_tip_ref.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -519,6 +612,7 @@ async fn swept_withdrawals_fail_validation() {
         chain_tip_height: chain_tip_ref.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -641,6 +735,7 @@ async fn cannot_sign_deposit_is_ok() {
         chain_tip_height: chain_tip_block.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -779,6 +874,7 @@ async fn sighashes_match_from_sbtc_requests_object() {
         chain_tip_height: chain_tip_block.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data = request
@@ -923,6 +1019,7 @@ async fn outcome_is_independent_of_input_order() {
         chain_tip_height: chain_tip_block.block_height,
         signer_public_key: setup.signers.keys[0],
         aggregate_key,
+        estimated_fee_rate: TEST_FEE_RATE,
     };
 
     let validation_data1 = request


### PR DESCRIPTION
## Description

Closes the Bitcoin half of: #1192

This PR is from another PR (#1392) that got split up to separate Bitcoin and Stacks behavior.

This part was separated from the Stacks half because there's an issue with the way the transaction will be represented in the Signer database when a transaction is marked as invalid based on the coordinator's proposed fee:

> @djordon 
> The only trouble with this is that it's not clear why the the transaction is invalid when looking at the data in the signers' database. I wonder if we should do something else here instead. Maybe we could change the result for the signers' UTXO to be something other than Ok when the fee is too high?  

## Changes

- Adds logic to bitcoin transaction validation that considers a transaction to be invalid if the fee on it is more than 5 times plus 5 satoshis greater than the Signer estimates it should cost.
- Adds unit tests and integration tests

## Testing Information

unit and integration tests

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
