### PR TITLE
chore(ci): add pull_request trigger to on-push workflow

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,5 +1,8 @@
 name: On Push
-on: [push]
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 permissions: read-all
 


### PR DESCRIPTION
## Description

Adds the `pull_request` trigger to the `on-push` workflow so that PR's from external forks run.