### PR TITLE
chore: switch more code to get_rng()

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -304,7 +304,6 @@ mod tests {
     use bitvec::array::BitArray;
     use clarity::vm::types::PrincipalData;
     use fake::Fake;
-    use rand::rngs::OsRng;
     use sbtc::events::KeyRotationEvent;
     use secp256k1::SECP256K1;
     use stacks_common::types::chainstate::StacksBlockId;
@@ -382,6 +381,7 @@ mod tests {
     where
         F: Fn(tokio::sync::MutexGuard<'_, Store>) -> bool,
     {
+        let mut rng = get_rng();
         let ctx = TestContext::builder()
             .with_in_memory_storage()
             .with_mocked_clients()
@@ -402,7 +402,7 @@ mod tests {
         let contract_name = ContractName::from(SBTC_REGISTRY_CONTRACT_NAME);
         let identifier = QualifiedContractIdentifier::new(issuer, contract_name.clone());
 
-        let fishy_principal: StacksPrincipal = fake::Faker.fake_with_rng(&mut OsRng);
+        let fishy_principal: StacksPrincipal = fake::Faker.fake_with_rng(&mut rng);
         let fishy_issuer = match PrincipalData::from(fishy_principal) {
             PrincipalData::Contract(contract) => contract.issuer,
             PrincipalData::Standard(standard) => standard,

--- a/signer/src/codec.rs
+++ b/signer/src/codec.rs
@@ -145,7 +145,6 @@ mod tests {
     use fake::Fake as _;
     use fake::Faker;
     use prost::bytes::Buf as _;
-    use rand::rngs::OsRng;
     use test_case::test_case;
 
     use p256k1::point::Point;
@@ -251,7 +250,8 @@ mod tests {
         U: From<T> + prost::Message + Default + PartialEq,
         E: std::fmt::Debug,
     {
-        let original: T = Faker.fake_with_rng(&mut OsRng);
+        let mut rng = get_rng();
+        let original: T = Faker.fake_with_rng(&mut rng);
         let proto_original = U::from(original.clone());
         let data = proto_original.encode_to_vec();
         let mut buf = data.as_slice();
@@ -316,7 +316,8 @@ mod tests {
         U: From<T> + prost::Message + Default + PartialEq,
         E: std::fmt::Debug,
     {
-        let original: T = Unit.fake_with_rng(&mut OsRng);
+        let mut rng = get_rng();
+        let original: T = Unit.fake_with_rng(&mut rng);
         let proto_original = U::from(original.clone());
         let data = proto_original.encode_to_vec();
         let mut buf = data.as_slice();

--- a/signer/src/ecdsa.rs
+++ b/signer/src/ecdsa.rs
@@ -263,7 +263,6 @@ mod tests {
     use std::marker::PhantomData;
 
     use fake::Fake as _;
-    use rand::rngs::OsRng;
 
     use crate::codec::Encode as _;
     use crate::ecdsa::SignEcdsa;
@@ -291,12 +290,13 @@ mod tests {
     where
         T: Into<message::Payload> + fake::Dummy<Faker>,
     {
-        let keypair = secp256k1::Keypair::new_global(&mut OsRng);
+        let mut rng = get_rng();
+        let keypair = secp256k1::Keypair::new_global(&mut rng);
         let private_key: PrivateKey = keypair.secret_key().into();
         let public_key: PublicKey = keypair.public_key().into();
         let original_message = SignerMessage {
             bitcoin_chain_tip: BitcoinBlockHash::from([1; 32]),
-            payload: Faker.fake_with_rng::<T, _>(&mut OsRng).into(),
+            payload: Faker.fake_with_rng::<T, _>(&mut rng).into(),
         };
 
         // We sign a payload digest. It should always be what this function
@@ -349,12 +349,13 @@ mod tests {
     where
         T: Into<message::Payload> + fake::Dummy<Faker>,
     {
-        let keypair = secp256k1::Keypair::new_global(&mut OsRng);
+        let mut rng = get_rng();
+        let keypair = secp256k1::Keypair::new_global(&mut rng);
         let private_key: PrivateKey = keypair.secret_key().into();
         let public_key: PublicKey = keypair.public_key().into();
         let original_message = SignerMessage {
             bitcoin_chain_tip: BitcoinBlockHash::from([1; 32]),
-            payload: Faker.fake_with_rng::<T, _>(&mut OsRng).into(),
+            payload: Faker.fake_with_rng::<T, _>(&mut rng).into(),
         };
 
         // We sign a payload digest. It should always be what this function
@@ -435,14 +436,15 @@ mod tests {
     where
         T: Into<message::Payload> + fake::Dummy<Faker>,
     {
+        let mut rng = get_rng();
         // This is the upgraded signer. They will construct a message for
         // consumption by another signer.
-        let keypair = secp256k1::Keypair::new_global(&mut OsRng);
+        let keypair = secp256k1::Keypair::new_global(&mut rng);
         let private_key: PrivateKey = keypair.secret_key().into();
         let public_key: PublicKey = keypair.public_key().into();
         let original_message = SignerMessage {
             bitcoin_chain_tip: BitcoinBlockHash::from([1; 32]),
-            payload: Faker.fake_with_rng::<T, _>(&mut OsRng).into(),
+            payload: Faker.fake_with_rng::<T, _>(&mut rng).into(),
         };
 
         // The upgraded signer sends messages with an additional field.
@@ -537,9 +539,10 @@ mod tests {
 
     #[test]
     fn backwards_compatible_updates2() {
+        let mut rng = get_rng();
         // This is the upgraded signer. They will construct a message for
         // consumption by another signer.
-        let keypair = secp256k1::Keypair::new_global(&mut OsRng);
+        let keypair = secp256k1::Keypair::new_global(&mut rng);
         let private_key: PrivateKey = keypair.secret_key().into();
         let public_key: PublicKey = keypair.public_key().into();
 
@@ -552,10 +555,10 @@ mod tests {
         // values.
         let mut new_field = std::collections::HashMap::new();
         for _ in 0..100 {
-            new_field.insert(Faker.fake_with_rng(&mut OsRng), proto::SetValueZst {});
+            new_field.insert(Faker.fake_with_rng(&mut rng), proto::SetValueZst {});
         }
-        let block_hash = Faker.fake_with_rng::<StacksBlockHash, _>(&mut OsRng);
-        let txid = Faker.fake_with_rng::<StacksTxId, _>(&mut OsRng);
+        let block_hash = Faker.fake_with_rng::<StacksBlockHash, _>(&mut rng);
+        let txid = Faker.fake_with_rng::<StacksTxId, _>(&mut rng);
         let decision = SignerWithdrawalDecisionUpgraded {
             request_id: 102,
             block_id: Some(proto::StacksBlockId::from(block_hash)),

--- a/signer/src/signature.rs
+++ b/signer/src/signature.rs
@@ -184,17 +184,19 @@ pub mod serde_utils {
 #[cfg(test)]
 mod tests {
     use fake::Fake;
-    use rand::rngs::OsRng;
 
     use super::*;
 
+    use crate::testing::get_rng;
+
     #[test]
     fn recoverable_signatures_recover_public_key() {
+        let mut rng = get_rng();
         // Let's create a random digest to sign, sign it, and recover the
         // public key from the signature.
-        let private_key = PrivateKey::new(&mut OsRng);
+        let private_key = PrivateKey::new(&mut rng);
 
-        let digest: [u8; 32] = fake::Faker.fake_with_rng(&mut OsRng);
+        let digest: [u8; 32] = fake::Faker.fake_with_rng(&mut rng);
         let msg = secp256k1::Message::from_digest(digest);
         let sig = private_key.sign_ecdsa_recoverable(&msg);
 
@@ -212,7 +214,8 @@ mod tests {
 
     #[test]
     fn deserialize_inverts_serialize_compact() {
-        let sig1 = crate::testing::dummy::recoverable_signature(&fake::Faker, &mut OsRng);
+        let mut rng = get_rng();
+        let sig1 = crate::testing::dummy::recoverable_signature(&fake::Faker, &mut rng);
         let data = sig1.to_byte_array();
         let sig2 = RecoverableSignature::from_byte_array(&data).unwrap();
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -1642,6 +1642,7 @@ mod tests {
     use crate::storage::{DbWrite, model};
     use crate::testing;
     use crate::testing::context::*;
+    use crate::testing::get_rng;
 
     use super::*;
 
@@ -1750,6 +1751,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_wsts_message_asserts_dkg_begin() {
+        let mut rng = get_rng();
         let context = TestContext::builder()
             .with_in_memory_storage()
             .with_mocked_clients()
@@ -1785,11 +1787,11 @@ mod tests {
         let mut signer = TxSignerEventLoop {
             context,
             network: network.connect(),
-            signer_private_key: PrivateKey::new(&mut rand::rngs::OsRng),
+            signer_private_key: PrivateKey::new(&mut rng),
             context_window: 1,
             wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
             threshold: 1,
-            rng: rand::rngs::OsRng,
+            rng,
             dkg_begin_pause: None,
             dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
         };
@@ -1820,6 +1822,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_handle_wsts_message_non_canonical_dkg_begin() {
+        let mut rng = get_rng();
         let context = TestContext::builder()
             .with_in_memory_storage()
             .with_mocked_clients()
@@ -1852,11 +1855,11 @@ mod tests {
         let mut signer = TxSignerEventLoop {
             context,
             network: network.connect(),
-            signer_private_key: PrivateKey::new(&mut rand::rngs::OsRng),
+            signer_private_key: PrivateKey::new(&mut rng),
             context_window: 1,
             wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
             threshold: 1,
-            rng: rand::rngs::OsRng,
+            rng,
             dkg_begin_pause: None,
             dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
         };
@@ -1913,6 +1916,7 @@ mod tests {
         }); "SignatureShareRequest")]
     #[tokio::test]
     async fn test_handle_wsts_message_non_canonical(wsts_message: WstsNetMessage) {
+        let mut rng = get_rng();
         let context = TestContext::builder()
             .with_in_memory_storage()
             .with_mocked_clients()
@@ -1937,11 +1941,11 @@ mod tests {
         let mut signer = TxSignerEventLoop {
             context,
             network: network.connect(),
-            signer_private_key: PrivateKey::new(&mut rand::rngs::OsRng),
+            signer_private_key: PrivateKey::new(&mut rng),
             context_window: 1,
             wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
             threshold: 1,
-            rng: rand::rngs::OsRng,
+            rng,
             dkg_begin_pause: None,
             dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
         };


### PR DESCRIPTION
## Description

This PR aims to eliminate all (or all I'll find xD) usages of raw `OsRng` and replace them with `get_rng()`. This is useful because it 1) Make flaky tests easy to reproduce. 2) Make our testing code more consistent across codebase.

Closes: #?

## Changes

Note: Scope of the changes is _only_ signer crate.

- Switched from raw `OsRng` to `get_rng()` usages.
- In `bitcoin::utxo.rs` added some workaround (`global_rng()`) to handle random usages in `test_case` headers.
- In `bitcoin::utxo.rs` some helper functions now expect `rand::Rng` input parameter instead of creating rng themselves

WIP

## Testing Information

No new tests needed.

## Checklist:

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
