### PR TITLE
[fix]: Emily don't return Error on limits/ if rolling window calculation failed

### DIFF
--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -838,7 +838,7 @@ pub async fn get_limits(context: &EmilyContext) -> Result<Limits, Error> {
         global_cap.rolling_withdrawal_blocks,
         global_cap.rolling_withdrawal_cap,
     )
-    .await?;
+    .await.ok().flatten();
 
     // Get the global limit for the whole thing.
     Ok(Limits {


### PR DESCRIPTION
## Description

Closes: #?

## Changes

## Testing Information

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
