### PR TITLE
fix: add critical replay protection in registry contract

### DIFF
--- a/contracts/contracts/sbtc-registry.clar
+++ b/contracts/contracts/sbtc-registry.clar
@@ -4,6 +4,8 @@
 (define-constant ERR_UNAUTHORIZED (err u400))
 (define-constant ERR_INVALID_REQUEST_ID (err u401))
 (define-constant ERR_AGG_PUBKEY_REPLAY (err u402))
+(define-constant ERR_REGISTRY_DEPOSIT_REPLAY (err u403))
+(define-constant ERR_REGISTRY_WITHDRAWAL_REPLAY (err u404))
 
 ;; Protocol contract type
 (define-constant governance-role 0x00)
@@ -207,6 +209,7 @@
 	)
 	(begin
 		(try! (is-protocol-caller withdrawal-role contract-caller))
+		(asserts! (is-none (map-get? withdrawal-status request-id)) ERR_REGISTRY_WITHDRAWAL_REPLAY)
 		;; Mark the withdrawal as completed
 		(map-insert withdrawal-status request-id true)
 		(map-insert completed-withdrawal-sweep request-id {
@@ -240,6 +243,7 @@
 	)
 	(begin
 		(try! (is-protocol-caller withdrawal-role contract-caller))
+		(asserts! (is-none (map-get? withdrawal-status request-id)) ERR_REGISTRY_WITHDRAWAL_REPLAY)
 		;; Mark the withdrawal as completed
 		(map-insert withdrawal-status request-id false)
 		(print {
@@ -269,6 +273,7 @@
 	)
 	(begin
 		(try! (is-protocol-caller deposit-role contract-caller))
+		(asserts! (is-none (map-get? deposit-status {txid: txid, vout-index: vout-index})) ERR_REGISTRY_DEPOSIT_REPLAY)
 		(map-insert deposit-status {txid: txid, vout-index: vout-index} true)
 		(map-insert completed-deposits {txid: txid, vout-index: vout-index} {
 			amount: amount,


### PR DESCRIPTION
Add defense-in-depth replay protection to the sbtc-registry contract to prevent:

1. Deposit vulnerability:
   - Double-minting of sBTC tokens for the same Bitcoin deposit

2. Withdrawal vulnerabilities:
   - Multiple fee refunds: Prevents repeated minting of fee refunds to requesters
   - Double unlock exploitation: Blocks the critical vulnerability where the same withdrawal could be rejected multiple times, unlocking and reminting the same sBTC amount repeatedly, effectively creating tokens out of nothing

Implementation:
- Added checks in complete-deposit to prevent double-minting
- Added checks in withdrawal acceptance/rejection functions to block devastating multiple-unlock and multiple-refund attacks
- Created specific error codes for registry-level replay detection

This addresses vulnerabilities where malicious deposit/withdrawal contracts could process the same transaction multiple times if compromised signers upgraded the contracts, with particularly severe consequences in the withdrawal flow.

The sbtc-registry contract lacks redundant internal checks to prevent processing the same deposit (txid, vout-index) multiple times within its complete-deposit function, and similarly for processing the same withdrawal request (request-id) multiple times in its complete-withdrawal-accept and complete-withdrawal-reject functions. It implicitly trusts the authorised contracts holding the deposit-role (normally .sbtc-deposit) and withdrawal-role (normally .sbtc-withdrawal) to perform replay checks before calling the registry.

