### PR TITLE
fix: install uv in docker

### DIFF
--- a/docker/sbtc/Dockerfile
+++ b/docker/sbtc/Dockerfile
@@ -23,7 +23,7 @@ ARG GIT_BRANCH=main
 RUN git checkout $GIT_BRANCH
 
 # Install uv from Astral's official script
-RUN curl -Ls https://astral.sh/uv/install.sh | sh
+RUN curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.7.3/uv-installer.sh | sh
 
 # Add installed uv to PATH
 ENV PATH="/root/.cargo/bin:/root/.local/bin:$PATH"


### PR DESCRIPTION
## Description

Installs uv in docker.

## Issue

When I'm on `feature` branch which don't have uv update yet and try to do `make integration-env-build` I see this docker error:

```shell
 => ERROR [emily-aws-setup builder  9/13] RUN make install && make build                                                                              0.2s
 => CACHED [emily-aws-setup emily-aws-setup 2/5] WORKDIR /code                                                                                        0.0s
------
 > [emily-aws-setup builder  9/13] RUN make install && make build:
0.166 uv --directory emily_cron venv && uv --directory emily_cron pip sync pyproject.toml
0.167 /bin/sh: 1: uv: not found
0.167 make: *** [Makefile:20: install-py] Error 127
```

## Changes

- Added few lines to dockerfile for installing uv and setting it's path

## Testing Information

- No new tests needed

## Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
