### PR TITLE
chore: Split deposit and withdrawal status on Emily

### DIFF
--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -8,8 +8,8 @@ use tracing::instrument;
 use warp::http::StatusCode;
 use warp::reply::{Reply, json, with_status};
 
-use crate::api::models::common::Status;
 use crate::api::models::common::requests::BasicPaginationQuery;
+use crate::api::models::common::{DepositStatus, WithdrawalStatus};
 use crate::api::models::deposit::responses::{
     DepositWithStatus, GetDepositsForTransactionResponse, UpdateDepositsResponse,
 };
@@ -24,12 +24,12 @@ use crate::api::models::{
 use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
-use crate::database::entries::StatusEntry;
 use crate::database::entries::chainstate::ApiStateEntry;
 use crate::database::entries::deposit::{
     DepositEntry, DepositEntryKey, DepositEvent, DepositParametersEntry,
     ValidatedUpdateDepositsRequest,
 };
+use crate::database::entries::{DepositStatusEntry, WithdrawalStatusEntry};
 
 /// Get deposit handler.
 #[utoipa::path(
@@ -376,12 +376,12 @@ pub async fn create_deposit(
                 lock_time: deposit_info.lock_time.to_consensus_u32(),
             },
             history: vec![DepositEvent {
-                status: StatusEntry::Pending,
+                status: DepositStatusEntry::Pending,
                 message: "Just received deposit".to_string(),
                 stacks_block_hash: stacks_block_hash.clone(),
                 stacks_block_height,
             }],
-            status: Status::Pending,
+            status: DepositStatus::Pending,
             last_update_block_hash: stacks_block_hash,
             last_update_height: stacks_block_height,
             amount: deposit_info.amount,

--- a/emily/handler/src/api/handlers/new_block.rs
+++ b/emily/handler/src/api/handlers/new_block.rs
@@ -16,7 +16,7 @@ use crate::api::handlers::deposit::update_deposits_sidecar;
 use crate::api::handlers::withdrawal::{create_withdrawal, update_withdrawals_sidecar};
 use crate::api::models::chainstate::Chainstate;
 use crate::api::models::common::Fulfillment;
-use crate::api::models::common::Status;
+use crate::api::models::common::{DepositStatus, WithdrawalStatus};
 use crate::api::models::deposit::requests::{DepositUpdate, UpdateDepositsRequestBody};
 use crate::api::models::new_block::NewBlockEventRaw;
 use crate::api::models::withdrawal::WithdrawalParameters;
@@ -266,7 +266,7 @@ async fn handle_completed_deposit(
     Ok(DepositUpdate {
         bitcoin_tx_output_index: event.outpoint.vout,
         bitcoin_txid: event.outpoint.txid.to_string(),
-        status: Status::Confirmed,
+        status: DepositStatus::Confirmed,
         fulfillment: Some(Fulfillment {
             bitcoin_block_hash: event.sweep_block_hash.to_string(),
             bitcoin_block_height: event.sweep_block_height,
@@ -296,7 +296,7 @@ fn handle_withdrawal_accept(event: WithdrawalAcceptEvent) -> WithdrawalUpdate {
 
     WithdrawalUpdate {
         request_id: event.request_id,
-        status: Status::Confirmed,
+        status: WithdrawalStatus::Confirmed,
         fulfillment: Some(Fulfillment {
             bitcoin_block_hash: event.sweep_block_hash.to_string(),
             bitcoin_block_height: event.sweep_block_height,
@@ -356,7 +356,7 @@ fn handle_withdrawal_reject(event: WithdrawalRejectEvent) -> WithdrawalUpdate {
     WithdrawalUpdate {
         fulfillment: None,
         request_id: event.request_id,
-        status: Status::Failed,
+        status: WithdrawalStatus::Failed,
         status_message: "Rejected".to_string(),
     }
 }
@@ -418,7 +418,7 @@ mod test {
         // Expected struct to be added to the rejected_withdrawals vector
         let expectation = WithdrawalUpdate {
             request_id: event.request_id,
-            status: Status::Failed,
+            status: WithdrawalStatus::Failed,
             fulfillment: None,
             status_message: "Rejected".to_string(),
         };
@@ -445,7 +445,7 @@ mod test {
 
         let expectation = WithdrawalUpdate {
             request_id: event.request_id,
-            status: Status::Confirmed,
+            status: WithdrawalStatus::Confirmed,
             fulfillment: Some(Fulfillment {
                 bitcoin_block_hash: event.sweep_block_hash.to_string(),
                 bitcoin_block_height: event.sweep_block_height,

--- a/emily/handler/src/api/handlers/withdrawal.rs
+++ b/emily/handler/src/api/handlers/withdrawal.rs
@@ -2,8 +2,8 @@
 use tracing::{debug, instrument};
 use warp::reply::{Reply, json, with_status};
 
-use crate::api::models::common::Status;
 use crate::api::models::common::requests::BasicPaginationQuery;
+use crate::api::models::common::{DepositStatus, WithdrawalStatus};
 use crate::api::models::withdrawal::responses::WithdrawalWithStatus;
 use crate::api::models::withdrawal::{Withdrawal, WithdrawalInfo};
 use crate::api::models::withdrawal::{
@@ -13,12 +13,12 @@ use crate::api::models::withdrawal::{
 use crate::common::error::Error;
 use crate::context::EmilyContext;
 use crate::database::accessors;
-use crate::database::entries::StatusEntry;
 use crate::database::entries::chainstate::ApiStateEntry;
 use crate::database::entries::withdrawal::{
     ValidatedUpdateWithdrawalRequest, WithdrawalEntry, WithdrawalEntryKey, WithdrawalEvent,
     WithdrawalParametersEntry,
 };
+use crate::database::entries::{DepositStatusEntry, WithdrawalStatusEntry};
 use warp::http::StatusCode;
 
 /// Get withdrawal handler.
@@ -261,7 +261,7 @@ pub async fn create_withdrawal(
             txid,
         } = body;
 
-        let status = Status::Pending;
+        let status = WithdrawalStatus::Pending;
 
         // Make table entry.
         let withdrawal_entry: WithdrawalEntry = WithdrawalEntry {
@@ -275,7 +275,7 @@ pub async fn create_withdrawal(
             amount,
             parameters: WithdrawalParametersEntry { max_fee: parameters.max_fee },
             history: vec![WithdrawalEvent {
-                status: StatusEntry::Pending,
+                status: WithdrawalStatusEntry::Pending,
                 message: "Just received withdrawal".to_string(),
                 stacks_block_hash: stacks_block_hash.clone(),
                 stacks_block_height,

--- a/emily/handler/src/api/models/common/mod.rs
+++ b/emily/handler/src/api/models/common/mod.rs
@@ -8,7 +8,7 @@ pub mod requests;
 
 // Common Types ----------------------------------------------------------------
 
-/// The status of the in-flight sBTC operation.
+/// The status of the in-flight sBTC deposit.
 #[derive(
     Clone,
     Default,
@@ -24,7 +24,7 @@ pub mod requests;
     ToResponse,
 )]
 #[serde(rename_all = "lowercase")]
-pub enum Status {
+pub enum DepositStatus {
     /// Transaction hasn't yet been addressed by the sBTC Signers.
     #[default]
     Pending,
@@ -50,6 +50,48 @@ pub enum Status {
     Failed,
     /// Transaction was replaced by another transaction via RBF.
     RBF,
+}
+
+/// The status of the in-flight sBTC withdrawal.
+#[derive(
+    Clone,
+    Default,
+    Debug,
+    Eq,
+    PartialEq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    ToSchema,
+    ToResponse,
+)]
+#[serde(rename_all = "lowercase")]
+pub enum WithdrawalStatus {
+    /// Transaction hasn't yet been addressed by the sBTC Signers.
+    #[default]
+    Pending,
+    /// Transaction was dealt with by the signers at one point but is now being
+    /// reprocessed. The Signers are aware of the operation request.
+    Reprocessing,
+    /// Transaction has been seen and accepted by the sBTC Signers, but is not
+    /// yet included in any on chain artifact. The transaction can still fail
+    /// at this point if the Signers fail to include the transaction in an on
+    /// chain artifact.
+    ///
+    /// For example, a deposit or withdrawal that has specified too low of a
+    /// BTC fee may fail after being accepted.
+    Accepted,
+    /// The artifacts that fulfill the operation have been observed in a valid fork of
+    /// both the Stacks blockchain and the Bitcoin blockchain by at least one signer.
+    ///
+    /// Note that if the signers detect a conflicting chainstate in which the operation
+    /// is not confirmed this status will be reverted to either ACCEPTED or REEVALUATING
+    /// depending on whether the conflicting chainstate calls the acceptance into question.
+    Confirmed,
+    /// The operation was not fulfilled.
+    Failed,
 }
 
 /// Data about the fulfillment of an sBTC Operation.

--- a/emily/handler/src/api/models/deposit/mod.rs
+++ b/emily/handler/src/api/models/deposit/mod.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::{ToResponse, ToSchema};
 
-use crate::api::models::common::{Fulfillment, Status};
+use crate::api::models::common::{DepositStatus, Fulfillment, WithdrawalStatus};
 
 /// Requests.
 pub mod requests;
@@ -44,7 +44,7 @@ pub struct Deposit {
     /// then this hash is the Stacks block hash that contains that artifact.
     pub last_update_block_hash: String,
     /// The status of the deposit.
-    pub status: Status,
+    pub status: DepositStatus,
     /// The status message of the deposit.
     pub status_message: String,
     /// Deposit parameters
@@ -119,7 +119,7 @@ pub struct DepositInfo {
     /// then this hash is the Stacks block hash that contains that artifact.
     pub last_update_block_hash: String,
     /// The status of the deposit.
-    pub status: Status,
+    pub status: DepositStatus,
     /// Raw reclaim script binary in hex.
     pub reclaim_script: String,
     /// Raw deposit script binary in hex.

--- a/emily/handler/src/api/models/deposit/requests.rs
+++ b/emily/handler/src/api/models/deposit/requests.rs
@@ -12,12 +12,12 @@ use utoipa::ToSchema;
 use sbtc::deposits::{CreateDepositRequest, DepositInfo};
 
 use crate::api::models::chainstate::Chainstate;
-use crate::api::models::common::{Fulfillment, Status};
+use crate::api::models::common::{DepositStatus, Fulfillment, WithdrawalStatus};
 use crate::common::error::{self, Error, ValidationError};
-use crate::database::entries::StatusEntry;
 use crate::database::entries::deposit::{
     DepositEntryKey, DepositEvent, ValidatedDepositUpdate, ValidatedUpdateDepositsRequest,
 };
+use crate::database::entries::{DepositStatusEntry, WithdrawalStatusEntry};
 
 /// Query structure for the GetDepositsQuery struct.
 #[derive(Clone, Default, Debug, PartialEq, Hash, Serialize, Deserialize, ToSchema)]
@@ -36,7 +36,7 @@ pub struct GetDepositsForTransactionQuery {
 #[serde(rename_all = "camelCase")]
 pub struct GetDepositsQuery {
     /// Operation status.
-    pub status: Status,
+    pub status: DepositStatus,
     /// Next token for the search.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub next_token: Option<String>,
@@ -124,7 +124,7 @@ pub struct DepositUpdate {
     /// Output index on the bitcoin transaction associated with this specific deposit.
     pub bitcoin_tx_output_index: u32,
     /// The status of the deposit.
-    pub status: Status,
+    pub status: DepositStatus,
     /// The status message of the deposit.
     pub status_message: String,
     /// Details about the on chain artifacts that fulfilled the deposit.
@@ -151,7 +151,7 @@ impl DepositUpdate {
             bitcoin_txid: self.bitcoin_txid.clone(),
         };
         // Only RBF transactions can have a replaced_by_tx.
-        if self.status != Status::RBF && self.replaced_by_tx.is_some() {
+        if self.status != DepositStatus::RBF && self.replaced_by_tx.is_some() {
             return Err(error::ValidationError::InvalidReplacedByTxStatus(
                 self.status,
                 self.bitcoin_txid,
@@ -159,21 +159,21 @@ impl DepositUpdate {
             ));
         }
         // Make status entry.
-        let status_entry: StatusEntry = match self.status {
-            Status::Confirmed => {
+        let status_entry: DepositStatusEntry = match self.status {
+            DepositStatus::Confirmed => {
                 let fulfillment =
                     self.fulfillment
                         .ok_or(ValidationError::DepositMissingFulfillment(
                             key.bitcoin_txid.clone(),
                             key.bitcoin_tx_output_index,
                         ))?;
-                StatusEntry::Confirmed(fulfillment)
+                DepositStatusEntry::Confirmed(fulfillment)
             }
-            Status::Accepted => StatusEntry::Accepted,
-            Status::Pending => StatusEntry::Pending,
-            Status::Reprocessing => StatusEntry::Reprocessing,
-            Status::Failed => StatusEntry::Failed,
-            Status::RBF => StatusEntry::RBF(self.replaced_by_tx.ok_or(
+            DepositStatus::Accepted => DepositStatusEntry::Accepted,
+            DepositStatus::Pending => DepositStatusEntry::Pending,
+            DepositStatus::Reprocessing => DepositStatusEntry::Reprocessing,
+            DepositStatus::Failed => DepositStatusEntry::Failed,
+            DepositStatus::RBF => DepositStatusEntry::RBF(self.replaced_by_tx.ok_or(
                 ValidationError::DepositMissingReplacementTx(
                     self.bitcoin_txid,
                     self.bitcoin_tx_output_index,

--- a/emily/handler/src/api/models/withdrawal/mod.rs
+++ b/emily/handler/src/api/models/withdrawal/mod.rs
@@ -3,7 +3,7 @@
 use serde::{Deserialize, Serialize};
 use utoipa::{ToResponse, ToSchema};
 
-use crate::api::models::common::{Fulfillment, Status};
+use crate::api::models::common::{DepositStatus, Fulfillment, WithdrawalStatus};
 
 /// Requests.
 pub mod requests;
@@ -48,7 +48,7 @@ pub struct Withdrawal {
     /// then this hash is the Stacks block hash that contains that artifact.
     pub last_update_block_hash: String,
     /// The status of the withdrawal.
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// The status message of the withdrawal.
     pub status_message: String,
     /// Withdrawal request parameters.
@@ -120,7 +120,7 @@ pub struct WithdrawalInfo {
     /// then this hash is the Stacks block hash that contains that artifact.
     pub last_update_block_hash: String,
     /// The status of the withdrawal.
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// The hex encoded txid of the stacks transaction that generated this event.
     pub txid: String,
 }

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -19,7 +19,10 @@ use utoipa::ToSchema;
 use warp::{reject::Reject, reply::Reply};
 
 use crate::{
-    api::models::{chainstate::Chainstate, common::Status},
+    api::models::{
+        chainstate::Chainstate,
+        common::{DepositStatus, WithdrawalStatus},
+    },
     database::entries::{
         chainstate::ChainstateEntry, deposit::DepositEntryKey, withdrawal::WithdrawalEntryKey,
     },
@@ -60,7 +63,7 @@ pub enum ValidationError {
     #[error(
         "deposit with replaced_by_tx is only valid if status is RBF, but got status {0:?} for txid: {1}, vout: {2}"
     )]
-    InvalidReplacedByTxStatus(Status, String, u32),
+    InvalidReplacedByTxStatus(DepositStatus, String, u32),
 
     /// In current implementation, withdrawals can't have RBF status. However, since we have same Status enum
     /// for both deposits and withdrawals, we need to handle this case.

--- a/emily/handler/src/database/entries/deposit.rs
+++ b/emily/handler/src/database/entries/deposit.rs
@@ -3,13 +3,13 @@
 use serde::{Deserialize, Serialize};
 
 use super::{
-    EntryTrait, KeyTrait, PrimaryIndex, PrimaryIndexTrait, SecondaryIndex, SecondaryIndexTrait,
-    StatusEntry, VersionedEntryTrait,
+    DepositStatusEntry, EntryTrait, KeyTrait, PrimaryIndex, PrimaryIndexTrait, SecondaryIndex,
+    SecondaryIndexTrait, VersionedEntryTrait, WithdrawalStatusEntry,
 };
 use crate::{
     api::models::{
         chainstate::Chainstate,
-        common::{Fulfillment, Status},
+        common::{DepositStatus, Fulfillment, WithdrawalStatus},
         deposit::{Deposit, DepositInfo, DepositParameters},
     },
     common::error::{Error, Inconsistency, ValidationError},
@@ -51,7 +51,7 @@ pub struct DepositEntry {
     pub parameters: DepositParametersEntry,
     /// The status of the deposit.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: DepositStatus,
     /// The raw reclaim script.
     pub reclaim_script: String,
     /// The raw deposit script.
@@ -182,7 +182,7 @@ impl DepositEntry {
         // latest update is the point at which the reorg happened.
         if self.history.is_empty() {
             self.history = vec![DepositEvent {
-                status: StatusEntry::Pending,
+                status: DepositStatusEntry::Pending,
                 message: "Reprocessing deposit status after reorg.".to_string(),
                 stacks_block_height: chainstate.stacks_block_height,
                 stacks_block_hash: chainstate.stacks_block_hash.clone(),
@@ -211,21 +211,21 @@ impl DepositEntry {
         // Get latest event.
         let latest_event: DepositEvent = self.latest_event()?.clone();
         // Calculate the new values.
-        let new_status: Status = (&latest_event.status).into();
+        let new_status: DepositStatus = (&latest_event.status).into();
         let new_last_update_height: u64 = latest_event.stacks_block_height;
 
         // Set variables.
-        if new_status == Status::Confirmed {
+        if new_status == DepositStatus::Confirmed {
             self.fulfillment = match &latest_event.status {
-                StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
+                DepositStatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
                 _ => None,
             };
         } else {
             self.fulfillment = None;
         }
-        if new_status == Status::RBF {
+        if new_status == DepositStatus::RBF {
             self.replaced_by_tx = match &latest_event.status {
-                StatusEntry::RBF(replaced_by_tx) => Some(replaced_by_tx.clone()),
+                DepositStatusEntry::RBF(replaced_by_tx) => Some(replaced_by_tx.clone()),
                 _ => None,
             };
         } else {
@@ -249,13 +249,13 @@ impl TryFrom<DepositEntry> for Deposit {
         // Extract data from the latest event.
         let latest_event = deposit_entry.latest_event()?;
         let status_message = latest_event.message.clone();
-        let status: Status = (&latest_event.status).into();
+        let status: DepositStatus = (&latest_event.status).into();
         let fulfillment = match &latest_event.status {
-            StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
+            DepositStatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
             _ => None,
         };
         let replaced_by_tx = match &latest_event.status {
-            StatusEntry::RBF(replaced_by_tx) => Some(replaced_by_tx.clone()),
+            DepositStatusEntry::RBF(replaced_by_tx) => Some(replaced_by_tx.clone()),
             _ => None,
         };
 
@@ -298,7 +298,7 @@ pub struct DepositParametersEntry {
 pub struct DepositEvent {
     /// Status code.
     #[serde(rename = "OpStatus")]
-    pub status: StatusEntry,
+    pub status: DepositStatusEntry,
     /// Status message.
     pub message: String,
     /// Stacks block height at the time of this update.
@@ -357,7 +357,7 @@ pub struct DepositInfoEntrySearchToken {
 pub struct DepositInfoEntryKey {
     /// The status of the deposit.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: DepositStatus,
     /// The most recent Stacks block height the API was aware of when the deposit was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
@@ -391,7 +391,7 @@ pub struct DepositInfoEntry {
 /// Implements the key trait for the deposit entry key.
 impl KeyTrait for DepositInfoEntryKey {
     /// The type of the partition key.
-    type PartitionKey = Status;
+    type PartitionKey = DepositStatus;
     /// the type of the sort key.
     type SortKey = u64;
     /// The table field name of the partition key.
@@ -479,7 +479,7 @@ pub struct DepositInfoByRecipientEntry {
     pub primary_index_key: DepositEntryKey,
     /// The status of the entry.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: DepositStatus,
     /// Amount of BTC being deposited in satoshis.
     pub amount: u64,
     /// The raw reclaim script.
@@ -582,7 +582,7 @@ pub struct DepositInfoByReclaimPubkeysEntry {
     pub primary_index_key: DepositEntryKey,
     /// The status of the entry.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: DepositStatus,
     /// The recipient of the deposit encoded in hex.
     pub recipient: String,
     /// Amount of BTC being deposited in satoshis.
@@ -725,14 +725,14 @@ mod tests {
     #[test]
     fn deposit_update_should_be_unnecessary_when_event_is_present() {
         let pending = DepositEvent {
-            status: StatusEntry::Pending,
+            status: DepositStatusEntry::Pending,
             message: "".to_string(),
             stacks_block_height: 0,
             stacks_block_hash: "".to_string(),
         };
 
         let accepted = DepositEvent {
-            status: StatusEntry::Accepted,
+            status: DepositStatusEntry::Accepted,
             message: "".to_string(),
             stacks_block_height: 1,
             stacks_block_hash: "".to_string(),
@@ -744,7 +744,7 @@ mod tests {
             recipient: "".to_string(),
             amount: 0,
             parameters: Default::default(),
-            status: Status::Pending,
+            status: DepositStatus::Pending,
             reclaim_script: "".to_string(),
             deposit_script: "".to_string(),
             last_update_height: 0,
@@ -766,14 +766,14 @@ mod tests {
     #[test]
     fn deposit_update_should_be_necessary_when_event_is_not_present() {
         let pending = DepositEvent {
-            status: StatusEntry::Pending,
+            status: DepositStatusEntry::Pending,
             message: "".to_string(),
             stacks_block_height: 0,
             stacks_block_hash: "".to_string(),
         };
 
         let accepted = DepositEvent {
-            status: StatusEntry::Accepted,
+            status: DepositStatusEntry::Accepted,
             message: "".to_string(),
             stacks_block_height: 1,
             stacks_block_hash: "".to_string(),
@@ -785,7 +785,7 @@ mod tests {
             recipient: "".to_string(),
             amount: 0,
             parameters: Default::default(),
-            status: Status::Pending,
+            status: DepositStatus::Pending,
             reclaim_script: "".to_string(),
             deposit_script: "".to_string(),
             last_update_height: 0,
@@ -804,27 +804,27 @@ mod tests {
         assert!(!update.is_unnecessary(&deposit));
     }
 
-    #[test_case(0, "hash0", 0, "hash0", StatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
-    #[test_case(5, "hash5", 4, "hash4", StatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
-    #[test_case(4, "hash4", 4, "hash4", StatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
-    #[test_case(4, "hash4-1", 2, "hash2", StatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
-    #[test_case(3, "hash3", 2, "hash2", StatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
+    #[test_case(0, "hash0", 0, "hash0", DepositStatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
+    #[test_case(5, "hash5", 4, "hash4", DepositStatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
+    #[test_case(4, "hash4", 4, "hash4", DepositStatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
+    #[test_case(4, "hash4-1", 2, "hash2", DepositStatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
+    #[test_case(3, "hash3", 2, "hash2", DepositStatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
     fn reorganizing_around_a_new_chainstate_results_in_valid_deposit(
         reorg_height: u64,
         reorg_hash: &str,
         expected_height: u64,
         expected_hash: &str,
-        expected_status: StatusEntry,
+        expected_status: DepositStatusEntry,
     ) {
         let pending = DepositEvent {
-            status: StatusEntry::Pending,
+            status: DepositStatusEntry::Pending,
             message: "initial test pending".to_string(),
             stacks_block_height: 2,
             stacks_block_hash: "hash2".to_string(),
         };
 
         let accepted = DepositEvent {
-            status: StatusEntry::Accepted,
+            status: DepositStatusEntry::Accepted,
             message: "accepted".to_string(),
             stacks_block_height: 4,
             stacks_block_hash: "hash4".to_string(),
@@ -832,7 +832,7 @@ mod tests {
 
         let fulfillment: Fulfillment = Default::default();
         let confirmed = DepositEvent {
-            status: StatusEntry::Confirmed(fulfillment.clone()),
+            status: DepositStatusEntry::Confirmed(fulfillment.clone()),
             message: "confirmed".to_string(),
             stacks_block_height: 6,
             stacks_block_hash: "hash6".to_string(),

--- a/emily/handler/src/database/entries/mod.rs
+++ b/emily/handler/src/database/entries/mod.rs
@@ -54,7 +54,7 @@ use serde::{Deserialize, Serialize};
 use serde_dynamo::Item;
 
 use crate::{
-    api::models::common::{Fulfillment, Status},
+    api::models::common::{DepositStatus, Fulfillment, WithdrawalStatus},
     common::error::Error,
     context::Settings,
 };
@@ -71,10 +71,10 @@ pub mod withdrawal;
 // Event structure
 // -----------------------------------------------------------------------------
 
-/// Status entry.
+/// Deposit Status entry.
 #[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "PascalCase")]
-pub enum StatusEntry {
+pub enum DepositStatusEntry {
     /// Transaction hasn't yet been addressed by the sBTC Signers.
     #[default]
     Pending,
@@ -103,15 +103,56 @@ pub enum StatusEntry {
     RBF(String),
 }
 
-impl From<&StatusEntry> for Status {
-    fn from(value: &StatusEntry) -> Self {
+/// Deposit Status entry.
+#[derive(Clone, Default, Debug, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "PascalCase")]
+pub enum WithdrawalStatusEntry {
+    /// Transaction hasn't yet been addressed by the sBTC Signers.
+    #[default]
+    Pending,
+    /// Transaction was dealt with by the signers at one point but is now being
+    /// reprocessed. The Signers are aware of the operation request.
+    Reprocessing,
+    /// Transaction has been seen and accepted by the sBTC Signers, but is not
+    /// yet included in any on chain artifact. The transaction can still fail
+    /// at this point if the Signers fail to include the transaction in an on
+    /// chain artifact.
+    ///
+    /// For example, a deposit or withdrawal that has specified too low of a
+    /// BTC fee may fail after being accepted.
+    Accepted,
+    /// The artifacts that fulfill the operation have been observed in a valid fork of
+    /// both the Stacks blockchain and the Bitcoin blockchain by at least one signer.
+    ///
+    /// Note that if the signers detect a conflicting chainstate in which the operation
+    /// is not confirmed this status will be reverted to either ACCEPTED or REEVALUATING
+    /// depending on whether the conflicting chainstate calls the acceptance into question.
+    Confirmed(Fulfillment),
+    /// The operation was not fulfilled.
+    Failed,
+}
+
+impl From<&DepositStatusEntry> for DepositStatus {
+    fn from(value: &DepositStatusEntry) -> Self {
         match value {
-            StatusEntry::Pending => Status::Pending,
-            StatusEntry::Reprocessing => Status::Reprocessing,
-            StatusEntry::Accepted => Status::Accepted,
-            StatusEntry::Confirmed(_) => Status::Confirmed,
-            StatusEntry::Failed => Status::Failed,
-            StatusEntry::RBF(_) => Status::RBF,
+            DepositStatusEntry::Pending => DepositStatus::Pending,
+            DepositStatusEntry::Reprocessing => DepositStatus::Reprocessing,
+            DepositStatusEntry::Accepted => DepositStatus::Accepted,
+            DepositStatusEntry::Confirmed(_) => DepositStatus::Confirmed,
+            DepositStatusEntry::Failed => DepositStatus::Failed,
+            DepositStatusEntry::RBF(_) => DepositStatus::RBF,
+        }
+    }
+}
+
+impl From<&WithdrawalStatusEntry> for WithdrawalStatus {
+    fn from(value: &WithdrawalStatusEntry) -> Self {
+        match value {
+            WithdrawalStatusEntry::Pending => WithdrawalStatus::Pending,
+            WithdrawalStatusEntry::Reprocessing => WithdrawalStatus::Reprocessing,
+            WithdrawalStatusEntry::Accepted => WithdrawalStatus::Accepted,
+            WithdrawalStatusEntry::Confirmed(_) => WithdrawalStatus::Confirmed,
+            WithdrawalStatusEntry::Failed => WithdrawalStatus::Failed,
         }
     }
 }

--- a/emily/handler/src/database/entries/withdrawal.rs
+++ b/emily/handler/src/database/entries/withdrawal.rs
@@ -5,15 +5,15 @@ use serde::{Deserialize, Serialize};
 use crate::{
     api::models::{
         chainstate::Chainstate,
-        common::Status,
+        common::{DepositStatus, WithdrawalStatus},
         withdrawal::{Withdrawal, WithdrawalInfo, WithdrawalParameters},
     },
     common::error::{Error, Inconsistency, ValidationError},
 };
 
 use super::{
-    EntryTrait, KeyTrait, PrimaryIndex, PrimaryIndexTrait, SecondaryIndex, SecondaryIndexTrait,
-    StatusEntry, VersionedEntryTrait,
+    DepositStatusEntry, EntryTrait, KeyTrait, PrimaryIndex, PrimaryIndexTrait, SecondaryIndex,
+    SecondaryIndexTrait, VersionedEntryTrait, WithdrawalStatusEntry,
 };
 
 // Withdrawal entry ---------------------------------------------------------------
@@ -56,7 +56,7 @@ pub struct WithdrawalEntry {
     pub parameters: WithdrawalParametersEntry,
     /// The status of the withdrawal.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// The most recent Stacks block height the API was aware of when the withdrawal was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
@@ -137,7 +137,7 @@ impl WithdrawalEntry {
         // latest update is the point at which the reorg happened.
         if self.history.is_empty() {
             self.history = vec![WithdrawalEvent {
-                status: StatusEntry::Pending,
+                status: WithdrawalStatusEntry::Pending,
                 message: "Reprocessing withdrawal status after reorg.".to_string(),
                 stacks_block_height: chainstate.stacks_block_height,
                 stacks_block_hash: chainstate.stacks_block_hash.clone(),
@@ -166,7 +166,7 @@ impl WithdrawalEntry {
         // Get latest event.
         let latest_event = self.latest_event()?.clone();
         // Calculate the new values.
-        let new_status: Status = (&latest_event.status).into();
+        let new_status: WithdrawalStatus = (&latest_event.status).into();
         let new_last_update_height: u64 = latest_event.stacks_block_height;
         // Set variables.
         self.status = new_status;
@@ -186,9 +186,9 @@ impl TryFrom<WithdrawalEntry> for Withdrawal {
         // Extract data from the latest event.
         let latest_event = withdrawal_entry.latest_event()?;
         let status_message = latest_event.message.clone();
-        let status: Status = (&latest_event.status).into();
+        let status: WithdrawalStatus = (&latest_event.status).into();
         let fulfillment = match &latest_event.status {
-            StatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
+            WithdrawalStatusEntry::Confirmed(fulfillment) => Some(fulfillment.clone()),
             _ => None,
         };
 
@@ -228,7 +228,7 @@ pub struct WithdrawalParametersEntry {
 pub struct WithdrawalEvent {
     /// Status code.
     #[serde(rename = "OpStatus")]
-    pub status: StatusEntry,
+    pub status: WithdrawalStatusEntry,
     /// Status message.
     pub message: String,
     /// Stacks block height at the time of this update.
@@ -327,7 +327,7 @@ pub struct WithdrawalInfoEntrySearchToken {
 pub struct WithdrawalInfoEntryKey {
     /// The status of the withdrawal.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// The most recent Stacks block height the API was aware of when the withdrawal was last
     /// updated. If the most recent update is tied to an artifact on the Stacks blockchain
     /// then this height is the Stacks block height that contains that artifact.
@@ -363,7 +363,7 @@ pub struct WithdrawalInfoEntry {
 /// Implements the key trait for the withdrawal info entry key.
 impl KeyTrait for WithdrawalInfoEntryKey {
     /// The type of the partition key.
-    type PartitionKey = Status;
+    type PartitionKey = WithdrawalStatus;
     /// the type of the sort key.
     type SortKey = u64;
     /// The table field name of the partition key.
@@ -452,7 +452,7 @@ pub struct WithdrawalInfoByRecipientEntry {
     pub stacks_block_height: u64,
     /// The status of the entry.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// The sender's Stacks principal.
     pub sender: String,
     /// Amount of BTC being withdrawn in satoshis.
@@ -558,7 +558,7 @@ pub struct WithdrawalInfoBySenderEntry {
     pub stacks_block_height: u64,
     /// The status of the entry.
     #[serde(rename = "OpStatus")]
-    pub status: Status,
+    pub status: WithdrawalStatus,
     /// Recipient's Bitcoin hex-encoded scriptPubKey.
     pub recipient: String,
     /// Amount of BTC being withdrawn in satoshis.
@@ -699,9 +699,9 @@ impl WithdrawalUpdatePackage {
 mod tests {
     use crate::api::models::chainstate::Chainstate;
     use crate::api::models::common::Fulfillment;
-    use crate::database::entries::StatusEntry;
+    use crate::database::entries::{DepositStatusEntry, WithdrawalStatusEntry};
     use crate::{
-        api::models::common::Status,
+        api::models::common::{DepositStatus, WithdrawalStatus},
         database::entries::withdrawal::{
             ValidatedWithdrawalUpdate, WithdrawalEntry, WithdrawalEntryKey, WithdrawalEvent,
             WithdrawalParametersEntry,
@@ -713,14 +713,14 @@ mod tests {
     fn withdrawal_update_should_be_unnecessary_when_event_is_present() {
         // Arrange
         let pending = WithdrawalEvent {
-            status: StatusEntry::Pending,
+            status: WithdrawalStatusEntry::Pending,
             message: "message".to_string(),
             stacks_block_height: 1,
             stacks_block_hash: "hash".to_string(),
         };
 
         let failed = WithdrawalEvent {
-            status: StatusEntry::Failed,
+            status: WithdrawalStatusEntry::Failed,
             message: "message".to_string(),
             stacks_block_height: 2,
             stacks_block_hash: "hash".to_string(),
@@ -737,7 +737,7 @@ mod tests {
             sender: "sender".to_string(),
             amount: 1,
             parameters: WithdrawalParametersEntry { max_fee: 1 },
-            status: Status::Pending,
+            status: WithdrawalStatus::Pending,
             last_update_height: 1,
             last_update_block_hash: "hash".to_string(),
             history: vec![pending, failed.clone()],
@@ -757,14 +757,14 @@ mod tests {
     fn withdrawal_update_should_be_necessary_when_event_is_not_present() {
         // Arrange
         let pending = WithdrawalEvent {
-            status: StatusEntry::Pending,
+            status: WithdrawalStatusEntry::Pending,
             message: "message".to_string(),
             stacks_block_height: 1,
             stacks_block_hash: "hash".to_string(),
         };
 
         let failed = WithdrawalEvent {
-            status: StatusEntry::Failed,
+            status: WithdrawalStatusEntry::Failed,
             message: "message".to_string(),
             stacks_block_height: 2,
             stacks_block_hash: "hash".to_string(),
@@ -781,7 +781,7 @@ mod tests {
             sender: "sender".to_string(),
             amount: 1,
             parameters: WithdrawalParametersEntry { max_fee: 1 },
-            status: Status::Pending,
+            status: WithdrawalStatus::Pending,
             last_update_height: 1,
             last_update_block_hash: "hash".to_string(),
             history: vec![pending.clone()],
@@ -797,27 +797,27 @@ mod tests {
         assert!(!is_unnecessary);
     }
 
-    #[test_case(0, "hash0", 0, "hash0", StatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
-    #[test_case(5, "hash5", 4, "hash4", StatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
-    #[test_case(4, "hash4", 4, "hash4", StatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
-    #[test_case(4, "hash4-1", 2, "hash2", StatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
-    #[test_case(3, "hash3", 2, "hash2", StatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
+    #[test_case(0, "hash0", 0, "hash0", WithdrawalStatusEntry::Pending; "reorg around genesis sets status to pending at genesis")]
+    #[test_case(5, "hash5", 4, "hash4", WithdrawalStatusEntry::Accepted; "reorg goes to earliest canonical event 1")]
+    #[test_case(4, "hash4", 4, "hash4", WithdrawalStatusEntry::Accepted; "reorg setting a height consistent with an event keeps it")]
+    #[test_case(4, "hash4-1", 2, "hash2", WithdrawalStatusEntry::Pending; "reorg setting a height inconsistent with an event removes it")]
+    #[test_case(3, "hash3", 2, "hash2", WithdrawalStatusEntry::Pending; "reorg  goes to earliest canonical event 2")]
     fn reorganizing_around_a_new_chainstate_results_in_valid_withdrawal(
         reorg_height: u64,
         reorg_hash: &str,
         expected_height: u64,
         expected_hash: &str,
-        expected_status: StatusEntry,
+        expected_status: WithdrawalStatusEntry,
     ) {
         let pending = WithdrawalEvent {
-            status: StatusEntry::Pending,
+            status: WithdrawalStatusEntry::Pending,
             message: "initial test pending".to_string(),
             stacks_block_height: 2,
             stacks_block_hash: "hash2".to_string(),
         };
 
         let accepted = WithdrawalEvent {
-            status: StatusEntry::Accepted,
+            status: WithdrawalStatusEntry::Accepted,
             message: "accepted".to_string(),
             stacks_block_height: 4,
             stacks_block_hash: "hash4".to_string(),
@@ -825,7 +825,7 @@ mod tests {
 
         let fulfillment: Fulfillment = Default::default();
         let confirmed = WithdrawalEvent {
-            status: StatusEntry::Confirmed(fulfillment.clone()),
+            status: WithdrawalStatusEntry::Confirmed(fulfillment.clone()),
             message: "confirmed".to_string(),
             stacks_block_height: 6,
             stacks_block_hash: "hash6".to_string(),
@@ -842,7 +842,7 @@ mod tests {
             sender: "test-sender".to_string(),
             amount: 1,
             parameters: WithdrawalParametersEntry { max_fee: 1 },
-            status: Status::Confirmed,
+            status: WithdrawalStatus::Confirmed,
             last_update_height: 6,
             last_update_block_hash: "hash6".to_string(),
             history: vec![pending.clone(), accepted.clone(), confirmed.clone()],


### PR DESCRIPTION
## Description

Closes: #1693

## Changes

Now Emily have two structs `DepositStatus` and `WithdrawalStatus` instead of old `Status` (same for `StatusEntry`). As for now they differ because deposits can have `RBF` status while withdrawals can't, and this split protect us from invalid state (withdrawal with `RBF` status) on compiler level.

## Testing Information

Refactoring. No new testing needed

## Checklist:

- [x] I have performed a self-review of my code

