### PR TITLE
fix: ignore (and log) coinbase tx

### DIFF
--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -25,7 +25,7 @@ pub mod testing;
 ///
 /// This particular X-coordinate was discussed in the original taproot BIP
 /// on spending rules BIP-0341[1]. Specifically, the X-coordinate is formed
-/// by taking the hash of the standard uncompressed encoding of the 
+/// by taking the hash of the standard uncompressed encoding of the
 /// secp256k1 base point G as the X-coordinate. In that BIP the authors
 /// wrote the X-coordinate that is reproduced below.
 ///

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -132,6 +132,21 @@ pub struct BitcoinTxInfo {
     pub block_time: u64,
 }
 
+/// Slim version of `BitcoinTxVin` for coinbase check
+#[derive(Clone, PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
+struct BitcoinCoinbaseTxVin {
+    /// Most of the details to the input into the transaction
+    #[serde(flatten)]
+    pub details: GetRawTransactionResultVin,
+}
+
+/// Slim version of `BitcoinTxInfo` for coinbase check
+#[derive(Clone, PartialEq, Eq, Debug, serde::Deserialize, serde::Serialize)]
+struct BitcoinCoinbaseTxInfo {
+    /// The inputs into the transaction.
+    pub vin: Vec<BitcoinCoinbaseTxVin>,
+}
+
 /// A slimmed down version of the `BitcoinTxInfo` struct which only contains the
 /// `fee`, `vsize`, and `confirmations` fields; used in fee-retrieval contexts.
 #[derive(Debug, Clone, Deserialize)]
@@ -403,8 +418,31 @@ impl BitcoinCoreClient {
             // in the provided block. Use `gettransaction` for wallet
             // transactions." In both cases the code is the same.
             Err(BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -5, .. }))) => Ok(None),
-            Err(err) => Err(Error::BitcoinCoreGetTransaction(err, *txid)),
+            Err(err) => {
+                // If the transaction is coinbase, return a specific error.
+                // Such transactions fail decoding with missing `prevout`, and
+                // here we filter for such decoding errors before calling
+                // `is_coinbase`.
+                if matches!(err,
+                    BtcRpcError::JsonRpc(JsonRpcError::Json(ref json_err))
+                        if json_err.classify() == serde_json::error::Category::Data)
+                    && self.is_coinbase(&args).unwrap_or(false)
+                {
+                    Err(Error::BitcoinTxCoinbase(*txid, Some(*block_hash)))
+                } else {
+                    Err(Error::BitcoinCoreGetTransaction(err, *txid))
+                }
+            }
         }
+    }
+
+    /// Repeat the `get_tx_info` rpc call with a slim data model to check if the
+    /// transaction queried for is a coinbase tx.
+    fn is_coinbase(&self, args: &[serde_json::Value]) -> Option<bool> {
+        self.inner
+            .call::<BitcoinCoinbaseTxInfo>("getrawtransaction", args)
+            .map(|res| res.vin.iter().any(|vin| vin.details.coinbase.is_some()))
+            .ok()
     }
 
     /// Fetch and decode raw transaction from bitcoin-core using the

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -90,6 +90,10 @@ impl DepositRequestValidator for CreateDepositRequest {
             return Ok(None);
         };
 
