### PR TITLE
P2P Metric

### DIFF
--- a/docker/observability/vector.toml
+++ b/docker/observability/vector.toml
@@ -18,6 +18,7 @@ endpoints = [
     "http://sbtc-signer-2:9182",
     "http://sbtc-signer-3:9183",
 ]
+instance_tag = "signer"
 
 ## App Metric Sinks
 

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -50,8 +50,8 @@ pub enum Metrics {
     /// The amount of time, in seconds for running bitcoin or stacks
     /// validation.
     ValidationDurationSeconds,
-    /// The number of peers connected in the libp2p network.
-    PeersConnectedTotal,
+    /// The number of peers connected in the p2p network.
+    PeersConnected,
 }
 
 impl From<Metrics> for metrics::KeyName {
@@ -79,12 +79,12 @@ impl Metrics {
 
     /// Increment the gauge for the number of connected peers
     pub fn increment_peers_connected_total() {
-        metrics::gauge!(Metrics::PeersConnectedTotal).increment(1.0);
+        metrics::gauge!(Metrics::PeersConnected).increment(1.0);
     }
 
     /// Decrement the gauge for the number of connected peers
     pub fn decrement_peers_connected_total() {
-        metrics::gauge!(Metrics::PeersConnectedTotal).decrement(1.0);
+        metrics::gauge!(Metrics::PeersConnected).decrement(1.0);
     }
 
     /// Increment number of presign requests that were processed noting

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -73,6 +73,16 @@ impl Metrics {
         )
         .increment(1);
     }
+
+    /// Increment the gauge for the number of connected peers
+    pub fn increment_peers_connected_total() {
+        metrics::gauge!(Metrics::PeersConnectedTotal).increment(1.0);
+    }
+
+    /// Decrement the gauge for the number of connected peers
+    pub fn decrement_peers_connected_total() {
+        metrics::gauge!(Metrics::PeersConnectedTotal).decrement(1.0);
+    }
 }
 
 /// Label for bitcoin blockchain based metrics

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -47,6 +47,8 @@ pub enum Metrics {
     /// The amount of time, in seconds for running bitcoin or stacks
     /// validation.
     ValidationDurationSeconds,
+    /// The number of peers connected in the libp2p network.
+    PeersConnectedTotal,
 }
 
 impl From<Metrics> for metrics::KeyName {

--- a/signer/src/network/libp2p/bootstrap.rs
+++ b/signer/src/network/libp2p/bootstrap.rs
@@ -16,6 +16,7 @@ use libp2p::{
 };
 
 use super::MultiaddrExt;
+use crate::metrics::Metrics;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -221,7 +222,7 @@ impl Behavior {
 
         // Only increment the gauge if this is a new peer
         if is_new_peer {
-            metrics::gauge!(crate::metrics::Metrics::PeersConnectedTotal).increment(1.0);
+            Metrics::increment_peers_connected_total();
         }
         Some(peer_info)
     }
@@ -249,7 +250,7 @@ impl Behavior {
         // connected peers map and return the peer info record.
         if remove_peer {
             // Decrement the gauge for connected peers
-            metrics::gauge!(crate::metrics::Metrics::PeersConnectedTotal).decrement(1.0);
+            Metrics::decrement_peers_connected_total();
             return self.connected_peers.remove(&peer_id);
         }
 

--- a/signer/src/network/libp2p/bootstrap.rs
+++ b/signer/src/network/libp2p/bootstrap.rs
@@ -1,6 +1,5 @@
 //! LibP2P behavior for bootstrapping the node against the network using
 //! the known seed addresses.
-use crate::metrics::Metrics;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     task::Poll,

--- a/signer/src/network/libp2p/bootstrap.rs
+++ b/signer/src/network/libp2p/bootstrap.rs
@@ -1,6 +1,6 @@
 //! LibP2P behavior for bootstrapping the node against the network using
 //! the known seed addresses.
-
+use crate::metrics::Metrics;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
     task::Poll,
@@ -200,6 +200,9 @@ impl Behavior {
         // Determine if this is one of our seed addresses.
         let is_seed_addr = self.config.seed_addresses.iter().any(|seed| seed == &addr);
 
+        // Check if this is a new peer (not already in connected_peers)
+        let is_new_peer = !self.connected_peers.contains_key(&peer_id);
+
         // Get or create the peer info record for the connected peer.
         let peer_info = self
             .connected_peers
@@ -217,6 +220,10 @@ impl Behavior {
         // Update the peer info record with the connection and address.
         peer_info.connections.insert(connection_id, addr);
 
+        // Only increment the gauge if this is a new peer
+        if is_new_peer {
+            metrics::gauge!(crate::metrics::Metrics::PeersConnectedTotal).increment(1.0);
+        }
         Some(peer_info)
     }
 
@@ -242,6 +249,8 @@ impl Behavior {
         // If the peer has no remaining connections, we remove the peer from the
         // connected peers map and return the peer info record.
         if remove_peer {
+            // Decrement the gauge for connected peers
+            metrics::gauge!(crate::metrics::Metrics::PeersConnectedTotal).decrement(1.0);
             return self.connected_peers.remove(&peer_id);
         }
 


### PR DESCRIPTION
## Description
This is a PR that adds P2P/networking metrics to Grafana. Currently in drafts, this PR has only one metric (total peers connected) so please feel free to suggest more relevant metrics to add.

Closes: #1131 

## Changes
Adds a new metric enum to Metrics.rs & updates the 'peer_connected' & 'peer_disconnected' functions to fire the new 'Peers Connected Total' metric.

## Testing Information
N/a

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
