### PR TITLE
chore: bump rust to 1.86.0

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-slim-bookworm AS build
+FROM rust:1.86.0-slim-bookworm AS build
 
 ARG CARGO_BUILD_ARGS="--release --locked"
 

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-slim-bookworm AS build
+FROM rust:1.86.0-slim-bookworm AS build
 
 ARG GIT_COMMIT
 RUN test -n "$GIT_COMMIT" || (echo "GIT_COMMIT not set" && false)

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Below is the output on a machine that is able to build and run all the sources a
 
 ```
 --- sBTC tool versions ---
-cargo 1.85.1 (d73d2caf9 2024-12-31)
+cargo 1.86.0 (adf9b6ad1 2025-02-28)
 cargo-lambda 1.2.1 (12f9b61 2024-04-05Z)
 pnpm 9.1.0
 GNU Make 3.81

--- a/docker/sbtc/Dockerfile
+++ b/docker/sbtc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85.1-slim-bookworm AS builder
+FROM rust:1.86.0-slim-bookworm AS builder
 
 # Install dependencies.
 RUN apt-get update

--- a/emily/handler/src/api/handlers/internal.rs
+++ b/emily/handler/src/api/handlers/internal.rs
@@ -28,12 +28,12 @@ pub struct ExecuteReorgRequest {
 ///
 /// Return meanings:
 /// - Err(e):
-///     Something went wrong.
+///   Something went wrong.
 /// - Ok(None):
-///     The API status is already what we wanted it to be, so there's
-///     no action required.
+///   The API status is already what we wanted it to be, so there's
+///   no action required.
 /// - Ok(Some(ApiStateEntry)):
-///     We have successfully converted the api to the state returned.
+///   We have successfully converted the api to the state returned.
 async fn set_api_state_status(
     context: &EmilyContext,
     new_status: &ApiStatus,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.85.1"
+channel = "1.86.0"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 profile = "minimal"

--- a/sbtc/src/idpack/segmenters/bitmap.rs
+++ b/sbtc/src/idpack/segmenters/bitmap.rs
@@ -283,7 +283,7 @@ impl BitmapSegmenter {
     ///
     /// ## Returns
     /// * `true` if values are sorted in ascending order and doesn't contain
-    ///    duplicates,
+    ///   duplicates,
     /// * `false` otherwise
     #[inline]
     fn is_unique_sorted(values: &[u64]) -> bool {

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -397,7 +397,7 @@ where
     /// ## Returns
     /// - `true` if the IDs will fit within the OP_RETURN size limits.
     /// - `false` if the IDs exceed the size limits, or an error occurs during
-    //    estimation (for example if the id's have become unsorted or contain
+    ///    estimation (for example if the id's have become unsorted or contain
     ///   duplicates).
     fn can_fit_withdrawal_ids(&self, ids: &[u64]) -> bool {
         if ids.is_empty() {

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -397,8 +397,8 @@ where
     /// ## Returns
     /// - `true` if the IDs will fit within the OP_RETURN size limits.
     /// - `false` if the IDs exceed the size limits, or an error occurs during
-    ///    estimation (for example if the id's have become unsorted or contain
-    ///    duplicates).
+    //    estimation (for example if the id's have become unsorted or contain
+    ///   duplicates).
     fn can_fit_withdrawal_ids(&self, ids: &[u64]) -> bool {
         if ids.is_empty() {
             return true;

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -397,7 +397,7 @@ where
     /// ## Returns
     /// - `true` if the IDs will fit within the OP_RETURN size limits.
     /// - `false` if the IDs exceed the size limits, or an error occurs during
-    ///    estimation (for example if the id's have become unsorted or contain
+    ///   estimation (for example if the id's have become unsorted or contain
     ///   duplicates).
     fn can_fit_withdrawal_ids(&self, ids: &[u64]) -> bool {
         if ids.is_empty() {

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -156,7 +156,7 @@ impl<'a> RequestPreprocessor<'a> {
 
     /// Validate deposit requests based on four constraints:
     /// 1. The user's max fee must be >= our minimum required fee for deposits
-    ///     (based on fixed deposit tx size)
+    ///    (based on fixed deposit tx size)
     /// 2. The deposit amount must be greater than or equal to the per-deposit minimum
     /// 3. The deposit amount must be less than or equal to the per-deposit cap
     /// 4. The total amount being minted must stay under the peg cap
@@ -195,8 +195,8 @@ impl<'a> RequestPreprocessor<'a> {
 
     /// Validate withdrawal requests based on three constraints:
     /// 1. The user's max fee must be >= our minimum required fee for
-    ///     withdrawals (based on the max transaction size for the allowed
-    ///     scriptPubKeys).
+    ///    withdrawals (based on the max transaction size for the allowed
+    ///    scriptPubKeys).
     /// 2. The withdrawal amount must be less than or equal to the
     ///    per-withdrawal cap.
     /// 3. The total amount being withdrawn must stay under the rolling


### PR DESCRIPTION
## Description

Bumps rust to [1.86.0](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html) and fixes a few new clippy lints. 

## Changes

- Updates `rust-toolchain.toml` to use rust 1.86
- Fixes new/updated clippy lints

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
