### PR TITLE
[feat]: send RBF status from Emily-cron to Emily

### DIFF
--- a/emily_cron/app/models/deposit.py
+++ b/emily_cron/app/models/deposit.py
@@ -14,6 +14,7 @@ class RequestStatus(Enum):
     CONFIRMED = "confirmed"
     FAILED = "failed"
     REPROCESSING = "reprocessing"
+    RBF = "rbf"
 
 
 @dataclass
@@ -154,3 +155,4 @@ class DepositUpdate:
     status: str
     status_message: str
     fulfillment: Optional[Fulfillment] = None
+    replaced_by_txid: Optional[str] = None

--- a/emily_cron/app/services/deposit_processor.py
+++ b/emily_cron/app/services/deposit_processor.py
@@ -97,8 +97,9 @@ class DepositProcessor:
                     DepositUpdate(
                         bitcoin_txid=tx.bitcoin_txid,
                         bitcoin_tx_output_index=tx.bitcoin_tx_output_index,
-                        status=RequestStatus.FAILED.value,
+                        status=RequestStatus.RBF.value,
                         status_message=f"Replaced by confirmed tx {confirmed_txid_in_group}",
+                        replaced_by_txid=confirmed_txid_in_group,
                     )
                 )
 

--- a/emily_cron/test/test_deposit_processor.py
+++ b/emily_cron/test/test_deposit_processor.py
@@ -488,6 +488,8 @@ class TestDepositProcessorWithRbf(TestDepositProcessorBase):
                     self.assertTrue("Locktime expired" in update.status_message)
                 elif update.bitcoin_txid == "rbf_original_tx":
                     self.assertTrue("Replaced by confirmed tx" in update.status_message)
+                    self.assertEqual(update.status, RequestStatus.RBF.value)
+                    self.assertEqual(update.replaced_by_txid, "rbf_replacement_tx")
                 elif update.bitcoin_txid == "long_pending_tx":
                     self.assertTrue(
                         f"Pending for too long ({settings.MAX_UNCONFIRMED_TIME} seconds)"

--- a/emily_cron/test/test_mempool_api_helpers.py
+++ b/emily_cron/test/test_mempool_api_helpers.py
@@ -145,7 +145,8 @@ class TestRbfProcessor(unittest.TestCase):
         self.assertIn("tx2", txids)
 
         for update in updates:
-            self.assertEqual(update.status, RequestStatus.FAILED.value)
+            self.assertEqual(update.status, RequestStatus.RBF.value)
+            self.assertEqual(update.replaced_by_txid, "tx3")
             self.assertTrue("Replaced by confirmed tx" in update.status_message)
             self.assertTrue("tx3" in update.status_message)
 


### PR DESCRIPTION
## Description

Closes: #1685


## Changes

- now Emily cron send rbf status for rbf transactions and provide `replaced_by_tx` field

## Testing Information

- Updated test to check `replaced_by_tx` field and to expect new status.

## Checklist:

- [x] I have performed a self-review of my code

