### PR TITLE
fix: skip DKG if latest shares are unverified

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2552,6 +2552,15 @@ pub async fn should_coordinate_dkg(
     let storage = context.get_storage();
     let config = context.config();
 
+    // If the latest shares are unverified, we want to prioritize verifying them
+    // instead of doing new DKG rounds. If we fail to do so they will eventually
+    // be marked as failed, and we will resume DKG-ing.
+    let latest_dkg_shares = storage.get_latest_encrypted_dkg_shares().await?;
+    if latest_dkg_shares.map(|s| s.dkg_shares_status) == Some(model::DkgSharesStatus::Unverified) {
+        tracing::debug!("latest shares are unverified; skipping DKG");
+        return Ok(false);
+    }
+
     // Trigger dkg if signatures_required has changed
     if context.state().current_signatures_required() != config.signer.bootstrap_signatures_required
     {


### PR DESCRIPTION
## Description

Currently if we need to DKG because of config changes we will keep doing DKGs until we get a confirmed rotate key tx. But if we don't manage to DKG + verify + rotate key submission in the same bitcoin tenure, we will "discard" the previous progress and just start a new round.

## Changes

Prevent DKG if latest shares are unverified. 

## Testing Information

## Checklist:

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
