### PR TITLE
fix: clear sources in Dockerfile before the COPY

### DIFF
--- a/docker/sbtc/Dockerfile
+++ b/docker/sbtc/Dockerfile
@@ -28,6 +28,11 @@ RUN make install-pnpm && make build
 
 # Build the codebase from the local sources.
 # -------------------------------------------
+# We first remove the existing sources so that the there is no conflict
+# when building from the sources copied over.
+RUN find sbtc signer emily emily_sidecar emily_cron blocklist-client \
+    -mindepth 1 -maxdepth 1 \
+    -exec rm -rf {} +
 COPY . /code/sbtc/
 RUN make install-pnpm && make build
 


### PR DESCRIPTION
## Description

This is a lingering "bug" that only strikes when building a docker image locally where the local branch has conflicting changes with what is on main in a particular way.

## Changes

* Clear the sources downloaded from main before copying over our local changes.

## Testing Information

I tested this out on the `feat/sql-transactions` branch by making a conflicting change there (the one mentioned in https://github.com/stacks-sbtc/sbtc/pull/1673#discussion_r2115350409, where I rename a directory), and I was able to get it to continue past where it failed before (I didn't wait for the full build because life is short... but I should).

## Checklist:

- [x] I have performed a self-review of my code
