### PR TITLE
fix: Update docker compose to the last version

### DIFF
--- a/docker/mainnet/README.md
+++ b/docker/mainnet/README.md
@@ -108,4 +108,4 @@ respectively, at `/mnt/bitcoin` and `/mnt/stacks`.
 ### sBTC signer and Stacks Node versions
 
 Always run the latest version of the docker images.
-You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the latest version of Stacks Core Image [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).
+You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the Stacks Core images [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).

--- a/docker/mainnet/README.md
+++ b/docker/mainnet/README.md
@@ -107,5 +107,5 @@ respectively, at `/mnt/bitcoin` and `/mnt/stacks`.
 
 ### sBTC signer and Stacks Node versions
 
-Always run last version of the docker images.
+Always run the latest version of the docker images.
 You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the latest version of Stacks Core Image [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).

--- a/docker/mainnet/README.md
+++ b/docker/mainnet/README.md
@@ -107,5 +107,5 @@ respectively, at `/mnt/bitcoin` and `/mnt/stacks`.
 
 ### sBTC signer and Stacks Node versions
 
-Run always last version of the docker images.
-You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the latest versions of Stacks [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).
+Always run last version of the docker images.
+You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the latest version of Stacks Core Image [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).

--- a/docker/mainnet/README.md
+++ b/docker/mainnet/README.md
@@ -104,3 +104,8 @@ sudo docker compose --env-file .env -f docker-compose.yml -f nodes/docker-compos
 
 This requires the chain-state for Bitcoin and Stacks to be present,
 respectively, at `/mnt/bitcoin` and `/mnt/stacks`.
+
+### sBTC signer and Stacks Node versions
+
+Run always last version of the docker images.
+You can find the sBTC images [here](https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc) and the latest versions of Stacks [here](https://hub.docker.com/r/blockstack/stacks-blockchain/tags).

--- a/docker/mainnet/docker-compose.yml
+++ b/docker/mainnet/docker-compose.yml
@@ -49,7 +49,7 @@ services:
   sbtc-signer:
     container_name: sbtc-signer
     restart: on-failure
-    image: blockstack/sbtc:signer-0.0.9-rc6@sha256:44d2c828c6452f75ea2fabe5160ba95a9f944c0fcaeeaea5523dff81da8bc342
+    image: ghcr.io/stacks-sbtc/sbtc:signer-v1.0.2@sha256:60832405b3f56e8c8ae9ac9429866ce5173f86ff79652bad7f38481f220b2332
     entrypoint: "/entrypoint.sh"
     command:
       - /bin/bash
@@ -99,7 +99,7 @@ services:
   blocklist-client:
     restart: on-failure
     container_name: blocklist-client
-    image: blockstack/sbtc:blocklist-client-0.0.9-rc6@sha256:e4fa52ac16c357ae69f3b9eb5d5254a43bc605dbded621291b5637064b04d105
+    image: ghcr.io/stacks-sbtc/sbtc:blocklist-client-v1.0.2@sha256:713a19fc6ad6f3538da7849d8c731f65b1bc0d9258f59947b487087c0c94d4be
     entrypoint: "/entrypoint.sh"
     command: "/usr/local/bin/blocklist-client"
     environment:

--- a/docker/mainnet/docker-compose.yml
+++ b/docker/mainnet/docker-compose.yml
@@ -49,6 +49,7 @@ services:
   sbtc-signer:
     container_name: sbtc-signer
     restart: on-failure
+    # this version can be outdated, check the last image on: https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc
     image: ghcr.io/stacks-sbtc/sbtc:signer-v1.0.2@sha256:60832405b3f56e8c8ae9ac9429866ce5173f86ff79652bad7f38481f220b2332
     entrypoint: "/entrypoint.sh"
     command:
@@ -99,6 +100,7 @@ services:
   blocklist-client:
     restart: on-failure
     container_name: blocklist-client
+    # this version can be outdated, check the last image on: https://github.com/stacks-sbtc/sbtc/pkgs/container/sbtc
     image: ghcr.io/stacks-sbtc/sbtc:blocklist-client-v1.0.2@sha256:713a19fc6ad6f3538da7849d8c731f65b1bc0d9258f59947b487087c0c94d4be
     entrypoint: "/entrypoint.sh"
     command: "/usr/local/bin/blocklist-client"

--- a/docker/mainnet/gh-attestation/entrypoint.sh
+++ b/docker/mainnet/gh-attestation/entrypoint.sh
@@ -8,8 +8,8 @@ if [[ -z "$BUNDLE_PATH" || -z "$TRUSTED_ROOT_PATH" || -z "$TAG" ]]; then
 fi
 
 # Define the image and repo (since they are fixed)
-IMAGE="index.docker.io/blockstack/sbtc:$TAG"
-REPO="stacks-network/sbtc"
+IMAGE="ghcr.io/stacks-sbtc/sbtc:$TAG"
+REPO="stacks-sbtc/sbtc"
 
 # Verifying attestation
 echo "✅ Verifying attestation for image: $IMAGE..."

--- a/docker/mainnet/nodes/docker-compose.chains.yml
+++ b/docker/mainnet/nodes/docker-compose.chains.yml
@@ -48,6 +48,7 @@ services:
           -zmqpubrawblock="tcp://*:$${BITCOIN_ZMQ_PORT}"
 
   stacks-blockchain:
+    # this version can be outdated, check the last image on: https://hub.docker.com/r/blockstack/stacks-blockchain/tags
     image: blockstack/stacks-blockchain:3.1.0.0.8.1@sha256:e8f03d925feec1035a5bd1813c68f05c67ec9e841555cfa913abbc0cf266c7a1
     container_name: stacks-blockchain
     restart: on-failure:3

--- a/docker/mainnet/nodes/docker-compose.chains.yml
+++ b/docker/mainnet/nodes/docker-compose.chains.yml
@@ -48,7 +48,7 @@ services:
           -zmqpubrawblock="tcp://*:$${BITCOIN_ZMQ_PORT}"
 
   stacks-blockchain:
-    image: blockstack/stacks-blockchain:3.1.0.0.4@sha256:bd0a8874224203dcd3f32dca4c8421a052f7afa8cd433bedecb2e6c88f04dd12
+    image: blockstack/stacks-blockchain:3.1.0.0.8.1@sha256:e8f03d925feec1035a5bd1813c68f05c67ec9e841555cfa913abbc0cf266c7a1
     container_name: stacks-blockchain
     restart: on-failure:3
     ports:

--- a/docker/mainnet/nodes/docker-compose.chains.yml
+++ b/docker/mainnet/nodes/docker-compose.chains.yml
@@ -49,7 +49,7 @@ services:
 
   stacks-blockchain:
     # this version can be outdated, check the last image on: https://hub.docker.com/r/blockstack/stacks-blockchain/tags
-    image: blockstack/stacks-blockchain:3.1.0.0.8.1@sha256:e8f03d925feec1035a5bd1813c68f05c67ec9e841555cfa913abbc0cf266c7a1
+    image: blockstack/stacks-blockchain:3.1.0.0.8@sha256:e8f03d925feec1035a5bd1813c68f05c67ec9e841555cfa913abbc0cf266c7a1
     container_name: stacks-blockchain
     restart: on-failure:3
     ports:


### PR DESCRIPTION
## Description

Update docker compose to the last docker version

## Changes

- Update Signer and Blocklist version
- Update Entry Point with GHCR
- Update Stacks Node
- Add links to find the last images release

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
