### PR TITLE
fix(tests): fixes for signer utxo tests

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -315,7 +315,6 @@ mod tests {
     use crate::storage::in_memory::Store;
     use crate::storage::model::DepositRequest;
     use crate::storage::model::StacksPrincipal;
-    use crate::storage::model::StacksTxId;
     use crate::testing::context::*;
     use crate::testing::get_rng;
     use crate::testing::storage::model::TestData;
@@ -658,10 +657,10 @@ mod tests {
 
         let db = ctx.inner_storage();
 
-        let txid: StacksTxId = fake::Faker.fake_with_rng(&mut OsRng);
+        let block_id: StacksBlockId = StacksBlockId(fake::Faker.fake_with_rng(&mut OsRng));
         let event = KeyRotationEvent {
-            txid: sbtc::events::StacksTxid(txid.into_bytes()),
-            block_id: StacksBlockId(fake::Faker.fake_with_rng(&mut OsRng)),
+            txid: sbtc::events::StacksTxid(fake::Faker.fake_with_rng(&mut OsRng)),
+            block_id,
             new_aggregate_pubkey: SECP256K1.generate_keypair(&mut OsRng).1.into(),
             new_keys: (0..3)
                 .map(|_| SECP256K1.generate_keypair(&mut OsRng).1.into())
@@ -675,7 +674,7 @@ mod tests {
         assert!(res.is_ok());
         let db = db.lock().await;
         assert_eq!(db.rotate_keys_transactions.len(), 1);
-        assert!(db.rotate_keys_transactions.get(&txid).is_some());
+        assert!(db.rotate_keys_transactions.get(&block_id.into()).is_some());
     }
 
     #[test_case(EVENT_OBSERVER_BODY_LIMIT, true; "event within limit")]

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -1001,14 +1001,6 @@ mod tests {
                 .get(&db_outpoint.0)
                 .is_some()
         );
-        assert_eq!(
-            storage
-                .raw_transactions
-                .get(db_outpoint.0.as_byte_array())
-                .unwrap()
-                .tx_type,
-            model::TransactionType::DepositRequest
-        );
     }
 
     /// Test that `BlockObserver::extract_sbtc_transactions` takes the

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -1001,6 +1001,14 @@ mod tests {
                 .get(&db_outpoint.0)
                 .is_some()
         );
+        assert_eq!(
+            storage
+                .raw_transactions
+                .get(db_outpoint.0.as_byte_array())
+                .unwrap()
+                .tx_type,
+            model::TransactionType::DepositRequest
+        );
     }
 
     /// Test that `BlockObserver::extract_sbtc_transactions` takes the

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -724,7 +724,7 @@ mod tests {
 
         let tx = model::StacksTransaction {
             txid: rotate_keys.txid,
-            block_hash: stacks_chain_tip.block_hash,
+            block_hash: stacks_chain_tip,
         };
 
         db.write_stacks_transaction(&tx).await.unwrap();

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -460,6 +460,7 @@ mod tests {
     use crate::testing::context::TestContext;
     use crate::testing::context::*;
     use crate::testing::get_rng;
+    use crate::testing::storage::DbReadTestExt;
     use crate::testing::storage::model::TestData;
 
     use super::*;
@@ -697,10 +698,12 @@ mod tests {
         let network = NetworkKind::Regtest;
         let wallet1 = SignerWallet::new(&signer_keys, signatures_required, network, 0).unwrap();
 
+        let (bitcoin_chain_tip, stacks_chain_tip) = db.get_chain_tips().await;
+
         // Let's store the key information about this wallet into the database
         let rotate_keys = KeyRotationEvent {
             txid: fake::Faker.fake_with_rng(&mut rng),
-            block_hash: fake::Faker.fake_with_rng(&mut rng),
+            block_hash: stacks_chain_tip,
             address: StacksPrincipal::from(clarity::vm::types::PrincipalData::from(
                 wallet1.address().clone(),
             )),
@@ -709,16 +712,11 @@ mod tests {
             signatures_required: wallet1.signatures_required,
         };
 
-        let bitcoin_chain_tip = db.get_bitcoin_canonical_chain_tip().await.unwrap().unwrap();
-        let stacks_chain_tip = db
-            .get_stacks_chain_tip(&bitcoin_chain_tip)
-            .await
-            .unwrap()
-            .unwrap();
-
         // We haven't stored any RotateKeysTransactions into the database
         // yet, so it will try to load the wallet from the context.
-        let wallet0 = SignerWallet::load(&ctx, &bitcoin_chain_tip).await.unwrap();
+        let wallet0 = SignerWallet::load(&ctx, &bitcoin_chain_tip.block_hash)
+            .await
+            .unwrap();
         let config = &ctx.config().signer;
         let bootstrap_aggregate_key =
             PublicKey::combine_keys(&config.bootstrap_signing_set()).unwrap();
@@ -735,7 +733,9 @@ mod tests {
             .unwrap();
 
         // Okay, now let's load it up and make sure things match.
-        let wallet2 = SignerWallet::load(&ctx, &bitcoin_chain_tip).await.unwrap();
+        let wallet2 = SignerWallet::load(&ctx, &bitcoin_chain_tip.block_hash)
+            .await
+            .unwrap();
 
         assert_eq!(wallet1.address(), wallet2.address());
         assert_eq!(wallet1.public_keys(), wallet2.public_keys());

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -23,7 +23,6 @@ use bitcoin::Witness;
 use bitcoin::key::TapTweak;
 use secp256k1::SECP256K1;
 
-use rand::CryptoRng;
 use rand::RngCore;
 use rand::SeedableRng;
 use rand::rngs::{OsRng, StdRng};
@@ -120,7 +119,7 @@ impl<I, T> IterTestExt<T> for I where I: IntoIterator<Item = T> + Sized {}
 
 /// Returns a seedable rng with random seed. Prints the seed to
 /// stderr so that it can be used to reproduce the test
-pub fn get_rng() -> impl CryptoRng + RngCore + Clone + Send {
+pub fn get_rng() -> StdRng {
     let seed = OsRng.next_u64();
 
     // Nextest prints stderr only for failing tests, so this message

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -2,8 +2,8 @@
 
 use std::collections::HashSet;
 
-use bitcoin::hashes::Hash as _;
 use bitcoin::ScriptBuf;
+use bitcoin::hashes::Hash as _;
 use fake::Dummy as _;
 use fake::Fake;
 

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashSet;
 
+use bitcoin::hashes::Hash as _;
 use bitcoin::ScriptBuf;
 use fake::Dummy as _;
 use fake::Fake;
@@ -237,15 +238,22 @@ impl TestData {
         signer_script_pubkeys: &HashSet<ScriptBuf>,
     ) {
         let mut bitcoin_transactions = vec![];
+        let mut transactions = vec![];
         let mut tx_outputs = Vec::new();
         let mut tx_prevouts = Vec::new();
 
         for tx_info in txs {
+            let model_tx = model::Transaction {
+                txid: tx_info.tx.compute_txid().to_byte_array(),
+                tx_type: model::TransactionType::Donation,
+                block_hash: block.block_hash.into_bytes(),
+            };
             let bitcoin_transaction = model::BitcoinTxRef {
                 txid: tx_info.tx.compute_txid().into(),
                 block_hash: block.block_hash,
             };
 
+            transactions.push(model_tx);
             bitcoin_transactions.push(bitcoin_transaction);
 
             for tx_output in tx_info.to_tx_outputs(signer_script_pubkeys) {
@@ -259,6 +267,7 @@ impl TestData {
 
         self.push(Self {
             bitcoin_transactions,
+            transactions,
             tx_outputs,
             tx_prevouts,
             ..Self::default()

--- a/signer/src/testing/storage/model.rs
+++ b/signer/src/testing/storage/model.rs
@@ -2,7 +2,6 @@
 
 use std::collections::HashSet;
 
-use bitcoin::hashes::Hash as _;
 use bitcoin::ScriptBuf;
 use fake::Dummy as _;
 use fake::Fake;
@@ -232,59 +231,6 @@ impl TestData {
 
     /// Push bitcoin txs to a specific bitcoin block
     pub fn push_bitcoin_txs(
-        &mut self,
-        block: &BitcoinBlockRef,
-        sbtc_txs: Vec<(model::TransactionType, bitcoin::Transaction)>,
-    ) {
-        let mut bitcoin_transactions = vec![];
-        let mut transactions = vec![];
-        let mut tx_outputs = Vec::new();
-
-        for (tx_type, tx) in sbtc_txs {
-            let model_tx = model::Transaction {
-                txid: tx.compute_txid().to_byte_array(),
-                tx_type,
-                block_hash: block.block_hash.into_bytes(),
-            };
-
-            let bitcoin_transaction = model::BitcoinTxRef {
-                txid: model_tx.txid.into(),
-                block_hash: block.block_hash,
-            };
-
-            transactions.push(model_tx);
-            bitcoin_transactions.push(bitcoin_transaction);
-
-            let output_type = match tx_type {
-                model::TransactionType::SbtcTransaction => model::TxOutputType::SignersOutput,
-                model::TransactionType::Donation => model::TxOutputType::Donation,
-                _ => continue,
-            };
-
-            if let Some(tx_out) = tx.output.first() {
-                // In our tests we always happen to put the first output as
-                // the signers UTXO, even if it is a donation.
-                let tx_output = model::TxOutput {
-                    txid: tx.compute_txid().into(),
-                    output_index: 0,
-                    script_pubkey: tx_out.script_pubkey.clone().into(),
-                    amount: tx_out.value.to_sat(),
-                    output_type,
-                };
-                tx_outputs.push(tx_output);
-            }
-        }
-
-        self.push(Self {
-            bitcoin_transactions,
-            transactions,
-            tx_outputs,
-            ..Self::default()
-        });
-    }
-
-    /// Push bitcoin txs to a specific bitcoin block
-    pub fn push_bitcoin_txs2(
         &mut self,
         block: &BitcoinBlockRef,
         txs: Vec<TestBitcoinTxInfo>,

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -1282,7 +1282,6 @@ where
             input: vec![TestBitcoinTxInfo::random_prevout(&mut rng)],
             ..EMPTY_BITCOIN_TX
         };
-        // model::BitcoinTxId::dummy_with_rng(&fake::Faker, &mut rng).into()
         let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
         let tx_info = TestBitcoinTxInfo {
             tx: tx_a1.clone(),

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -208,11 +208,11 @@ where
             ..EMPTY_BITCOIN_TX
         };
         let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
-        let txs = TestBitcoinTxInfo {
+        let tx_info = TestBitcoinTxInfo {
             tx: tx_1.clone(),
             prevouts: Vec::new(),
         };
-        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![tx_info], &signer_script_pubkeys);
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;
 
@@ -356,14 +356,14 @@ where
             ..EMPTY_BITCOIN_TX
         };
         let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
-        let txs = TestBitcoinTxInfo {
+        let tx_info = TestBitcoinTxInfo {
             tx: tx_1.clone(),
             prevouts: vec![bitcoin::TxOut {
                 value: bitcoin::Amount::from_sat(1000),
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
         };
-        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![tx_info], &signer_script_pubkeys);
 
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;
@@ -509,14 +509,14 @@ where
             ..EMPTY_BITCOIN_TX
         };
         let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
-        let txs = TestBitcoinTxInfo {
+        let tx_info = TestBitcoinTxInfo {
             tx: tx_1.clone(),
             prevouts: vec![bitcoin::TxOut {
                 value: bitcoin::Amount::from_sat(1000),
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
         };
-        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![tx_info], &signer_script_pubkeys);
 
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;

--- a/signer/src/testing/transaction_coordinator.rs
+++ b/signer/src/testing/transaction_coordinator.rs
@@ -208,13 +208,7 @@ where
             }],
             ..EMPTY_BITCOIN_TX
         };
-        // test_data.push_bitcoin_txs(
-        //     &bitcoin_chain_tip,
-        //     vec![(model::TransactionType::SbtcTransaction, tx_1.clone())],
-        // );
-        let signer_script_pubkeys = [aggregate_key.signers_script_pubkey()]
-            .into_iter()
-            .collect();
+        let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
         let txs = TestBitcoinTxInfo {
             tx: tx_1.clone(),
             prevouts: vec![bitcoin::TxOut {
@@ -222,7 +216,7 @@ where
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
         };
-        test_data.push_bitcoin_txs2(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;
 
@@ -362,12 +356,25 @@ where
                 value: bitcoin::Amount::from_sat(1_337_000_000_000),
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: model::BitcoinTxId::dummy_with_rng(&fake::Faker, &mut rng).into(),
+                    vout: 0,
+                },
+                sequence: bitcoin::Sequence::ZERO,
+                ..Default::default()
+            }],
             ..EMPTY_BITCOIN_TX
         };
-        test_data.push_bitcoin_txs(
-            &bitcoin_chain_tip,
-            vec![(model::TransactionType::SbtcTransaction, tx_1.clone())],
-        );
+        let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
+        let txs = TestBitcoinTxInfo {
+            tx: tx_1.clone(),
+            prevouts: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1000),
+                script_pubkey: aggregate_key.signers_script_pubkey(),
+            }],
+        };
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
 
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;
@@ -509,12 +516,25 @@ where
                 value: bitcoin::Amount::from_sat(1_337_000_000_000),
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
+            input: vec![bitcoin::TxIn {
+                previous_output: bitcoin::OutPoint {
+                    txid: model::BitcoinTxId::dummy_with_rng(&fake::Faker, &mut rng).into(),
+                    vout: 0,
+                },
+                sequence: bitcoin::Sequence::ZERO,
+                ..Default::default()
+            }],
             ..EMPTY_BITCOIN_TX
         };
-        test_data.push_bitcoin_txs(
-            &bitcoin_chain_tip,
-            vec![(model::TransactionType::SbtcTransaction, tx_1.clone())],
-        );
+        let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
+        let txs = TestBitcoinTxInfo {
+            tx: tx_1.clone(),
+            prevouts: vec![bitcoin::TxOut {
+                value: bitcoin::Amount::from_sat(1000),
+                script_pubkey: aggregate_key.signers_script_pubkey(),
+            }],
+        };
+        test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
 
         test_data.remove(original_test_data);
         self.write_test_data(&test_data).await;
@@ -962,7 +982,7 @@ where
             tx: tx.clone(),
             prevouts: Vec::new(),
         };
-        test_data.push_bitcoin_txs2(&block_ref, vec![tx_info], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&block_ref, vec![tx_info], &signer_script_pubkeys);
         test_data.push(block);
 
         let expected = SignerUtxo {
@@ -1034,7 +1054,7 @@ where
                 tx: tx.clone(),
                 prevouts: Vec::new(),
             };
-            test_data_rc.borrow_mut().push_bitcoin_txs2(
+            test_data_rc.borrow_mut().push_bitcoin_txs(
                 block_ref,
                 vec![tx_info],
                 &signer_script_pubkeys,
@@ -1198,7 +1218,7 @@ where
                 },
             ],
         };
-        test_data.push_bitcoin_txs2(
+        test_data.push_bitcoin_txs(
             &block_ref,
             vec![tx_info_1, tx_info_2, tx_info_3],
             &signer_script_pubkeys,
@@ -1284,7 +1304,7 @@ where
                 script_pubkey: aggregate_key.signers_script_pubkey(),
             }],
         };
-        test_data.push_bitcoin_txs2(&block_a1, vec![tx_info], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&block_a1, vec![tx_info], &signer_script_pubkeys);
         test_data.push(block);
 
         let (block, block_a2) = test_data.new_block(
@@ -1304,7 +1324,7 @@ where
             tx: tx_a2.clone(),
             prevouts: Vec::new(),
         };
-        test_data.push_bitcoin_txs2(&block_a2, vec![tx_info], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&block_a2, vec![tx_info], &signer_script_pubkeys);
         test_data.push(block);
 
         let (block, block_b1) = test_data.new_block(
@@ -1324,7 +1344,7 @@ where
             tx: tx_b1.clone(),
             prevouts: Vec::new(),
         };
-        test_data.push_bitcoin_txs2(&block_b1, vec![tx_info], &signer_script_pubkeys);
+        test_data.push_bitcoin_txs(&block_b1, vec![tx_info], &signer_script_pubkeys);
         test_data.push(block);
 
         test_data.remove(original_test_data);

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2704,7 +2704,6 @@ mod tests {
         test_environment().assert_get_signer_utxo_fork().await;
     }
 
-    #[ignore = "test data needs to be updated to store tx inputs first"]
     #[tokio::test]
     async fn should_get_signer_utxo_unspent() {
         test_environment().assert_get_signer_utxo_unspent().await;

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -14,7 +14,6 @@ use bitcoin::block::Version;
 use bitcoin::consensus::encode::serialize_hex;
 use bitcoin::hashes::Hash as _;
 use bitcoincore_rpc_json::Utxo;
-use fake::Dummy as _;
 use fake::Fake as _;
 use futures::future::join_all;
 use signer::testing::storage::model::TestBitcoinTxInfo;
@@ -198,14 +197,7 @@ async fn deposit_flow() {
             value: bitcoin::Amount::from_sat(1_337_000_000_000),
             script_pubkey: aggregate_key.signers_script_pubkey(),
         }],
-        input: vec![bitcoin::TxIn {
-            previous_output: bitcoin::OutPoint {
-                txid: model::BitcoinTxId::dummy_with_rng(&fake::Faker, &mut rng).into(),
-                vout: 0,
-            },
-            sequence: bitcoin::Sequence::ZERO,
-            ..Default::default()
-        }],
+        input: vec![TestBitcoinTxInfo::random_prevout(&mut rng)],
     };
     let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
     let txs = TestBitcoinTxInfo {

--- a/signer/tests/integration/emily.rs
+++ b/signer/tests/integration/emily.rs
@@ -200,14 +200,14 @@ async fn deposit_flow() {
         input: vec![TestBitcoinTxInfo::random_prevout(&mut rng)],
     };
     let signer_script_pubkeys = HashSet::from([aggregate_key.signers_script_pubkey()]);
-    let txs = TestBitcoinTxInfo {
+    let tx_info = TestBitcoinTxInfo {
         tx: signers_utxo_tx.clone(),
         prevouts: vec![bitcoin::TxOut {
             value: bitcoin::Amount::from_sat(1000),
             script_pubkey: aggregate_key.signers_script_pubkey(),
         }],
     };
-    test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![txs], &signer_script_pubkeys);
+    test_data.push_bitcoin_txs(&bitcoin_chain_tip, vec![tx_info], &signer_script_pubkeys);
     test_data.remove(original_test_data);
     test_data.write_to(&context.get_storage_mut()).await;
 


### PR DESCRIPTION
## Description

These are all testing related changes.

This was done on the way to doing https://github.com/stacks-sbtc/sbtc/issues/1598, but should probably be merged regardless of what we do for https://github.com/stacks-sbtc/sbtc/issues/1598, since it fixes one of our tests.

## Changes

* Update how rotate keys transactions are stored and fetched in the in-memory database. This change makes it possible to not use `write_transaction` or `write_transactions`.
* Adds a new `TestBitcoinTxInfo` struct to simulate having a `BitcoinTxInfo` struct, so that it can be deconstructed.
* Update the `TestData::push_bitcoin_txs` function to deconstruct the given transactions into inputs and outputs. This change fixes the `transaction_coordinator::tests::should_get_signer_utxo_unspent` test.

## Testing Information

This PR should only affect tests. It enables a previously ignored test changes some tests, the signer UTXO ones, to go through the transaction deconstruction code. This should more closely align with what happens in production code.

## Checklist:

- [x] I have performed a self-review of my code