+        if response.tx.is_coinbase() {
+            return Err(Error::BitcoinTxCoinbase(self.outpoint.txid));
+        }
+
         // The `get_tx_info` call here should not return None, we know that
         // it has been included in a block.
         let Some(tx_info) = client.get_tx_info(&self.outpoint.txid, &block_hash).await? else {
@@ -436,21 +440,20 @@ impl<C: Context, B> BlockObserver<C, B> {
                 continue;
             }
 
+            let txid = tx.compute_txid();
+            if tx.is_coinbase() {
+                tracing::warn!(%txid, "ignoring coinbase tx when extracting sbtc transaction");
+                continue;
+            }
+
             // This function is called after we have received a
             // notification of a bitcoin block, and we are iterating
             // through all of the transactions within that block. This
             // means the `get_tx_info` call below should not fail.
-            let txid = tx.compute_txid();
-
-            let tx_info_result = btc_rpc.get_tx_info(&txid, &block_hash).await;
-
-            // If the tx is coinbase, we just ignore it.
-            if let Err(err @ Error::BitcoinTxCoinbase(_, _)) = tx_info_result {
-                tracing::warn!(%err, "ignoring coinbase tx when extracting sbtc transaction");
-                continue;
-            }
-
-            let tx_info = tx_info_result?.ok_or(Error::BitcoinTxMissing(txid, None))?;
+            let tx_info = btc_rpc
+                .get_tx_info(&txid, &block_hash)
+                .await?
+                .ok_or(Error::BitcoinTxMissing(txid, None))?;
 
             // sBTC transactions have as first txin a signers spendable output
             let tx_type = if tx_info.is_signer_created(&signer_script_pubkeys) {

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -177,6 +177,10 @@ pub enum Error {
     #[error("transaction is missing, txid: {0}, block hash {1:?}")]
     BitcoinTxMissing(bitcoin::Txid, Option<bitcoin::BlockHash>),
 
+    /// The bitcoin transaction is a coinbase (that we don't support)
+    #[error("transaction is coinbase, txid: {0}, block hash {1:?}")]
+    BitcoinTxCoinbase(bitcoin::Txid, Option<bitcoin::BlockHash>),
+
     /// This is the error that is returned when validating a bitcoin
     /// transaction.
     #[error("bitcoin validation error: {0}")]
@@ -723,7 +727,7 @@ pub enum Error {
 
     /// Error when withdrawal requests would exceed sBTC's rolling withdrawal caps
     #[error("total withdrawal amounts ({amounts}) exceeds rolling caps ({cap} over
-            {cap_blocks}) with the currently withdrawn total {withdrawn_total})", 
+            {cap_blocks}) with the currently withdrawn total {withdrawn_total})",
             amounts = .0.amounts, cap = .0.cap, cap_blocks = .0.cap_blocks, withdrawn_total = .0.withdrawn_total)]
     ExceedsWithdrawalCap(WithdrawalCapContext),
 

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -178,8 +178,8 @@ pub enum Error {
     BitcoinTxMissing(bitcoin::Txid, Option<bitcoin::BlockHash>),
 
     /// The bitcoin transaction is a coinbase (that we don't support)
-    #[error("transaction is coinbase, txid: {0}, block hash {1:?}")]
-    BitcoinTxCoinbase(bitcoin::Txid, Option<bitcoin::BlockHash>),
+    #[error("transaction is coinbase, txid: {0}")]
+    BitcoinTxCoinbase(bitcoin::Txid),
 
     /// This is the error that is returned when validating a bitcoin
     /// transaction.

--- a/signer/src/storage/postgres.rs
+++ b/signer/src/storage/postgres.rs
@@ -449,7 +449,7 @@ impl PgStore {
               ON bo.txid = bi.txid
             JOIN sbtc_signer.bitcoin_transactions AS bt
               ON bt.txid = bi.txid
-            JOIN bitcoin_blockchain_until($1, $2) AS bb 
+            JOIN bitcoin_blockchain_until($1, $2) AS bb
               ON bb.block_hash = bt.block_hash
             WHERE bo.output_type = 'signers_output'
               AND bi.prevout_type = 'signers_input'
@@ -853,7 +853,7 @@ impl PgStore {
               , wr.block_hash   AS stacks_block_hash
               , sb.block_height AS stacks_block_height
             FROM sbtc_signer.withdrawal_requests AS wr
-            JOIN sbtc_signer.stacks_blocks AS sb 
+            JOIN sbtc_signer.stacks_blocks AS sb
               ON sb.block_hash = wr.block_hash
             LEFT JOIN sbtc_signer.withdrawal_signers AS ws
               ON ws.request_id = wr.request_id
@@ -885,7 +885,7 @@ impl PgStore {
     ) -> Result<Option<model::BitcoinTxRef>, Error> {
         sqlx::query_as::<_, model::BitcoinTxRef>(
             r#"
-            SELECT 
+            SELECT
                 bwo.bitcoin_txid AS txid
               , bt.block_hash
             FROM sbtc_signer.withdrawal_requests AS wr
@@ -1506,7 +1506,7 @@ impl super::DbRead for PgStore {
             -- get_pending_accepted_withdrawal_requests
             WITH recursive
 
-            -- Get all withdrawal requests which have a bitcoin block height 
+            -- Get all withdrawal requests which have a bitcoin block height
             -- of at least minimum height provided.
             requests AS (
                 SELECT
@@ -1532,7 +1532,7 @@ impl super::DbRead for PgStore {
                 -- Join in any rejection events we know about.
                 LEFT JOIN sbtc_signer.withdrawal_reject_events AS wre
                     ON wre.request_id = wr.request_id
-                
+
                 -- Only requests where the bitcoin height is >= than the minimum.
                 WHERE wr.bitcoin_block_height >= $3
             ),
@@ -1569,7 +1569,7 @@ impl super::DbRead for PgStore {
                 JOIN bitcoin_blockchain anchor
                     ON anchor.block_hash = parent.bitcoin_anchor
             )
-            
+
             -- Main select clause (what we're returning).
             SELECT
                 wr.request_id
@@ -1602,7 +1602,7 @@ impl super::DbRead for PgStore {
             LEFT JOIN stacks_blockchain AS canonical_reject
                 ON wr.reject_block_hash = canonical_reject.block_hash
 
-            GROUP BY 
+            GROUP BY
                 wr.request_id
               , wr.block_hash
               , wr.txid
@@ -1620,7 +1620,7 @@ impl super::DbRead for PgStore {
                 -- Ensure there are no confirmed reject contract-calls.
                 AND COUNT(canonical_reject.block_hash) = 0
 
-            ORDER BY 
+            ORDER BY
                 wr.request_id ASC
             "#,
         )
@@ -1708,7 +1708,7 @@ impl super::DbRead for PgStore {
             -- Request is expired
             WHERE wr.bitcoin_block_height < $4
 
-            -- we need to group since we could have multiple withdrawals 
+            -- we need to group since we could have multiple withdrawals
             -- outputs for a single request, and some of them may not be in
             -- the canonical chain, resulting in a NULL bc_trx.block_hash;
             -- so we group and check that all the rows have NULL

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1624,7 +1624,7 @@ async fn block_observer_ignores_coinbase() {
     let validate_result =
         signer::block_observer::DepositRequestValidator::validate(&request, &bitcoin_client, false);
     match validate_result.await {
-        Err(Error::BitcoinTxCoinbase(tx, _)) if tx == deposit_request.outpoint.txid => {}
+        Err(Error::BitcoinTxCoinbase(tx)) if tx == deposit_request.outpoint.txid => {}
         _ => panic!("Expected a err, got something else"),
     }
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -15,11 +15,16 @@ use bitcoincore_rpc::RpcApi as _;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
 use blockstack_lib::net::api::getpoxinfo::RPCPoxInfoData;
+use clarity::types::chainstate::StacksAddress;
+use clarity::vm::types::PrincipalData;
 use emily_client::apis::deposit_api;
 use emily_client::models::CreateDepositRequestBody;
 use fake::Fake as _;
 use fake::Faker;
 use rand::SeedableRng as _;
+use sbtc::deposits::CreateDepositRequest;
+use sbtc::deposits::DepositScriptInputs;
+use sbtc::deposits::ReclaimScriptInputs;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::Recipient;
 use signer::bitcoin::utxo::SbtcRequests;
@@ -1414,4 +1419,252 @@ async fn block_observer_updates_dkg_shares_after_observing_bitcoin_block() {
     assert!(assert_allow_dkg_begin(&ctx, &db_chain_tip).await.is_ok());
 
     testing::storage::drop_db(db).await;
+}
+
+#[test_log::test(tokio::test)]
+async fn block_observer_ignores_coinbase() {
+    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let (rpc, faucet) = regtest::initialize_blockchain();
+
+    let emily_client = EmilyClient::try_new(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+        None,
+    )
+    .unwrap();
+
+    testing_api::wipe_databases(&emily_client.config().as_testing())
+        .await
+        .unwrap();
+
+    // Generate a block to ensure we start with an empty mempool
+    faucet.generate_block();
+
+    let chain_tip_info = rpc.get_chain_tips().unwrap().pop().unwrap();
+
+    // 1. Create a database, an associated context for the block observer.
+
+    let db = testing::storage::new_test_database().await;
+    let mut ctx = TestContext::builder()
+        .with_storage(db.clone())
+        .with_first_bitcoin_core_client()
+        .with_emily_client(emily_client.clone())
+        .with_mocked_stacks_client()
+        .build();
+
+    let mut signal_receiver = ctx.get_signal_receiver();
+
+    // The block observer reaches out to the stacks node to get the most
+    // up-to-date information. We don't have stacks-core running so we mock
+    // these calls.
+    ctx.with_stacks_client(|client| {
+        client
+            .expect_get_tenure_info()
+            .returning(move || Box::pin(std::future::ready(Ok(DUMMY_TENURE_INFO.clone()))));
+
+        let chain_tip = BitcoinBlockHash::from(chain_tip_info.hash);
+        client.expect_get_tenure().returning(move |_| {
+            let mut tenure = TenureBlocks::nearly_empty().unwrap();
+            tenure.anchor_block_hash = chain_tip;
+            Box::pin(std::future::ready(Ok(tenure)))
+        });
+
+        client.expect_get_pox_info().returning(|| {
+            let response = serde_json::from_str::<RPCPoxInfoData>(GET_POX_INFO_JSON)
+                .map_err(Error::JsonSerialize);
+            Box::pin(std::future::ready(response))
+        });
+    })
+    .await;
+
+    // ** Step 2 **
+    //
+    // Start the BlockObserver
+    //
+    // We only proceed with the test after the process has started, and
+    // we use this counter to notify us when that happens.
+    let start_flag = Arc::new(AtomicBool::new(false));
+    let flag = start_flag.clone();
+
+    let block_observer = BlockObserver {
+        context: ctx.clone(),
+        bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT).await,
+    };
+
+    tokio::spawn(async move {
+        flag.store(true, Ordering::Relaxed);
+        block_observer.run().await
+    });
+
+    while !start_flag.load(Ordering::SeqCst) {
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+
+    // Let's do a sanity check that we do not have any donation or deposit.
+    assert!(fetch_output(&db, TxOutputType::Donation).await.is_empty());
+    assert!(fetch_input(&db, TxPrevoutType::Deposit).await.is_empty());
+
+    // ** Step 3 **
+    //
+    // Create a coinbase tx sending funds to the signers. In this case there is
+    // only one signer in the signer set.
+    let signer = Recipient::new(AddressType::P2tr);
+
+    // We need to have run DKG in order for the block observer to know
+    // which addresses to filter on.
+    let mut shares: EncryptedDkgShares = Faker.fake_with_rng(&mut rng);
+    shares.aggregate_key = signer.keypair.public_key().into();
+    shares.script_pubkey = shares.aggregate_key.signers_script_pubkey().into();
+    shares.dkg_shares_status = model::DkgSharesStatus::Verified;
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    // Okay, now to make the actual coinbase donation. We send some funds to
+    // their address.
+    let script_pub_key = shares.script_pubkey.deref();
+    let address = Address::from_script(script_pub_key, bitcoin::Network::Regtest).unwrap();
+
+    // We include also another donation to ensure we correctly process the block
+    let donation_amount = 123_456;
+    let donation_outpoint = faucet.send_to(donation_amount, &address);
+
+    rpc.generate_to_address(1, &address).unwrap();
+
+    // Let's wait for the block observer to signal that it has finished
+    // processing everything.
+    let signal = signal_receiver.recv();
+    let Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) = signal.await else {
+        panic!("Not the right signal")
+    };
+
+    // Okay now we check we ignored the coinbase donation but processed the
+    // block as expected and have the second donation.
+    let donations = fetch_output(&db, TxOutputType::Donation).await;
+    assert_eq!(donations.len(), 1);
+    let TxOutput { txid, output_index, amount, .. } = donations[0];
+
+    assert_eq!(amount, donation_amount);
+    assert_eq!(output_index, donation_outpoint.vout);
+    assert_eq!(txid.deref(), &donation_outpoint.txid);
+
+    // ** Step 4 **
+    //
+    // Create a deposit from coinbase.
+
+    // First, we also send a donation (that will endup in the same block as the
+    // deposit) to ensure we process the block just fine.
+    let donation_amount_2 = 123_456 + 1;
+    let donation_outpoint_2 = faucet.send_to(donation_amount_2, &address);
+
+    let max_fee = 100_042;
+    let signers_public_key = shares.aggregate_key.into();
+    let (deposit_tx, deposit_request) =
+        make_coinbase_deposit_request(&rpc, max_fee, signers_public_key);
+
+    // `make_coinbase_deposit_request` will generate a block, ensure we process
+    // it just fine.
+    let signal = signal_receiver.recv();
+    let Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) = signal.await else {
+        panic!("Not the right signal")
+    };
+
+    // ** Step 5 **
+    //
+    // Inform emily about the deposit
+    let body = CreateDepositRequestBody {
+        bitcoin_tx_output_index: deposit_request.outpoint.vout,
+        bitcoin_txid: deposit_request.outpoint.txid.to_string(),
+        deposit_script: deposit_request.deposit_script.to_hex_string(),
+        reclaim_script: deposit_request.reclaim_script.to_hex_string(),
+        transaction_hex: serialize_hex(&deposit_tx),
+    };
+    dbg!(
+        deposit_api::create_deposit(emily_client.config(), body)
+            .await
+            .unwrap()
+    );
+
+    // ** Step 6 **
+    //
+    // Check that the block observer populates the tables correctly
+    faucet.generate_blocks(1);
+
+    // Okay now there is a deposit, and it has been confirmed. We should
+    // pick it up automatically.
+    let signal = signal_receiver.recv();
+    let Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) = signal.await else {
+        panic!("Not the right signal")
+    };
+
+    // We should have two donations if we processed both blocks correctly
+    let donations = fetch_output(&db, TxOutputType::Donation).await;
+    assert_eq!(donations.len(), 2);
+
+    let TxOutput { txid, output_index, amount, .. } = donations[0];
+    assert_eq!(amount, donation_amount);
+    assert_eq!(output_index, donation_outpoint.vout);
+    assert_eq!(txid.deref(), &donation_outpoint.txid);
+
+    let TxOutput { txid, output_index, amount, .. } = donations[1];
+    assert_eq!(amount, donation_amount_2);
+    assert_eq!(output_index, donation_outpoint_2.vout);
+    assert_eq!(txid.deref(), &donation_outpoint_2.txid);
+
+    // But we should have no deposits
+    assert!(fetch_input(&db, TxPrevoutType::Deposit).await.is_empty());
+
+    // Since the deposit check is buried in the logs, we also manually check
+    // that the deposit request validation in the block observer failed as
+    // expected.
+    let request = CreateDepositRequest {
+        outpoint: deposit_request.outpoint.clone(),
+        reclaim_script: deposit_request.reclaim_script.clone(),
+        deposit_script: deposit_request.deposit_script.clone(),
+    };
+    let bitcoin_client = ctx.get_bitcoin_client();
+    let validate_result =
+        signer::block_observer::DepositRequestValidator::validate(&request, &bitcoin_client, false);
+    match validate_result.await {
+        Err(Error::BitcoinTxCoinbase(tx, _)) if tx == deposit_request.outpoint.txid => {}
+        _ => panic!("Expected a err, got something else"),
+    }
+
+    testing::storage::drop_db(db).await;
+}
+
+fn make_coinbase_deposit_request(
+    rpc: &bitcoincore_rpc::Client,
+    max_fee: u64,
+    signers_public_key: bitcoin::XOnlyPublicKey,
+) -> (bitcoin::Transaction, signer::bitcoin::utxo::DepositRequest) {
+    let deposit_inputs = DepositScriptInputs {
+        signers_public_key,
+        max_fee,
+        recipient: PrincipalData::from(StacksAddress::burn_address(false)),
+    };
+    let reclaim_inputs = ReclaimScriptInputs::try_new(50, bitcoin::ScriptBuf::new()).unwrap();
+
+    let deposit_script = deposit_inputs.deposit_script();
+    let reclaim_script = reclaim_inputs.reclaim_script();
+
+    let script_pub_key =
+        sbtc::deposits::to_script_pubkey(deposit_script.clone(), reclaim_script.clone());
+    let address = Address::from_script(&script_pub_key, bitcoin::Network::Regtest).unwrap();
+
+    let block_hash = rpc.generate_to_address(1, &address).unwrap()[0];
+    let transactions = rpc.get_block(&block_hash).unwrap();
+
+    let deposit_tx = transactions.txdata[0].clone();
+    // Sanity check
+    assert!(deposit_tx.input[0].previous_output.is_null());
+
+    let req = signer::bitcoin::utxo::DepositRequest {
+        outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),
+        max_fee: max_fee,
+        signer_bitmap: bitvec::array::BitArray::ZERO,
+        amount: deposit_tx.output[0].value.to_sat(),
+        deposit_script: deposit_script,
+        reclaim_script: reclaim_script,
+        signers_public_key: signers_public_key,
+    };
+    (deposit_tx, req)
 }

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1651,9 +1651,12 @@ fn make_coinbase_deposit_request(
     let block_hash = rpc.generate_to_address(1, &address).unwrap()[0];
     let transactions = rpc.get_block(&block_hash).unwrap();
 
-    let deposit_tx = transactions.txdata[0].clone();
-    // Sanity check
-    assert!(deposit_tx.input[0].previous_output.is_null());
+    let deposit_tx = transactions
+        .txdata
+        .iter()
+        .find(|tx| tx.is_coinbase())
+        .expect("missing coinbase")
+        .clone();
 
     let req = signer::bitcoin::utxo::DepositRequest {
         outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1424,7 +1424,7 @@ async fn block_observer_updates_dkg_shares_after_observing_bitcoin_block() {
 
 #[test_log::test(tokio::test)]
 async fn block_observer_ignores_coinbase() {
-    let mut rng = rand::rngs::StdRng::seed_from_u64(51);
+    let mut rng = get_rng();
     let (rpc, faucet) = regtest::initialize_blockchain();
 
     let emily_client = EmilyClient::try_new(
@@ -1551,7 +1551,7 @@ async fn block_observer_ignores_coinbase() {
     //
     // Create a deposit from coinbase.
 
-    // First, we also send a donation (that will endup in the same block as the
+    // First, we also send a donation (that will end up in the same block as the
     // deposit) to ensure we process the block just fine.
     let donation_amount_2 = 123_456 + 1;
     let donation_outpoint_2 = faucet.send_to(donation_amount_2, &address);
@@ -1578,11 +1578,9 @@ async fn block_observer_ignores_coinbase() {
         reclaim_script: deposit_request.reclaim_script.to_hex_string(),
         transaction_hex: serialize_hex(&deposit_tx),
     };
-    dbg!(
-        deposit_api::create_deposit(emily_client.config(), body)
-            .await
-            .unwrap()
-    );
+    deposit_api::create_deposit(emily_client.config(), body)
+        .await
+        .unwrap();
 
     // ** Step 6 **
     //

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -21,7 +21,6 @@ use emily_client::apis::deposit_api;
 use emily_client::models::CreateDepositRequestBody;
 use fake::Fake as _;
 use fake::Faker;
-use rand::SeedableRng as _;
 use sbtc::deposits::CreateDepositRequest;
 use sbtc::deposits::DepositScriptInputs;
 use sbtc::deposits::ReclaimScriptInputs;

--- a/signer/tests/integration/complete_deposit.rs
+++ b/signer/tests/integration/complete_deposit.rs
@@ -512,7 +512,7 @@ async fn complete_deposit_validation_fee_too_low() {
         r#"
         UPDATE deposit_requests AS dr
         SET amount = $1
-        WHERE 
+        WHERE
             dr.txid = $2
             AND dr.output_index = $3;
     "#,
@@ -553,7 +553,7 @@ async fn complete_deposit_validation_fee_too_low() {
         r#"
         UPDATE deposit_requests AS dr
         SET amount = $1
-        WHERE 
+        WHERE
             dr.txid = $2
             AND dr.output_index = $3;
     "#,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -6351,7 +6351,7 @@ mod get_pending_accepted_withdrawal_requests {
     ///            ┊  │      ┌─┊──────┐    ┊  The request is confirmed (✔) in S1
     ///            ┊  └──────► ┊ B2b  │    ┊  and rejected (✖) in S2b, but its
     ///            ┊         └─┊────▲─┘    ┊  anchor later gets orphaned by B3a.
-    ///            ┊           ┊    ┊      ┊  
+    ///            ┊           ┊    ┊      ┊
     ///          ┌─┴──────┐  ┌─┴──────┐  ┌─┴──────┐
     /// Stacks:  │   S1 ✔ ├──►  S2a   ├──►  S3a   │
     ///          └────┬───┘  └────────┘  └────────┘
@@ -7023,12 +7023,12 @@ mod get_pending_accepted_withdrawal_requests {
     ///
     /// ```text
     /// Height:       0           1           2          3
-    ///          ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐  
+    ///          ┌────────┐  ┌────────┐  ┌────────┐  ┌────────┐
     /// Bitcoin: │   B1   ├──►   B2   ├──►   B3   ├──►   B4   │  We create a withdrawal
     ///          └─▲──────┘  └─▲──────┘  └─▲──────┘  └─▲──────┘  request which is confirmed
     ///          ┌─┴──────┐  ┌─┴──────┐  ┌─┴──────┐  ┌─┴──────┐  in S2, but we set its
-    /// Stacks:  │   S1   ├──►   S2 ✔ ├──►   S3 ⚠️ ├──►   S4   │  bitcoin height to 3.  
-    ///          └────────┘  └────────┘  └────────┘  └────────┘  
+    /// Stacks:  │   S1   ├──►   S2 ✔ ├──►   S3 ⚠️ ├──►   S4   │  bitcoin height to 3.
+    ///          └────────┘  └────────┘  └────────┘  └────────┘
     /// ```
     #[tokio::test]
     async fn test_confirmed_anchor_block_lower_than_block_height() {
@@ -7142,7 +7142,7 @@ mod get_pending_accepted_withdrawal_requests {
     ///
     /// ```text
     ///
-    /// Height:       0           1           2     
+    /// Height:       0           1           2
     ///          ┌────────┐  ┌────────┐  ┌────────┐
     /// Bitcoin: │   B1   ├──►   B2   ├──►   B3   │  We create a withdrawal
     ///          └─▲──────┘  └─▲──────┘  └─▲──────┘  request which is confirmed


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-sbtc/sbtc/issues/1196

## Changes

Avoid calling `get_tx_info` if the transaction is a coinbase one, and log it when extracting sbtc txs (deposit ones are already logged with something like `WARN block-observer:load_latest_deposit_requests:load_requests: signer::block_observer: could not validate deposit request error=transaction is coinbase, txid: ..., block hash Some(...)`).

Also removed some random trailing spaces in the first commit.

## Testing Information

Added a test for coinbase donation and deposit.
