### PR TITLE
chore: don't sort items in packaging

### DIFF
--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -67,12 +67,10 @@ where
     // This is a variant of the Best-Fit-Decreasing algorithm, so we sort
     // by "weight" decreasing. We use the votes against as the weight, but
     // vsize is a reasonable weight metric as well.
-    let mut item_vec: Vec<(u32, T)> = items
+    let item_vec: Vec<(u32, T)> = items
         .into_iter()
         .map(|item| (item.votes().count_ones(), item))
         .collect();
-
-    item_vec.sort_by_key(|(vote_count, _)| std::cmp::Reverse(*vote_count));
 
     // Now we just add each item into a bag, and return the
     // collection of bags afterward.

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -64,9 +64,10 @@ where
     I: IntoIterator<Item = T>,
     T: Weighted,
 {
-    // This is a variant of the Best-Fit-Decreasing algorithm, so we sort
-    // by "weight" decreasing. We use the votes against as the weight, but
-    // vsize is a reasonable weight metric as well.
+    // We might want to sort the items, and previously the was sorted by votes.
+    // However, it can allow malicious signer to speedup/slowdown requests execution,
+    // so it is not so good key to sort with. Some better keys can be time or something
+    // like this, but it require a bit more work so for now we just keep it unsorted.
     let item_vec: Vec<(u32, T)> = items
         .into_iter()
         .map(|item| (item.votes().count_ones(), item))

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -504,6 +504,7 @@ mod tests {
     use rand::Rng;
     use rand::prelude::SliceRandom;
     use signer::testing::get_rng;
+    use std::sync::atomic::AtomicU64;
     use test_case::test_case;
 
     impl<T> BestFitPackager<T>
@@ -556,6 +557,8 @@ mod tests {
         withdrawal_id: Option<u64>,
     }
 
+    static NEXT_REQUEST_ID: AtomicU64 = AtomicU64::new(0);
+
     impl RequestItem {
         /// Create a new request item with no votes against.
         fn no_votes() -> Self {
@@ -605,7 +608,7 @@ mod tests {
             let needs_signature = rng.gen_bool(0.5);
             let vsize = rng.gen_range(1..=10000);
             let withdrawal_id = if !needs_signature {
-                Some(rng.gen_range(1..=100))
+                Some(NEXT_REQUEST_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
             } else {
                 None
             };

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -64,22 +64,13 @@ where
     I: IntoIterator<Item = T>,
     T: Weighted,
 {
-    // We might want to sort the items, and previously the was sorted by votes.
-    // However, it can allow malicious signer to speedup/slowdown requests execution,
-    // so it is not so good key to sort with. Some better keys can be time or something
-    // like this, but it require a bit more work so for now we just keep it unsorted.
-    let item_vec: Vec<(u32, T)> = items
-        .into_iter()
-        .map(|item| (item.votes().count_ones(), item))
-        .collect();
-
     // Now we just add each item into a bag, and return the
     // collection of bags afterward.
     // Create config and packager
     let config = PackagerConfig::new(max_votes_against, max_needs_signature);
     let mut packager = BestFitPackager::new(config);
 
-    for (_, item) in item_vec {
+    for item in items {
         packager.insert_item(item);
     }
 

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -749,6 +749,36 @@ mod tests {
         assert!(!bag.can_fit_withdrawal_ids(&large_set));
     }
 
+    use rand::prelude::SliceRandom;
+
+    #[test]
+    fn item_order_matters_in_compute_optimal_packages() {
+        let mut rng = get_rng();
+        let len = rng.gen_range(10..=100) as usize;
+        let mut items = Vec::with_capacity(len);
+        for _ in 0..len {
+            items.push(RequestItem::with_rng(&mut rng));
+        }
+
+        let max_needs_signature = 100;
+        let max_votes_against = 3;
+        let packages1 = compute_optimal_packages(
+            items.clone(),
+            max_votes_against,
+            max_needs_signature,
+        ).collect::<Vec<_>>();
+
+        items.shuffle(&mut rng);
+
+        let packages2 = compute_optimal_packages(
+            items,
+            max_votes_against,
+            max_needs_signature,
+        ).collect::<Vec<_>>();
+        
+        assert_ne!(packages1, packages2);
+    }
+
     /// Tests that bags correctly collect, sort, and deduplicate withdrawal IDs.
     #[test]
     fn test_bag_collects_withdrawal_ids() {

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -604,7 +604,7 @@ mod tests {
             }
             let needs_signature = rng.gen_bool(0.5);
             let vsize = rng.gen_range(1..=10000);
-            let withdrawal_id = if rng.gen_bool(0.5) {
+            let withdrawal_id = if needs_signature && rng.gen_bool(0.5) {
                 Some(rng.gen_range(1..=100))
             } else {
                 None
@@ -777,7 +777,7 @@ mod tests {
     #[test]
     fn item_order_matters_in_compute_optimal_packages() {
         let mut rng = get_rng();
-        let len = rng.gen_range(10..=100) as usize;
+        let len = rng.gen_range(25..=100) as usize;
         let mut items = Vec::with_capacity(len);
         for _ in 0..len {
             items.push(RequestItem::with_rng(&mut rng));

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -604,7 +604,7 @@ mod tests {
             }
             let needs_signature = rng.gen_bool(0.5);
             let vsize = rng.gen_range(1..=10000);
-            let withdrawal_id = if needs_signature && rng.gen_bool(0.5) {
+            let withdrawal_id = if !needs_signature {
                 Some(rng.gen_range(1..=100))
             } else {
                 None


### PR DESCRIPTION
## Description

Sorting items by amount of votes gives ability for malicious signer to delay or speedup some requests, thus it should be deleted

Closes: #1661

## Changes

- don't sort items in packaging anymore (however, we probably want to add sort by some other key in the future)

## Testing Information

No new tests needed

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
