### PR TITLE
chore: clean-up logging in Emily v1

### DIFF
--- a/emily/handler/src/api/handlers/internal.rs
+++ b/emily/handler/src/api/handlers/internal.rs
@@ -83,8 +83,8 @@ async fn set_api_state_status(
                 return Ok(Some(api_state));
             }
             // Retry if there was a version conflict.
-            Err(Error::VersionConflict) => {
-                debug!("Failed to update API state - retrying: {api_state:?}")
+            Err(Error::VersionConflict(error)) => {
+                debug!(%error, "Failed to update API state - retrying; {api_state:?}")
             }
             // If some other error occurred then return from here; this shouldn't
             // happen and something has actually gone wrong.
@@ -139,8 +139,9 @@ pub async fn execute_reorg_handler(
             entry.reorganize_around(&request.canonical_tip)?;
             match accessors::set_deposit_entry(context, &mut entry).await {
                 Ok(_) => break,
-                Err(Error::VersionConflict) => {
-                    debug!(
+                Err(Error::VersionConflict(error)) => {
+                    warn!(
+                        %error,
                         "Encountered race condition in updating entry {:?}. Attempt {}/{}",
                         entry, attempt, ENTRY_UPDATE_RETRIES
                     );
@@ -178,8 +179,9 @@ pub async fn execute_reorg_handler(
             entry.reorganize_around(&request.canonical_tip)?;
             match accessors::set_withdrawal_entry(context, &mut entry).await {
                 Ok(_) => break,
-                Err(Error::VersionConflict) => {
-                    debug!(
+                Err(Error::VersionConflict(error)) => {
+                    warn!(
+                        %error,
                         "Encountered race condition in updating entry {:?}. Attempt {}/{}",
                         entry, attempt, ENTRY_UPDATE_RETRIES
                     );

--- a/emily/handler/src/api/handlers/internal.rs
+++ b/emily/handler/src/api/handlers/internal.rs
@@ -73,8 +73,9 @@ async fn set_api_state_status(
         debug!(
             ?api_state,
             ?original_api_state,
-            attampt = %attempt_number,
-            "Changing Api state, max attempts {MAX_SET_API_STATE_ATTEMPTS_DURING_REORG}."
+            attempt = %attempt_number,
+            max_attempts = %MAX_SET_API_STATE_ATTEMPTS_DURING_REORG,
+            "Changing the API state"
         );
 
         // Attempt to set the API state.

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -187,9 +187,9 @@ pub enum Error {
     #[error("Could not retrieve an item from DynamoDB; {0}")]
     AwsSdkDynamoDbGetItem(#[from] SdkError<GetItemError>),
 
-    /// This happens when attempting to store an item in DynamoDB. Note
-    /// that precondition checks that occur when putting an item into
-    /// DynamoDB are transformed into the `VersionConflict` error variant.
+    /// This error occurs when storing an item in DynamoDB. Note that
+    /// precondition errors on a PutItem operation are returned in the
+    /// `VersionConflict` variant.
     #[error("Could not put the item into DynamoDB; {0}")]
     AwsSdkDynamoDbPutItem(#[source] Box<PutItemError>),
 
@@ -202,10 +202,14 @@ pub enum Error {
     AwsSdkDynamoDbScan(#[from] SdkError<ScanError>),
 
     /// This happens when attempting to update a stored item in DynamoDB.
+    /// Note that precondition errors on an UpdateItem operation are
+    /// returned in the `VersionConflict` variant.
     #[error("Could not update the item in DynamoDB; {0}")]
     AwsSdkDynamoDbUpdateItem(#[source] Box<UpdateItemError>),
 
     /// This happens when attempting to delete an item in the database.
+    /// Note that precondition errors on a DeleteItem operation are
+    /// returned in the `VersionConflict` variant.
     #[error("Could not deleting an item in DynamoDB; {0}")]
     AwsSdkDynamoDbDeleteItem(#[source] Box<DeleteItemError>),
 

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -34,7 +34,7 @@ pub enum Inconsistency {
     /// are considered equally canonical.
     Chainstates(Vec<Chainstate>),
     /// There is an inconsistency in the way an item is being updated.
-    ItemUpdate(String),
+    ItemUpdate(&'static str),
 }
 
 /// Errors from the internal API logic.

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -180,7 +180,7 @@ pub enum Error {
 
     /// This happens when attempting to parse an integer from a string that
     /// has been read from an environment variable.
-    #[error("Could not parse the string into an integer; {0}")]
+    #[error("Failed to parse the environment variable's value as an integer; {0}")]
     EnvParseInt(#[from] std::num::ParseIntError),
 
     /// This happens when attempting to read an item from DynamoDB.

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -97,12 +97,12 @@ pub enum Error {
     InconsistentState(Inconsistency),
 
     /// API is reorganizing.
-    #[error("the API is reorganizing around new chain tip {0:?}")]
+    #[error("The API is reorganizing around new chain tip {0:?}")]
     Reorganizing(Chainstate),
 
     /// An entry update version conflict in a resource update resulted
     /// in an update not being performed.
-    #[error("there was a conflict when attempting to update the database; {0}")]
+    #[error("There was a conflict when attempting to update the database; {0}")]
     VersionConflict(#[source] Box<ConditionalCheckFailedException>),
 
     /// Deserialization error
@@ -112,44 +112,44 @@ pub enum Error {
     /// This happens if the deposit entry that was stored in the database
     /// was invalid, or if the deposit entry that we are creating to store
     /// in the database is invalid.
-    #[error("deposit entry failed validation; {0}; ID: {1}")]
+    #[error("Deposit entry failed validation; {0}; ID: {1}")]
     DepositEntry(&'static str, DepositEntryKey),
 
     /// This happens when there is a mismatch in the outpoint of the new
     /// deposit event and the fetched deposit entry. Seeing this is
     /// probably due to a programming error.
-    #[error("mismatch when updateing deposit request; existing: {0}; update: {1}")]
+    #[error("Mismatch when updateing deposit request; existing: {0}; update: {1}")]
     DepositUpdate(DepositEntryKey, DepositEntryKey),
 
     /// This happens if the withdrawal entry that was stored in the database
     /// was invalid, or if the withdrawal entry that we are creating to store
     /// in the database is invalid.
-    #[error("withdrawal entry failed validation; {0}; ID: {1}")]
+    #[error("Withdrawal entry failed validation; {0}; ID: {1}")]
     WithdrawalEntry(&'static str, WithdrawalEntryKey),
 
     /// This happens when there is a mismatch in the request ID of the new
     /// withdrawal event and the fetched withdrawal entry. Seeing this is
     /// probably due to a programming error.
-    #[error("mismatch when updateing withdrawal request; existing: {0}; update: {1}")]
+    #[error("Mismatch when updating withdrawal request; existing: {0}; update: {1}")]
     WithdrawalUpdate(WithdrawalEntryKey, u64),
 
     /// This means that the stacks address in the environment for the
     /// signers multisig address is invalid.
-    #[error("could not parse a stacks address from a string")]
+    #[error("Could not parse a stacks address from a string")]
     InvalidStacksAddress(#[source] clarity::vm::errors::Error),
 
     /// This happens when the request to DynamoDB succeeds but does not
     /// return any values. This happens when the request instructs the
     /// database to refrain from returning values, so this is likely a
     /// programming error.
-    #[error("entry in database for deposit request not returned from DynamoDB; {0}")]
+    #[error("Entry in database for deposit request not returned from DynamoDB; {0}")]
     MissingAttributesDeposit(DepositEntryKey),
 
     /// This happens when the request to DynamoDB succeeds but does not
     /// return any values. This happens when the request instructs the
     /// database to refrain from returning values, so this is likely a
     /// programming error.
-    #[error("entry in database for withdrawal request not returned from DynamoDB; {0}")]
+    #[error("Entry in database for withdrawal request not returned from DynamoDB; {0}")]
     MissingAttributesWithdrawal(WithdrawalEntryKey),
 
     /// DynamoDB should only contain one entry per withdrawal request ID.
@@ -161,12 +161,12 @@ pub enum Error {
 
     /// This happens when we fail to decode a base64 encoded string into a
     /// vector of bytes.
-    #[error("failed to base64 decode the string into bytes; {0}")]
+    #[error("Failed to base64 decode the string into bytes; {0}")]
     Base64Decode(base64::DecodeError),
 
     /// This is used when trying to get a required value from the
     /// environment and that operation fails.
-    #[error("could not read the environment variable; {0}")]
+    #[error("Could not read the environment variable; {0}")]
     EnvVariable(#[from] env::VarError),
 
     /// This occurs when serializing or deserializing an object into or
@@ -180,33 +180,33 @@ pub enum Error {
 
     /// This happens when attempting to parse an integer from a string that
     /// has been read from an environment variable.
-    #[error("could not parse the string into an integer; {0}")]
+    #[error("Could not parse the string into an integer; {0}")]
     EnvParseInt(#[from] std::num::ParseIntError),
 
     /// This happens when attempting to read an item from DynamoDB.
-    #[error("could not retrieve an item from DynamoDB; {0}")]
+    #[error("Could not retrieve an item from DynamoDB; {0}")]
     AwsSdkDynamoDbGetItem(#[from] SdkError<GetItemError>),
 
     /// This happens when attempting to store an item in DynamoDB. Note
     /// that precondition checks that occur when putting an item into
     /// DynamoDB are transformed into the `VersionConflict` error variant.
-    #[error("could not put the item into DynamoDB; {0}")]
+    #[error("Could not put the item into DynamoDB; {0}")]
     AwsSdkDynamoDbPutItem(#[source] Box<PutItemError>),
 
     /// This happens when attempting the "Query" operation in DynamoDB.
-    #[error("could complete Query operation on DynamoDB; {0}")]
+    #[error("Could complete Query operation on DynamoDB; {0}")]
     AwsSdkDynamoDbQuery(#[from] SdkError<QueryError>),
 
     /// This happens when attempting the "Scan" operation in DynamoDB.
-    #[error("could complete Scan operation on DynamoDB; {0}")]
+    #[error("Could complete Scan operation on DynamoDB; {0}")]
     AwsSdkDynamoDbScan(#[from] SdkError<ScanError>),
 
     /// This happens when attempting to update a stored item in DynamoDB.
-    #[error("could not update the item in DynamoDB; {0}")]
+    #[error("Could not update the item in DynamoDB; {0}")]
     AwsSdkDynamoDbUpdateItem(#[source] Box<UpdateItemError>),
 
     /// This happens when attempting to delete an item in the database.
-    #[error("Error when deleting an item in DynamoDB; {0}")]
+    #[error("Could not deleting an item in DynamoDB; {0}")]
     AwsSdkDynamoDbDeleteItem(#[source] Box<DeleteItemError>),
 
     /// This happens when we fail to build a request object when trying to

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -154,7 +154,7 @@ pub enum Error {
 
     /// DynamoDB should only contain one entry per withdrawal request ID.
     ///
-    /// TODO: In case of a re-org, tripple check that we can identify the
+    /// TODO: In case of a re-org, triple check that we can identify the
     /// correct withdrawal request if the transaction is replayed.
     #[error("DynamoDB contained many entries for the given request ID: {0}")]
     TooManyWithdrawalEntries(u64),

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -118,7 +118,7 @@ pub enum Error {
     /// This happens when there is a mismatch in the outpoint of the new
     /// deposit event and the fetched deposit entry. Seeing this is
     /// probably due to a programming error.
-    #[error("Mismatch when updateing deposit request; existing: {0}; update: {1}")]
+    #[error("Mismatch when updating deposit request; existing: {0}; update: {1}")]
     DepositUpdate(DepositEntryKey, DepositEntryKey),
 
     /// This happens if the withdrawal entry that was stored in the database

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -194,11 +194,11 @@ pub enum Error {
     AwsSdkDynamoDbPutItem(#[source] Box<PutItemError>),
 
     /// This happens when attempting the "Query" operation in DynamoDB.
-    #[error("Could complete Query operation on DynamoDB; {0}")]
+    #[error("Could not complete Query operation on DynamoDB; {0}")]
     AwsSdkDynamoDbQuery(#[from] SdkError<QueryError>),
 
     /// This happens when attempting the "Scan" operation in DynamoDB.
-    #[error("Could complete Scan operation on DynamoDB; {0}")]
+    #[error("Could not complete Scan operation on DynamoDB; {0}")]
     AwsSdkDynamoDbScan(#[from] SdkError<ScanError>),
 
     /// This happens when attempting to update a stored item in DynamoDB.

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -113,25 +113,25 @@ pub enum Error {
     /// was invalid, or if the deposit entry that we are creating to store
     /// in the database is invalid.
     #[error("Deposit entry failed validation; {0}; ID: {1}")]
-    DepositEntry(&'static str, DepositEntryKey),
+    InvalidDepositEntry(&'static str, DepositEntryKey),
 
     /// This happens when there is a mismatch in the outpoint of the new
     /// deposit event and the fetched deposit entry. Seeing this is
     /// probably due to a programming error.
     #[error("Mismatch when updating deposit request; existing: {0}; update: {1}")]
-    DepositUpdate(DepositEntryKey, DepositEntryKey),
+    DepositOutputMismatch(DepositEntryKey, DepositEntryKey),
 
     /// This happens if the withdrawal entry that was stored in the database
     /// was invalid, or if the withdrawal entry that we are creating to store
     /// in the database is invalid.
     #[error("Withdrawal entry failed validation; {0}; ID: {1}")]
-    WithdrawalEntry(&'static str, WithdrawalEntryKey),
+    InvalidWithdrawalEntry(&'static str, WithdrawalEntryKey),
 
     /// This happens when there is a mismatch in the request ID of the new
     /// withdrawal event and the fetched withdrawal entry. Seeing this is
     /// probably due to a programming error.
     #[error("Mismatch when updating withdrawal request; existing: {0}; update: {1}")]
-    WithdrawalUpdate(WithdrawalEntryKey, u64),
+    WithdrawalRequestIdMismatch(WithdrawalEntryKey, u64),
 
     /// This means that the stacks address in the environment for the
     /// signers multisig address is invalid.
@@ -243,10 +243,10 @@ impl Error {
             Error::VersionConflict(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::Deserialization(_) => StatusCode::BAD_REQUEST,
             Error::InvalidStacksAddress(_) => StatusCode::INTERNAL_SERVER_ERROR,
-            Error::DepositEntry(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
-            Error::DepositUpdate(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
-            Error::WithdrawalEntry(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
-            Error::WithdrawalUpdate(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::InvalidDepositEntry(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::DepositOutputMismatch(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::InvalidWithdrawalEntry(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
+            Error::WithdrawalRequestIdMismatch(_, _) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::MissingAttributesDeposit(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::MissingAttributesWithdrawal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             Error::TooManyWithdrawalEntries(_) => StatusCode::INTERNAL_SERVER_ERROR,
@@ -290,8 +290,8 @@ impl Error {
             | Error::SerdeJson(_)
             | Error::SerdeDynamo(_)
             | Error::EnvParseInt(_)
-            | Error::DepositEntry(_, _)
-            | Error::WithdrawalEntry(_, _)
+            | Error::InvalidDepositEntry(_, _)
+            | Error::InvalidWithdrawalEntry(_, _)
             | Error::AwsSdkDynamoDbDeleteItem(_)
             | Error::AwsSdkDynamoDbGetItem(_)
             | Error::AwsSdkDynamoDbPutItem(_)

--- a/emily/handler/src/context.rs
+++ b/emily/handler/src/context.rs
@@ -88,7 +88,7 @@ impl Settings {
     pub fn from_env() -> Result<Self, Error> {
         let deployer_address = env::var("DEPLOYER_ADDRESS")?;
         let deployer_address = PrincipalData::parse_standard_principal(&deployer_address)
-            .map_err(|e| Error::Debug(format!("Failed to parse deployer address: {}", e)))?;
+            .map_err(Error::InvalidStacksAddress)?;
 
         Ok(Settings {
             is_local: env::var("IS_LOCAL")?.to_lowercase() == "true",

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -317,8 +317,9 @@ pub async fn get_withdrawal_entry(
         [withdrawal] => Ok(withdrawal.clone()),
         _ => {
             warn!(
-                "Found too many withdrawals for id {key}: {}",
-                serde_json::to_string_pretty(&entries)?
+                request_id = %key,
+                entries = %serde_json::to_string_pretty(&entries)?,
+                "Found too many withdrawals",
             );
             Err(Error::TooManyWithdrawalEntries(*key))
         }
@@ -442,7 +443,7 @@ pub async fn pull_and_update_withdrawal_with_retry(
         // Attempt to update the withdrawal.
         match update_withdrawal(context, &update_package).await {
             Err(Error::VersionConflict(error)) => {
-                warn!(%error, "received an error when updating a withdrawal request");
+                warn!(%error, "Received an error when updating a withdrawal request");
                 err = *error;
                 // Retry.
                 continue;

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -64,7 +64,6 @@ pub async fn get_deposit_entry(
     key: &DepositEntryKey,
 ) -> Result<DepositEntry, Error> {
     let entry = get_entry::<DepositTablePrimaryIndex>(context, key).await?;
-    #[cfg(feature = "testing")]
     Ok(entry)
 }
 
@@ -311,11 +310,7 @@ pub async fn get_withdrawal_entry(
     // Return.
     match entries.as_slice() {
         [] => Err(Error::NotFound),
-        [withdrawal] =>
-        {
-            #[cfg(feature = "testing")]
-            Ok(withdrawal.clone())
-        }
+        [withdrawal] => Ok(withdrawal.clone()),
         _ => {
             warn!(
                 "Found too many withdrawals for id {key}: {}",
@@ -588,6 +583,7 @@ pub async fn add_chainstate_entry(
         {
             for chainstate in chainstates {
                 // Remove the entry from the table.
+                // TODO: Figure out whether we need to delete anything at all here.
                 let existing_entry: ChainstateEntry = chainstate.into();
                 delete_entry::<ChainstateTablePrimaryIndex>(context, &existing_entry.key).await?;
             }

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -211,7 +211,7 @@ pub async fn pull_and_update_deposit_with_retry(
         match update_deposit(context, &update_package).await {
             Err(Error::VersionConflict(error)) => {
                 warn!(%error, "received an error when updating a deposit request");
-                err = error;
+                err = *error;
                 // Retry.
                 continue;
             }
@@ -221,7 +221,7 @@ pub async fn pull_and_update_deposit_with_retry(
         }
     }
     // Failed to update due to a version conflict
-    Err(Error::VersionConflict(err))
+    Err(Error::from(err))
 }
 
 /// Updates a deposit.
@@ -443,7 +443,7 @@ pub async fn pull_and_update_withdrawal_with_retry(
         match update_withdrawal(context, &update_package).await {
             Err(Error::VersionConflict(error)) => {
                 warn!(%error, "received an error when updating a withdrawal request");
-                err = error;
+                err = *error;
                 // Retry.
                 continue;
             }
@@ -453,7 +453,7 @@ pub async fn pull_and_update_withdrawal_with_retry(
         }
     }
     // Failed to update due to a version conflict
-    Err(Error::VersionConflict(err))
+    Err(Error::from(err))
 }
 
 /// Updates a withdrawal based on the update package.

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -557,7 +557,7 @@ pub async fn add_chainstate_entry(
             .await
             .and_then(|existing_entry: ChainstateEntry| {
                 if existing_entry.key != entry.key {
-                    debug!(
+                    warn!(
                         ?existing_entry,
                         ?entry,
                         "Inconsistent state because of a conflict with the current interpretation of a height."

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -523,7 +523,7 @@ pub async fn add_chainstate_entry_with_retry(
     for _ in 0..retries {
         match add_chainstate_entry(context, entry).await {
             Err(Error::VersionConflict(error)) => {
-                warn!(%error, "received an error when updating the chainstate");
+                warn!(%error, "Received an error when updating the chainstate");
                 // Retry.
                 continue;
             }

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -270,7 +270,7 @@ pub async fn update_deposit(
         .send()
         .await?
         .attributes
-        .ok_or(Error::Debug("Failed updating withdrawal".into()))
+        .ok_or(Error::MissingAttributesDeposit(update.key.clone()))
         .and_then(|attributes| {
             serde_dynamo::from_item::<Item, DepositEntry>(attributes.into()).map_err(Error::from)
         })
@@ -321,9 +321,7 @@ pub async fn get_withdrawal_entry(
                 "Found too many withdrawals for id {key}: {}",
                 serde_json::to_string_pretty(&entries)?
             );
-            Err(Error::Debug(format!(
-                "Found too many withdrawals for id {key}: {entries:?}"
-            )))
+            Err(Error::TooManyWithdrawalEntries(*key))
         }
     }
 }
@@ -505,7 +503,7 @@ pub async fn update_withdrawal(
         .send()
         .await?
         .attributes
-        .ok_or(Error::Debug("Failed updating withdrawal".into()))
+        .ok_or(Error::MissingAttributesWithdrawal(update.key.clone()))
         .and_then(|attributes| {
             serde_dynamo::from_item::<Item, WithdrawalEntry>(attributes.into()).map_err(Error::from)
         })

--- a/emily/handler/src/database/accessors.rs
+++ b/emily/handler/src/database/accessors.rs
@@ -617,8 +617,8 @@ pub async fn add_chainstate_entry(
         warn!(
             ?chaintip,
             ?entry,
-            "Attempting to add a chaintip that is more than one block ({}) higher than the current tip",
-            blocks_higher_than_current_tip,
+            %blocks_higher_than_current_tip,
+            "Attempting to add a chaintip with height that is more than one block greater than the current tip height",
         );
         // TODO(TBD): Determine the ramifications of allowing a chaintip to be added much
         // higher than expected.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -137,19 +137,19 @@ impl DepositEntry {
 
         // Verify that the latest event is the current one shown in the entry.
         if self.last_update_block_hash != latest_event.stacks_block_hash {
-            return Err(Error::DepositEntry(
+            return Err(Error::InvalidDepositEntry(
                 "last update block hash is inconsistent between history and top level data",
                 self.key.clone(),
             ));
         }
         if self.last_update_height != latest_event.stacks_block_height {
-            return Err(Error::DepositEntry(
+            return Err(Error::InvalidDepositEntry(
                 "last update block height is inconsistent between history and top level data",
                 self.key.clone(),
             ));
         }
         if self.status != (&latest_event.status).into() {
-            return Err(Error::DepositEntry(
+            return Err(Error::InvalidDepositEntry(
                 "most recent status is inconsistent between history and top level data",
                 self.key.clone(),
             ));
@@ -159,7 +159,7 @@ impl DepositEntry {
 
     /// Gets the latest event.
     pub fn latest_event(&self) -> Result<&DepositEvent, Error> {
-        self.history.last().ok_or(Error::DepositEntry(
+        self.history.last().ok_or(Error::InvalidDepositEntry(
             "Deposit entry must always have at least one event but did not",
             self.key.clone(),
         ))
@@ -687,7 +687,7 @@ impl DepositUpdatePackage {
     pub fn try_from(entry: &DepositEntry, update: ValidatedDepositUpdate) -> Result<Self, Error> {
         // Ensure the keys are equal.
         if update.key != entry.key {
-            return Err(Error::DepositUpdate(entry.key.clone(), update.key));
+            return Err(Error::DepositOutputMismatch(entry.key.clone(), update.key));
         }
         // Ensure that this event is valid if it follows the current latest event.
         entry

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -684,9 +684,7 @@ impl DepositUpdatePackage {
     pub fn try_from(entry: &DepositEntry, update: ValidatedDepositUpdate) -> Result<Self, Error> {
         // Ensure the keys are equal.
         if update.key != entry.key {
-            return Err(Error::Debug(
-                "Attempted to update deposit txid + output index combo".into(),
-            ));
+            return Err(Error::DepositUpdate(entry.key.clone(), update.key));
         }
         // Ensure that this event is valid if it follows the current latest event.
         entry

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -298,21 +298,24 @@ impl DepositEvent {
     pub fn ensure_following_event_is_valid(&self, next_event: &DepositEvent) -> Result<(), Error> {
         // Determine if event is valid.
         if self.stacks_block_height > next_event.stacks_block_height {
-            let err_msg = format!(
-                "Attempting to update a deposit with a block height earlier than it should be.\n
-                latest_existing_event:\n{self:?}\n
-                newest_event:\n{next_event:?}"
+            let message =
+                "Attempting to update a deposit with a block height earlier than it should be";
+            tracing::warn!(
+                new_event = ?next_event,
+                last_existing_event = ?self,
+                message,
             );
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(err_msg)));
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(message)));
         } else if self.stacks_block_height == next_event.stacks_block_height
             && self.stacks_block_hash != next_event.stacks_block_hash
         {
-            let err_msg = format!(
-                "Attempting to update a deposit with a block height and hash that conflicts with its current history.\n
-                latest_existing_event:\n{self:?}\n
-                newest_event:\n{next_event:?}"
+            let message = "Attempting to update a deposit with a block height and hash that conflicts with its current history";
+            tracing::warn!(
+                new_event = ?next_event,
+                last_existing_event = ?self,
+                message
             );
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(err_msg)));
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(message)));
         }
 
         Ok(())

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -339,7 +339,6 @@ pub(crate) trait TableIndexTrait {
     }
 
     /// Get all entries from a dynamodb table.
-    #[cfg(feature = "testing")]
     async fn get_all_entries(
         dynamodb_client: &aws_sdk_dynamodb::Client,
         settings: &Settings,
@@ -371,7 +370,6 @@ pub(crate) trait TableIndexTrait {
     }
 
     /// Generic delete table entry.
-    #[cfg(feature = "testing")]
     async fn delete_entry(
         dynamodb_client: &aws_sdk_dynamodb::Client,
         settings: &Settings,
@@ -588,7 +586,7 @@ fn detokenize<T>(token: String) -> Result<T, Error>
 where
     T: for<'de> Deserialize<'de>,
 {
-    let decoded = URL_SAFE_NO_PAD.decode(token)?;
+    let decoded = URL_SAFE_NO_PAD.decode(token).map_err(Error::Base64Decode)?;
     let deserialized = serde_json::from_slice::<T>(&decoded)?;
     Ok(deserialized)
 }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -94,19 +94,19 @@ impl WithdrawalEntry {
 
         // Verify that the latest event is the current one shown in the entry.
         if self.last_update_block_hash != latest_event.stacks_block_hash {
-            return Err(Error::WithdrawalEntry(
+            return Err(Error::InvalidWithdrawalEntry(
                 "last update block hash is inconsistent between history and top level data",
                 self.key.clone(),
             ));
         }
         if self.last_update_height != latest_event.stacks_block_height {
-            return Err(Error::WithdrawalEntry(
+            return Err(Error::InvalidWithdrawalEntry(
                 "last update block height is inconsistent between history and top level data",
                 self.key.clone(),
             ));
         }
         if self.status != (&latest_event.status).into() {
-            return Err(Error::WithdrawalEntry(
+            return Err(Error::InvalidWithdrawalEntry(
                 "most recent status is inconsistent between history and top level data",
                 self.key.clone(),
             ));
@@ -116,7 +116,7 @@ impl WithdrawalEntry {
 
     /// Gets the latest event.
     pub fn latest_event(&self) -> Result<&WithdrawalEvent, Error> {
-        self.history.last().ok_or(Error::WithdrawalEntry(
+        self.history.last().ok_or(Error::InvalidWithdrawalEntry(
             "Withdrawal entry must always have at least one event, but did not",
             self.key.clone(),
         ))
@@ -680,7 +680,7 @@ impl WithdrawalUpdatePackage {
         // Ensure the keys are equal.
         let key = entry.key.clone();
         if update.request_id != entry.key.request_id {
-            return Err(Error::WithdrawalUpdate(key, update.request_id));
+            return Err(Error::WithdrawalRequestIdMismatch(key, update.request_id));
         }
         // Ensure that this event is valid if it follows the current latest event.
         entry

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -672,8 +672,9 @@ impl WithdrawalUpdatePackage {
     ) -> Result<Self, Error> {
         // Ensure the keys are equal.
         if update.request_id != entry.key.request_id {
-            return Err(Error::Debug(
-                "Attempted to update withdrawal request_id combo.".into(),
+            return Err(Error::WithdrawalUpdate(
+                entry.key.clone(),
+                update.request_id,
             ));
         }
         // Ensure that this event is valid if it follows the current latest event.

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -246,17 +246,24 @@ impl WithdrawalEvent {
     ) -> Result<(), Error> {
         // Determine if event is valid.
         if self.stacks_block_height > next_event.stacks_block_height {
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
-                "Attempting to update a withdrawal with a block height earlier than it should be."
-                    .into(),
-            )));
+            let message =
+                "Attempting to update a withdrawal with a block height earlier than it should be";
+            tracing::warn!(
+                new_event = ?next_event,
+                last_existing_event = ?self,
+                message
+            );
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(message)));
         } else if self.stacks_block_height == next_event.stacks_block_height
             && self.stacks_block_hash != next_event.stacks_block_hash
         {
-            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(
-                "Attempting to update a withdrawal with a block height and hash that conflicts with the current history."
-                    .into(),
-            )));
+            let message = "Attempting to update a withdrawal with a block height and hash that conflicts with the current history";
+            tracing::warn!(
+                new_event = ?next_event,
+                last_existing_event = ?self,
+                message
+            );
+            return Err(Error::InconsistentState(Inconsistency::ItemUpdate(message)));
         }
 
         Ok(())

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -671,11 +671,9 @@ impl WithdrawalUpdatePackage {
         update: ValidatedWithdrawalUpdate,
     ) -> Result<Self, Error> {
         // Ensure the keys are equal.
+        let key = entry.key.clone();
         if update.request_id != entry.key.request_id {
-            return Err(Error::WithdrawalUpdate(
-                entry.key.clone(),
-                update.request_id,
-            ));
+            return Err(Error::WithdrawalUpdate(key, update.request_id));
         }
         // Ensure that this event is valid if it follows the current latest event.
         entry
@@ -683,7 +681,7 @@ impl WithdrawalUpdatePackage {
             .ensure_following_event_is_valid(&update.event)?;
         // Create the withdrawal update package.
         Ok(WithdrawalUpdatePackage {
-            key: entry.key.clone(),
+            key,
             version: entry.version,
             event: update.event,
         })


### PR DESCRIPTION
## Description

There were a few small issues that were bothersome around our logs that this PR fixes.

## Changes

* Remove unused error variants.
* Remove the `Debug` error variant and the associated 418 status code that was associated with those error. The response code is now likely to be 500 now.
* Create more targeted error variants for the errors that can happen.
* Update the logging message and comments around the new error variants.
* Make sure production code is compiled without the `testing` feature.
* Add more logging around errors, upgrade their level.

## Testing Information

This is all logging and error refactoring, so no new tests.

## Checklist:

- [x] I have performed a self-review of my code
