### PR TITLE
chore(ci): fix double CI-runs between PR and push

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -10,7 +10,7 @@ concurrency:
   # Ensure that this workflow only runs once at a time for each PR or push,
   # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
   group: push-pr-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: true 
 
 env:
   NODE_VERSION: 22.1.0

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,6 +1,5 @@
 name: Push & PR
 on:
-  push:
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -9,7 +9,7 @@ permissions: read-all
 concurrency:
   # Ensure that this workflow only runs once at a time for each PR or push,
   # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
-  group: on-pr-or-push-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -10,7 +10,7 @@ concurrency:
   # Ensure that this workflow only runs once at a time for each PR or push,
   # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
   group: push-pr-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true 
+  cancel-in-progress: true
 
 env:
   NODE_VERSION: 22.1.0

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -11,7 +11,7 @@ permissions: read-all
 concurrency:
   # Ensure that this workflow only runs once at a time for each PR or push,
   # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
-  group: push-pr-${{ github.head_ref || github.ref }}
+  group: push-pr-${{ github.head_ref || github.ref_name || github.run_id}}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,4 +1,4 @@
-name: On Push
+name: On PR/Push
 on:
   push:
   pull_request:
@@ -7,8 +7,9 @@ on:
 permissions: read-all
 
 concurrency:
-  # limit concurrency of entire workflow runs for a specific branch
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Ensure that this workflow only runs once at a time for each PR or push,
+  # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
+  group: on-pr-or-push-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,5 +1,8 @@
 name: Push & PR
 on:
+  push:
+    branches:
+      - main
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,4 +1,4 @@
-name: On PR/Push
+name: Push & PR
 on:
   push:
   pull_request:
@@ -9,7 +9,7 @@ permissions: read-all
 concurrency:
   # Ensure that this workflow only runs once at a time for each PR or push,
   # cancelling any in-progress runs for the same HEAD (PR) or branch (Push).
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: push-pr-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -1,10 +1,23 @@
 name: Push & PR
 on:
+  # We explicitly filter on `main` to avoid triggering on pushes to PR branches,
+  # which would otherwise be triggered by the `pull_request.synchronize` event
+  # and cause multiple runs of the same workflow for the same push.
+  # When the merge queue merges to main, it will trigger this workflow.
   push:
     branches:
       - main
+  # This trigger will trigger on pushes to PR branches via the `synchronize`
+  # event type.
   pull_request:
     types: [opened, synchronize, reopened]
+  # This is required for the merge queue to work properly with the CI-required
+  # check. `checks_requested` is currently the only event type supported, but
+  # we're being explicit to avoid the potential addition of types like
+  # `checks_completed`, `queue_position`, etc. in the future from causing
+  # multiple CI runs for the same merge queue entry.
+  merge_group:
+    types: [checks_requested]
 
 permissions: read-all
 


### PR DESCRIPTION
## Description

Turns out we ran into the issue of concurrently running (same) workflows for push + PR, this attempts to resolve it.

## Changes

Changes the concurrency grouping to use `${{ github.workflow }}-${{ github.head_ref || github.ref }}` instead of only `github.ref`. `github.head_ref` is apparently used for PRs, and `github.ref` for pushes. This should hopefully result in them being the same for both...

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
