### PR TITLE
fix: `EMILY_API_KEY` name mismatch in docker

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -155,7 +155,7 @@ services:
       target: emily-cron
     restart: on-failure
     environment:
-      - API_KEY=testApiKey
+      - EMILY_API_KEY=testApiKey
       - EMILY_ENDPOINT=http://emily-server:3031
       - PRIVATE_EMILY_ENDPOINT=http://emily-server:3031
       - MEMPOOL_API_URL=http://mempool-web:8083/api

--- a/docker/sbtc/emily-cron/Dockerfile
+++ b/docker/sbtc/emily-cron/Dockerfile
@@ -20,7 +20,7 @@ RUN chmod +x /app/main.py
 RUN touch /var/log/cron.log
 
 # Environment variables
-ENV API_KEY=testApiKey
+ENV EMILY_API_KEY=testApiKey
 ENV EMILY_ENDPOINT=http://emily-server:3031
 ENV PRIVATE_EMILY_ENDPOINT=http://emily-server:3031
 ENV MEMPOOL_API_URL=https://mempool.space/api


### PR DESCRIPTION
## Description

While deploying and testing on private mainnet, we realized that the dockerfile was setting a wrong environment variable. It was working on devenv because of the default test api key.

https://github.com/stacks-sbtc/sbtc/blob/d2cf286a38047f9c35e162233bd29b2d7cbe926b/emily_cron/app/settings.py#L4

## Changes
- `API_KEY` -> `EMILY_API_KEY`

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
