### PR TITLE
fix: add dependencies to build ecdsa on mac

### DIFF
--- a/docker/sbtc/emily-cron/Dockerfile
+++ b/docker/sbtc/emily-cron/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.13-slim AS emily-cron
 COPY --from=ghcr.io/astral-sh/uv@sha256:562193a4a9d398f8aedddcb223e583da394ee735de36b5815f8f1d22cb49be15 /uv /uvx /bin/
 
 # Install cron
-RUN apt-get update && apt-get install -y cron && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends cron build-essential libgmp3-dev && rm -rf /var/lib/apt/lists/*
 
 # Copy the application into the container
 COPY ../../emily_cron /app


### PR DESCRIPTION
## Description

Fix `make devenv-up` build failure for the `emily-cron` service on macOS (specifically ARM64 architectures). The build previously failed during the `uv sync` step when attempting to compile the `fastecdsa` dependency, as necessary build tools (`gcc`) and development libraries (`libgmp3-dev`) were missing from the base image. On x64,  it was working out-of-the-box because pypi offers the compiled binaries, and it was skipping the compilation phase

Tested on @fabergat mac

## Changes

- Modified `docker/sbtc/emily-cron/Dockerfile`:
    - Added `build-essential` and `libgmp-dev` to the `apt-get install` command to ensure necessary build dependencies are available for compiling Python packages with C extensions like `fastecdsa`.

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules