### PR TITLE
feat: add timestamp support for sqlx+postgres integration

### DIFF
--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1506,14 +1506,8 @@ pub struct StacksBlockHeight(u64);
 
 /// A newtype over [`time::OffsetDateTime`] which implements encode/decode for sqlx
 /// and integrates seamlessly with the Postgres `TIMESTAMPTZ` type.
-#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct Timestamp(time::OffsetDateTime);
-
-impl std::fmt::Debug for Timestamp {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
 
 impl Deref for Timestamp {
     type Target = time::OffsetDateTime;

--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -1504,6 +1504,30 @@ pub struct BitcoinBlockHeight(u64);
 #[serde(transparent)]
 pub struct StacksBlockHeight(u64);
 
+/// A newtype over [`time::OffsetDateTime`] which implements encode/decode for sqlx
+/// and integrates seamlessly with the Postgres `TIMESTAMPTZ` type.
+#[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Timestamp(time::OffsetDateTime);
+
+impl std::fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Deref for Timestamp {
+    type Target = time::OffsetDateTime;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<time::OffsetDateTime> for Timestamp {
+    fn from(value: time::OffsetDateTime) -> Self {
+        Self(value)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use fake::Fake;

--- a/signer/src/storage/sqlx.rs
+++ b/signer/src/storage/sqlx.rs
@@ -26,9 +26,9 @@ use crate::storage::model::StacksTxId;
 
 use super::model::Timestamp;
 
-/// The PostgreSQL epoch is 2000-01-01 00:00:00 UTC 
+/// The PostgreSQL epoch is 2000-01-01 00:00:00 UTC
 /// (https://en.wikipedia.org/wiki/Epoch_(computing)).
-/// This constant is the number of seconds between `1970-01-01 00:00:00 UTC` 
+/// This constant is the number of seconds between `1970-01-01 00:00:00 UTC`
 /// (Unix epoch) and `2000-01-01 00:00:00 UTC` (PostgreSQL epoch).
 const PG_EPOCH_SECONDS_FROM_UNIX_EPOCH: i64 = 946_684_800;
 

--- a/signer/src/storage/sqlx.rs
+++ b/signer/src/storage/sqlx.rs
@@ -26,8 +26,10 @@ use crate::storage::model::StacksTxId;
 
 use super::model::Timestamp;
 
-/// Seconds between 1970-01-01 00:00:00 UTC (Unix epoch)
-/// and 2000-01-01 00:00:00 UTC (PostgreSQL epoch for TIMESTAMPTZ).
+/// The PostgreSQL epoch is 2000-01-01 00:00:00 UTC 
+/// (https://en.wikipedia.org/wiki/Epoch_(computing)).
+/// This constant is the number of seconds between `1970-01-01 00:00:00 UTC` 
+/// (Unix epoch) and `2000-01-01 00:00:00 UTC` (PostgreSQL epoch).
 const PG_EPOCH_SECONDS_FROM_UNIX_EPOCH: i64 = 946_684_800;
 
 /// Number of microseconds in a second (as an `i64`).

--- a/signer/src/storage/sqlx.rs
+++ b/signer/src/storage/sqlx.rs
@@ -36,6 +36,7 @@ const PG_EPOCH_SECONDS_FROM_UNIX_EPOCH: i64 = 946_684_800;
 const MICROS_PER_SECOND: i64 = 1_000_000;
 
 /// OID for PostgreSQL's TIMESTAMPTZ type.
+/// https://github.com/postgres/postgres/blob/5d6eac80cdce7aa7c5f4ec74208ddc1feea9eef3/src/include/catalog/pg_type.dat#L306
 const TIMESTAMPTZ_OID: Oid = Oid(1184);
 
 // For the [`ScriptPubKey`]

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -771,6 +771,22 @@ impl fake::Dummy<fake::Faker> for BitcoinPreSignAck {
         BitcoinPreSignAck {}
     }
 }
+
+impl fake::Dummy<fake::Faker> for model::Timestamp {
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        // The PostgreSQL epoch is 2000-01-01 00:00:00 UTC
+        const PG_UNIX_EPOCH: i64 = 946_684_800;
+        // Let's try to be somewhat realistic: 2050-01-01 00:00:00 UTC
+        const TIMESTAMP_MAX: i64 = 2_524_608_000;
+        // Generate a random timestamp between the PostgreSQL epoch and the maximum i64 value
+        // to avoid PG overflow.
+        let unix_timestamp: i64 = rng.gen_range(PG_UNIX_EPOCH..TIMESTAMP_MAX);
+        time::OffsetDateTime::from_unix_timestamp(unix_timestamp)
+            .expect("failed to create OffsetDateTime")
+            .into()
+    }
+}
+
 /// A struct to help with creating dummy values for testing
 pub struct Unit;
 

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -778,7 +778,7 @@ impl fake::Dummy<fake::Faker> for model::Timestamp {
         const PG_UNIX_EPOCH: i64 = 946_684_800;
         // Let's try to be somewhat realistic: 2050-01-01 00:00:00 UTC
         const TIMESTAMP_MAX: i64 = 2_524_608_000;
-        // Generate a random timestamp between the PostgreSQL epoch and the maximum i64 value
+        // Generate a random timestamp between the PostgreSQL epoch and TIMESTAMP_MAX (2050-01-01 00:00:00 UTC)
         // to avoid PG overflow.
         let unix_timestamp: i64 = rng.gen_range(PG_UNIX_EPOCH..TIMESTAMP_MAX);
         time::OffsetDateTime::from_unix_timestamp(unix_timestamp)

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5851,6 +5851,41 @@ async fn compute_withdrawn_total_gets_all_amounts_in_chain() {
     signer::testing::storage::drop_db(db).await;
 }
 
+#[tokio::test]
+async fn timestamps() {
+    let db = testing::storage::new_test_database().await;
+    let pool = db.pool();
+    let mut rng = get_rng();
+
+    #[derive(sqlx::FromRow, Debug, PartialEq)]
+    struct TimestampTest {
+        ts: model::Timestamp,
+    }
+
+    let timestamp: model::Timestamp = Faker.fake_with_rng(&mut rng);
+
+    sqlx::query("CREATE TABLE IF NOT EXISTS timestamp_test (ts TIMESTAMPTZ)")
+        .execute(pool)
+        .await
+        .unwrap();
+
+    sqlx::query("INSERT INTO timestamp_test (ts) VALUES ($1)")
+        .bind(timestamp)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    let fetched_ts: TimestampTest = sqlx::query_as("SELECT ts FROM timestamp_test WHERE ts = $1")
+        .bind(timestamp)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+
+    assert_eq!(fetched_ts.ts, timestamp);
+
+    testing::storage::drop_db(db).await;
+}
+
 /// Check that the query in `compute_withdrawn_total` returns the total
 /// amount of withdrawal amounts on the identified blockchain.
 ///

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -5864,23 +5864,27 @@ async fn timestamps() {
 
     let timestamp: model::Timestamp = Faker.fake_with_rng(&mut rng);
 
+    // Create a new table specifically for this test
     sqlx::query("CREATE TABLE IF NOT EXISTS timestamp_test (ts TIMESTAMPTZ)")
         .execute(pool)
         .await
         .unwrap();
 
+    // Attempt to insert a `Timestamp` into the table
     sqlx::query("INSERT INTO timestamp_test (ts) VALUES ($1)")
         .bind(timestamp)
         .execute(pool)
         .await
         .unwrap();
 
+    // Attempt to fetch the `Timestamp` back from the table
     let fetched_ts: TimestampTest = sqlx::query_as("SELECT ts FROM timestamp_test WHERE ts = $1")
         .bind(timestamp)
         .fetch_one(pool)
         .await
         .unwrap();
 
+    // Check that the fetched timestamp matches the original
     assert_eq!(fetched_ts.ts, timestamp);
 
     testing::storage::drop_db(db).await;


### PR DESCRIPTION
## Description

Adds a new `Timestamp` model which can be seamlessly used in `sqlx` queries against `TIMESTAMPZ` columns.

## Changes

- New `Timestamp` type and related `sqlx` implementations.
- `Dummy` implementation which generates timestamps valid for PostgreSQL
- Integration test to verify it works

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
