### PR TITLE
chore: make bootstrap_signer_set containing self pubkey mandatory

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -718,7 +718,7 @@ where
                 let signer_set = shares.signer_set_public_keys.into_iter().collect();
                 Ok((Some(shares.aggregate_key), signer_set))
             }
-            None => Ok((None, context.config().signer.bootstrap_signing_set())),
+            None => Ok((None, context.config().signer.bootstrap_signing_set.clone())),
         },
     }
 }

--- a/signer/src/config/error.rs
+++ b/signer/src/config/error.rs
@@ -81,4 +81,9 @@ pub enum SignerConfigError {
     /// An error returned for duration parameters that must be positive.
     #[error("Duration for {0} must be nonzero")]
     ZeroDurationForbidden(&'static str),
+
+    /// An error returned if bootstrap_signer_set does not contain pubkey of
+    /// this signer
+    #[error("Bootstrap signer set must contain pubkey of this signer")]
+    MissingPubkeyInBootstrapSignerSet,
 }

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -120,8 +120,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // signing set, and only assume we are bootstrapping if that source is
     // empty.
     let settings = context.config();
-    for signer in settings.signer.bootstrap_signing_set() {
-        context.state().current_signer_set().add_signer(signer);
+    for signer in &settings.signer.bootstrap_signing_set {
+        context.state().current_signer_set().add_signer(*signer);
     }
 
     // Run the application components concurrently. We're `join!`ing them

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -190,7 +190,7 @@ impl SignerWallet {
     /// Load the bootstrap wallet implicitly defined in the signer config.
     pub fn load_boostrap_wallet(config: &SignerConfig) -> Result<SignerWallet, Error> {
         let network_kind = config.network;
-        let public_keys = config.bootstrap_signing_set();
+        let public_keys = config.bootstrap_signing_set.clone();
         let signatures_required = config.bootstrap_signatures_required;
 
         SignerWallet::new(&public_keys, signatures_required, network_kind, 0)
@@ -720,7 +720,7 @@ mod tests {
         let wallet0 = SignerWallet::load(&ctx, &bitcoin_chain_tip).await.unwrap();
         let config = &ctx.config().signer;
         let bootstrap_aggregate_key =
-            PublicKey::combine_keys(&config.bootstrap_signing_set()).unwrap();
+            PublicKey::combine_keys(&config.bootstrap_signing_set).unwrap();
         assert_eq!(wallet0.aggregate_key, bootstrap_aggregate_key);
 
         let tx = model::StacksTransaction {

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1091,7 +1091,7 @@ async fn block_observer_updates_state_after_observing_bitcoin_block() {
     // There is no aggregate key since there aren't any key rotation
     // contract calls and no DKG shares. But the current signer set should
     // be the bootstrap signing set now.
-    let bootstrap_signing_set = ctx.config().signer.bootstrap_signing_set();
+    let bootstrap_signing_set = ctx.config().signer.bootstrap_signing_set.clone();
     assert_eq!(state.get_current_limits(), SbtcLimits::unlimited());
     assert!(state.current_aggregate_key().is_none());
     assert_eq!(state.current_signer_public_keys(), bootstrap_signing_set);


### PR DESCRIPTION
## Description

This PR makes mandatory for `bootstrap_signer_set` to contain public key of this signer.

Closes: no issue.

## Motivation

Currently, `SignerConfig` have both method `bootstrap_signing_set()` and similarly named field `bootstrap_signing_set`. They also have different types, `BTreeSet<Pubkey>` vs `Vec<Pubkey>`. This can give an impression, that the method just converts `Vec` to `BTreeSet`. But it is wrong, and method also adds one more pubkey to set, which is counterintuitive imo.

I did some lookup through the code, found zero places relying on `bootstrap_signing_set` does not contain pubkey of current signer, so I made `bootstrap_signing_set` always containing the pubkey of current signer, via settings validation.

## Changes

- Now `bootstrap_signing_set()` always contain same pubkeys as `bootstrap_signing_set` and only move them from `Vec` to `BTreeSet`.
- Now signer will panic during config validation if `bootstrap_signing_set` doesn't contain pubkey of this signer.

## Testing Information

- Added one test checking that we panic if `bootstrap_signing_set` doesn't contain pubkey of this signer.
- Added some changes to existing tests to make them complying new rule of config validation.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
