### PR TITLE
feat: coordinator processes requests on DKG failure

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -347,7 +347,8 @@ where
                 Ok(key) => key,
                 Err(error) => {
                     tracing::error!(%error, "failed to coordinate DKG; using existing aggregate key");
-                    maybe_aggregate_key.ok_or(Error::MissingAggregateKey(*bitcoin_chain_tip.block_hash))?
+                    maybe_aggregate_key
+                        .ok_or(Error::MissingAggregateKey(*bitcoin_chain_tip.block_hash))?
                 }
             }
         } else {

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -285,12 +285,13 @@ where
         Ok(is_epoch3)
     }
 
+    /// A function for processing new blocks
     #[tracing::instrument(skip_all, fields(
         public_key = %self.signer_public_key(),
         bitcoin_tip_hash = tracing::field::Empty,
         bitcoin_tip_height = tracing::field::Empty,
     ))]
-    async fn process_new_blocks(&mut self) -> Result<(), Error> {
+    pub async fn process_new_blocks(&mut self) -> Result<(), Error> {
         if !self.is_epoch3().await? {
             return Ok(());
         }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4712,8 +4712,8 @@ mod get_eligible_pending_withdrawal_requests {
     }
 }
 
-// This test checks that blocks are still created
-// if DKG encounters an error but there's an existing
+// This test checks that the coordinator attempts to fulfill its 
+// other duties if DKG encounters an error but there's an existing
 // aggregate key to fallback on.
 #[test_log::test(tokio::test)]
 async fn should_handle_dkg_coordination_failure() {
@@ -4787,8 +4787,8 @@ async fn should_handle_dkg_coordination_failure() {
     };
 
     // We're verifying that the coordinator is currently
-    // processing blocks correctly. Since we previously checked
-    // that 'should_coordinate_dkg' will trigger & we set the
+    // processing requests correctly. Since we previously checked
+    // that 'should_coordinate_dkg' will trigger and we set the
     // 'dkg_max_duration' to 10 milliseconds we expect that
     // DKG will run & fail
     let result = coordinator.process_new_blocks().await;

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -119,7 +119,6 @@ use signer::testing::wsts::SignerSet;
 use signer::transaction_coordinator;
 use signer::transaction_coordinator::TxCoordinatorEventLoop;
 use signer::transaction_signer::TxSignerEventLoop;
-use signer::transaction_coordinator::should_coordinate_dkg;
 use tokio::sync::broadcast::Sender;
 
 use crate::complete_deposit::make_complete_deposit;
@@ -4732,14 +4731,19 @@ async fn should_handle_dkg_coordination_failure() {
         aggregate_key: existing_aggregate_key,
         ..Faker.fake_with_rng(&mut rng)
     };
-    storage.write_encrypted_dkg_shares(&dkg_shares).await.unwrap();
+    storage
+        .write_encrypted_dkg_shares(&dkg_shares)
+        .await
+        .unwrap();
 
     // Create a bitcoin block to serve as chain tip
     let bitcoin_block: model::BitcoinBlock = Faker.fake_with_rng(&mut rng);
     storage.write_bitcoin_block(&bitcoin_block).await.unwrap();
 
     // Update the context state with the existing aggregate key
-    context.state().set_current_aggregate_key(existing_aggregate_key);
+    context
+        .state()
+        .set_current_aggregate_key(existing_aggregate_key);
 
     // Create coordinator with test parameters using SignerNetwork::single
     let network = SignerNetwork::single(&context);
@@ -4750,14 +4754,17 @@ async fn should_handle_dkg_coordination_failure() {
         threshold: 3,
         context_window: 5,
         signing_round_max_duration: std::time::Duration::from_secs(5),
-        bitcoin_presign_request_max_duration: std::time::Duration::from_secs(5), 
+        bitcoin_presign_request_max_duration: std::time::Duration::from_secs(5),
         dkg_max_duration: std::time::Duration::from_secs(5),
         is_epoch3: true,
     };
 
     // Run the coordinator - this will handle process_new_blocks internally
     let run_result = coordinator.run().await;
-    assert!(run_result.is_ok(), "Coordinator run should complete successfully");
+    assert!(
+        run_result.is_ok(),
+        "Coordinator run should complete successfully"
+    );
 
     // Verify the existing aggregate key was used as fallback
     let current_key = context.state().current_aggregate_key();

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4778,8 +4778,8 @@ async fn should_handle_dkg_coordination_failure() {
         context_window: 5,
         signing_round_max_duration: std::time::Duration::from_secs(5),
         bitcoin_presign_request_max_duration: std::time::Duration::from_secs(5),
-        // extremely short duration so that DKG fails...
-        dkg_max_duration: Duration::from_millis(1),
+        // short be short enough to broadcast, yet fail
+        dkg_max_duration: Duration::from_millis(10),
         is_epoch3: true,
     };
 
@@ -4789,6 +4789,8 @@ async fn should_handle_dkg_coordination_failure() {
         result.is_ok(),
         "process_new_blocks should complete successfully even with DKG failure"
     );
+
+    // TODO: should probably assert that DKG did actually attempt to run & fail
 
     // Verify that we can still process blocks after DKG failure
     let result = coordinator.process_new_blocks().await;

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4712,7 +4712,7 @@ mod get_eligible_pending_withdrawal_requests {
     }
 }
 
-// This test checks that the coordinator attempts to fulfill its 
+// This test checks that the coordinator attempts to fulfill its
 // other duties if DKG encounters an error but there's an existing
 // aggregate key to fallback on.
 #[test_log::test(tokio::test)]

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4790,7 +4790,12 @@ async fn should_handle_dkg_coordination_failure() {
         "process_new_blocks should complete successfully even with DKG failure"
     );
 
-    // TODO: should probably assert that DKG did actually attempt to run & fail
+    // Check if DKG shares exist
+    let dkg_shares = storage.get_latest_encrypted_dkg_shares().await.unwrap();
+    assert!(
+        dkg_shares.is_none(),
+        "DKG shares should not exist since DKG failed to complete due to timeout"
+    );
 
     // Verify that we can still process blocks after DKG failure
     let result = coordinator.process_new_blocks().await;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1593

This PR updates so that when DKG coordination fails in the transaction coordinator, instead of failing the entire process (aka entirely halt), we now gracefully fall back to using the existing aggregate key if one is available. This improves system resilience by allowing operations to continue even when DKG coordination encounters issues.

## Changes
Modified `process_new_blocks` to handle DKG coordination failures by falling back to existing aggregate key. The system will now:

1. Attempt DKG coordination as normal
2. On failure, log the error and attempt to use existing aggregate key
3. Only fail if _**no**_ existing aggregate key is available

## Testing Information
There is a single test added that verifies fallback behavior works as expected.

## Checklist:
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
