### PR TITLE
chore: introduce make fix command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,12 @@ lint:
 	pnpm --recursive run lint
 
 fix:
-	cargo $(CARGO_FLAGS) fmt --all
-	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
+	cargo fmt --all
+	cargo clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
+
+fix-uncommited:
+	cargo fmt --all
+	cargo clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty -- -D warnings
 
 format:
 	cargo $(CARGO_FLAGS) fmt

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ lint:
 	pnpm --recursive run lint
 
 fix:
-	cargo fmt --all
-	cargo clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
+	cargo $(CARGO_FLAGS) fmt --all
+	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
 
 fix-uncommitted:
 	cargo fmt --all

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,8 @@ fix:
 	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
 
 fix-uncommitted:
-	cargo fmt --all
-	cargo clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty -- -D warnings
+	cargo $(CARGO_FLAGS) fmt --all
+	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty -- -D warnings
 
 format:
 	cargo $(CARGO_FLAGS) fmt

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fix:
 	cargo fmt --all
 	cargo clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
 
-fix-uncommited:
+fix-uncommitted:
 	cargo fmt --all
 	cargo clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty -- -D warnings
 

--- a/Makefile
+++ b/Makefile
@@ -40,18 +40,22 @@ test:
 test-build:
 	cargo $(CARGO_FLAGS) test build --features "testing"  $(CARGO_EXCLUDES) --no-run --locked ${CARGO_BUILD_ARGS}
 
+CARGO_FMT = cargo $(CARGO_FLAGS) fmt --all
+CARGO_CLIPPY_BASE = cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps
+CLIPPY_FLAGS = -D warnings
+
 lint:
-	cargo $(CARGO_FLAGS) fmt --all -- --check
-	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+	$(CARGO_FMT) -- --check
+	$(CARGO_CLIPPY_BASE) -- $(CLIPPY_FLAGS)
 	pnpm --recursive run lint
 
 fix:
-	cargo $(CARGO_FLAGS) fmt --all
-	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
+	$(CARGO_FMT)
+	$(CARGO_CLIPPY_BASE) --fix -- $(CLIPPY_FLAGS)
 
 fix-uncommitted:
-	cargo $(CARGO_FLAGS) fmt --all
-	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix --allow-dirty -- -D warnings
+	$(CARGO_FMT)
+	$(CARGO_CLIPPY_BASE) --fix --allow-dirty -- $(CLIPPY_FLAGS)
 
 format:
 	cargo $(CARGO_FLAGS) fmt

--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ lint:
 	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps -- -D warnings
 	pnpm --recursive run lint
 
+fix:
+	cargo $(CARGO_FLAGS) fmt --all
+	cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps --fix -- -D warnings
+
 format:
 	cargo $(CARGO_FLAGS) fmt
 


### PR DESCRIPTION
## Description

I widely use `cargo clippy --fix`, it can easily eliminate all unused imports or other machine-applicable clippy lints. However, I don't remember sometimes whole long command we use for clippy in CI, which makes me open our Makefile, copy command from it, edit adding --fix flag, which is annoying. This PR aims to solve the problem.

Closes: no issue

## Changes

Added two new Makefile commands:

`make fix` -- runs `cargo fmt` and `clippy --fix` for all targets we need. If you have any uncommited changes it will bail and only `cargo fmt` will be runned.
`make fix-uncommited` -- same as above, but this command won't bail if you have any uncommited changes and will perform it's work.

## Note

I'm not sure if we need both versions of the command since I usually don't afraid to run clippy on uncommited changes if same for you then probably we want just one command.

## Testing Information

It is developer tools, no testing needed. I tryied them locally and it seems they do what they should.

## Checklist:

- [x] I have performed a self-review of my code

