### PR TITLE
feat: additional test helpers & utilities (part 2)

### DIFF
--- a/sbtc/src/testing/mod.rs
+++ b/sbtc/src/testing/mod.rs
@@ -1,3 +1,23 @@
 //! All testing utility functions.
 pub mod deposits;
 pub mod regtest;
+
+/// A trait that provides an implementation for a type to be converted into
+/// satoshis (which are represented as `u64`).
+pub trait AsSatoshis {
+    /// Convert the value into satoshis.
+    #[track_caller]
+    fn as_satoshis(&self) -> u64;
+}
+
+impl AsSatoshis for bitcoin::Amount {
+    fn as_satoshis(&self) -> u64 {
+        self.to_sat()
+    }
+}
+
+impl AsSatoshis for u64 {
+    fn as_satoshis(&self) -> u64 {
+        *self
+    }
+}

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -409,7 +409,6 @@ mod tests {
         // This should compile without warning because the output is `()`, which
         // is *not* #[must_use].
         futures_vec.into_iter().join_all().await;
-        println!("Joined unit futures");
     }
 
     /// Tests [`FuturesIterExt::join_all`] followed by

--- a/signer/src/testing/mod.rs
+++ b/signer/src/testing/mod.rs
@@ -341,7 +341,8 @@ where
     where
         <Self::Item as Future>::Output: JoinOutputAdapter,
     {
-        // Join on all of the futures, consuming `self` and returning a `Vec` of `Results`s
+        // Join on all of the futures, consuming `self` and returning a `Vec` of
+        // the results from each future.
         let results = futures::future::join_all(self).await;
 
         // Use the adapter to convert Vec<Future::Output> to the final desired type

--- a/signer/src/testing/requests.rs
+++ b/signer/src/testing/requests.rs
@@ -1,0 +1,572 @@
+//! Helpers for requests
+
+use std::{
+    borrow::Borrow,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use bitcoin::Txid as BitcoinTxid;
+use bitcoin::{
+    AddressType, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
+    XOnlyPublicKey, absolute::LockTime, transaction::Version,
+};
+use bitcoincore_rpc::RpcApi;
+use bitcoincore_rpc_json::Utxo;
+use bitvec::array::BitArray;
+use clarity::{types::chainstate::StacksAddress, vm::types::PrincipalData};
+use emily_client::apis::deposit_api;
+use emily_client::models::Deposit as EmilyDepositModel;
+use fake::Fake;
+use rand::{Rng, RngCore, distributions::Uniform, rngs::OsRng};
+use sbtc::{
+    deposits::{CreateDepositRequest, DepositInfo, DepositScriptInputs, ReclaimScriptInputs},
+    testing::{
+        AsSatoshis,
+        regtest::{self, AsUtxo, Faucet, Recipient},
+    },
+};
+
+use crate::{
+    bitcoin::utxo::{DepositRequest, WithdrawalRequest},
+    emily_client::EmilyClient,
+    storage::model::TaprootScriptHash,
+    testing::TestUtilityError,
+};
+
+/// A static counter for generating unique request IDs for withdrawals.
+pub static REQUEST_IDS: AtomicU64 = AtomicU64::new(0);
+
+/// Generates a random withdrawal request with a random amount and max fee.
+pub fn generate_withdrawal() -> (WithdrawalRequest, Recipient) {
+    let amount = OsRng.sample(Uniform::new(200_000, 250_000));
+    make_withdrawal(amount, amount / 2)
+}
+
+/// Creates a withdrawal request with the specified amount and max fee,
+/// returning the request and a recipient with a new P2TR address.
+pub fn make_withdrawal(amount: u64, max_fee: u64) -> (WithdrawalRequest, Recipient) {
+    let recipient = Recipient::new(AddressType::P2tr);
+
+    let req = WithdrawalRequest {
+        amount,
+        max_fee,
+        script_pubkey: recipient.script_pubkey.clone().into(),
+        signer_bitmap: BitArray::ZERO,
+        request_id: REQUEST_IDS.fetch_add(1, Ordering::Relaxed),
+        txid: fake::Faker.fake_with_rng(&mut OsRng),
+        block_hash: fake::Faker.fake_with_rng(&mut OsRng),
+    };
+
+    (req, recipient)
+}
+
+/// Creates multiple deposit requests, one for each amount in the `amounts` slice.
+/// The deposit requests are submitted to Emily, and a single Bitcoin transaction
+/// containing all deposits is submitted to the Bitcoin node.
+pub fn make_deposit_requests<U, TxAmt, FeeAmt>(
+    depositor: &Recipient,
+    amounts: &[TxAmt],
+    utxo: U,
+    max_fee: FeeAmt,
+    signers_public_key: bitcoin::XOnlyPublicKey,
+) -> (Transaction, Vec<DepositRequest>)
+where
+    U: regtest::AsUtxo,
+    TxAmt: AsSatoshis,
+    FeeAmt: AsSatoshis,
+{
+    let amounts_sats = amounts.iter().map(|a| a.as_satoshis()).collect::<Vec<_>>();
+    let max_fee_sats = max_fee.as_satoshis();
+
+    let deposit_inputs = DepositScriptInputs {
+        signers_public_key,
+        max_fee: max_fee_sats,
+        recipient: PrincipalData::from(StacksAddress::burn_address(false)),
+    };
+    let reclaim_inputs = ReclaimScriptInputs::try_new(50, bitcoin::ScriptBuf::new()).unwrap();
+
+    let deposit_script = deposit_inputs.deposit_script();
+    let reclaim_script = reclaim_inputs.reclaim_script();
+
+    let mut outputs = vec![];
+    for amount in amounts {
+        outputs.push(bitcoin::TxOut {
+            value: Amount::from_sat(amount.as_satoshis()),
+            script_pubkey: sbtc::deposits::to_script_pubkey(
+                deposit_script.clone(),
+                reclaim_script.clone(),
+            ),
+        })
+    }
+
+    let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
+    outputs.push(bitcoin::TxOut {
+        value: utxo.amount() - Amount::from_sat(amounts_sats.iter().sum::<u64>() + fee),
+        script_pubkey: depositor.address.script_pubkey(),
+    });
+
+    let mut deposit_tx = Transaction {
+        version: bitcoin::transaction::Version::ONE,
+        lock_time: bitcoin::absolute::LockTime::ZERO,
+        input: vec![bitcoin::TxIn {
+            previous_output: bitcoin::OutPoint::new(utxo.txid(), utxo.vout()),
+            sequence: bitcoin::Sequence::ZERO,
+            script_sig: bitcoin::ScriptBuf::new(),
+            witness: bitcoin::Witness::new(),
+        }],
+        output: outputs,
+    };
+
+    regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &[utxo], &depositor.keypair);
+
+    let mut requests = vec![];
+    for (index, &amount) in amounts_sats.iter().enumerate() {
+        let req = CreateDepositRequest {
+            outpoint: bitcoin::OutPoint::new(deposit_tx.compute_txid(), index as u32),
+            deposit_script: deposit_script.clone(),
+            reclaim_script: reclaim_script.clone(),
+        };
+
+        requests.push(DepositRequest {
+            outpoint: req.outpoint,
+            max_fee: max_fee_sats,
+            signer_bitmap: BitArray::ZERO,
+            amount,
+            deposit_script: deposit_script.clone(),
+            reclaim_script: reclaim_script.clone(),
+            reclaim_script_hash: Some(TaprootScriptHash::from(&reclaim_script)),
+            signers_public_key,
+        });
+    }
+
+    (deposit_tx, requests)
+}
+
+/// A simple helper struct representing a deposit/withdrawal request amount and
+/// max fee.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AmountSpec<TxAmt, FeeAmt> {
+    /// The amount to be deposited or withdrawn.
+    pub amount: TxAmt,
+    /// The maximum fee that can be paid for the transaction.
+    pub max_fee: FeeAmt,
+}
+
+/// Provides a constructor for [`AmountSpec`] with the specified amount and max
+/// fee which must implement [`AsSatoshis`], allowing amounts to be provided as
+/// e.g. `u64`, `bitcoin::Amount`, etc.
+impl<TxAmt, FeeAmt> AmountSpec<TxAmt, FeeAmt>
+where
+    TxAmt: AsSatoshis,
+    FeeAmt: AsSatoshis,
+{
+    /// Creates a new `AmountSpec` instance with the specified amount and max
+    /// fee.
+    pub fn new(amount: TxAmt, max_fee: FeeAmt) -> Self {
+        Self { amount, max_fee }
+    }
+}
+
+impl<TxAmt> AmountSpec<TxAmt, u64>
+where
+    TxAmt: AsSatoshis,
+{
+    /// Creates a new `AmountSpec` instance with the specified amount and a
+    /// max fee derived from the amount using the specified fraction.
+    pub fn with_derived_max_fee(amount: TxAmt, fraction: f32) -> AmountSpec<TxAmt, u64> {
+        let max_fee: u64 = (amount.as_satoshis() as f32 * fraction) as u64;
+        AmountSpec { amount, max_fee }
+    }
+}
+
+/// Represents a submitted deposit.
+pub struct SubmittedDeposit {
+    /// The Bitcoin transaction that was submitted for the deposit.
+    pub tx: Transaction,
+    /// The deposit request that was created for the deposit.
+    pub request: DepositRequest,
+    /// The deposit information.
+    pub info: DepositInfo,
+}
+
+/// Represents a prepared deposit which is ready to be submitted.
+pub struct PreparedDeposit<'a, Bitcoin, Emily, BitcoinTxid = (), EmilyDeposit = ()> {
+    /// The Bitcoin transaction that was submitted for the deposit.
+    pub tx: Transaction,
+    /// The deposit request that was created for the deposit.
+    pub request: DepositRequest,
+    /// The deposit information.
+    pub info: DepositInfo,
+
+    bitcoin: &'a Bitcoin,
+    emily: &'a Emily,
+
+    _bitcoin_txid: BitcoinTxid,
+    _emily_deposit: EmilyDeposit,
+}
+
+/// Provides specialized functionality for `PreparedDeposit` when the Bitcoin
+/// transaction has not yet been submitted to the Bitcoin node, and the Emily
+/// deposit has not yet been created.
+///
+/// This is identified by the `BitcoinTxid` type parameter being `()`.
+impl<'a, Bitcoin, Emily, EmilyDeposit> PreparedDeposit<'a, Bitcoin, Emily, (), EmilyDeposit>
+where
+    Bitcoin: Borrow<bitcoincore_rpc::Client>,
+{
+    /// Submits the deposit transaction to the Bitcoin node.
+    #[track_caller]
+    pub fn submit_to_bitcoin(
+        self,
+    ) -> PreparedDeposit<'a, Bitcoin, Emily, BitcoinTxid, EmilyDeposit> {
+        let txid = self
+            .bitcoin
+            .borrow()
+            .send_raw_transaction(&self.tx)
+            .unwrap_or_else(|e| {
+                panic!(
+                    "Failed to submit raw transaction with txid '{}' to Bitcoin node: {e}",
+                    self.tx.compute_txid()
+                )
+            });
+
+        assert_eq!(txid, self.request.outpoint.txid);
+
+        PreparedDeposit {
+            tx: self.tx,
+            request: self.request,
+            info: self.info,
+            bitcoin: self.bitcoin,
+            emily: self.emily,
+            _bitcoin_txid: txid,
+            _emily_deposit: self._emily_deposit,
+        }
+    }
+}
+
+/// Provides specialized functionality for `PreparedDeposit` when the Bitcoin
+/// transaction has been submitted to the Bitcoin node, but not yet to Emily.
+///
+/// This is identified by the `BitcoinTxid` type parameter being a
+/// [`bitcoin::Txid`] and the `EmilyDeposit` type parameter being `()`.
+impl<'a, Bitcoin> PreparedDeposit<'a, Bitcoin, EmilyClient, BitcoinTxid, ()> {
+    /// Submits the deposit request to Emily.
+    pub async fn submit_to_emily(
+        self,
+    ) -> Result<
+        PreparedDeposit<'a, Bitcoin, EmilyClient, BitcoinTxid, EmilyDepositModel>,
+        TestUtilityError,
+    > {
+        let emily_request_body = self.request.as_emily_request(&self.tx);
+        let response = deposit_api::create_deposit(self.emily.config(), emily_request_body)
+            .await
+            .map_err(|e| format!("Failed to submit deposit to Emily: {e}"))?;
+
+        Ok(PreparedDeposit {
+            tx: self.tx,
+            request: self.request,
+            info: self.info,
+            bitcoin: self.bitcoin,
+            emily: self.emily,
+            _bitcoin_txid: self._bitcoin_txid,
+            _emily_deposit: response,
+        })
+    }
+}
+
+/// A helper struct for submitting deposits to the Bitcoin network and Emily
+/// from a given depositor.
+///
+/// This helper uses typestate to provide differing functionality based on the
+/// types of `Bitcoin`, `Emily`, and `Depositor` used.
+pub struct DepositHelper<'a, Bitcoin, Emily = (), Depositor = ()> {
+    bitcoin: &'a Bitcoin,
+    emily: &'a Emily,
+    depositor: Depositor,
+}
+
+/// Provides constructors for creating a `DepositHelper` instance with a
+/// [`Recipient`].
+impl<'a> DepositHelper<'a, (), (), Recipient> {
+    /// Creates a new `DepositHelper` instance with the specified Bitcoin client
+    /// and depositor.
+    pub fn with_depositor(depositor: Recipient) -> Self {
+        Self {
+            bitcoin: &(),
+            emily: &(),
+            depositor,
+        }
+    }
+
+    /// Creates a new `DepositHelper` instance with a new depositor generated
+    /// using the provided RNG.
+    pub fn new_depositor<R>(rng: &mut R) -> Self
+    where
+        R: RngCore,
+    {
+        let depositor = Recipient::new_with_rng(AddressType::P2tr, rng);
+        Self {
+            bitcoin: &(),
+            emily: &(),
+            depositor,
+        }
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` and `Depositor` are any type,
+/// * `Emily` is unset/default (`()`).
+impl<'a, Bitcoin, Depositor> DepositHelper<'a, Bitcoin, (), Depositor> {
+    /// Sets the Emily client for this `DepositHelper`, enabling deposit
+    /// submission to Emily. Consumes this instance and returns a new one with
+    /// the Emily client set.
+    pub fn with_emily(
+        self,
+        emily: &'a EmilyClient,
+    ) -> DepositHelper<'a, Bitcoin, EmilyClient, Depositor> {
+        DepositHelper {
+            bitcoin: self.bitcoin,
+            emily,
+            depositor: self.depositor,
+        }
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` is unset/default (`()`),
+/// * `Emily` and `Depositor` are any type,
+impl<'a, Emily, Depositor> DepositHelper<'a, (), Emily, Depositor> {
+    /// Sets the Bitcoin client for this `DepositHelper`, enabling deposit
+    /// submission to Bitcoin. Consumes this instance and returns a new one with
+    /// the Bitcoin client set.
+    pub fn with_bitcoin<B>(self, bitcoin: &'a B) -> DepositHelper<'a, B, Emily, Depositor>
+    where
+        B: Borrow<bitcoincore_rpc::Client>,
+    {
+        DepositHelper {
+            bitcoin,
+            emily: self.emily,
+            depositor: self.depositor,
+        }
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` and `Emily` are any type,
+/// * `Depositor` implements `Borrow<bitcoin::Address>`, for example a
+///   [`bitcoin::Address`] or [`Recipient`].
+impl<Bitcoin, Emily, Depositor> DepositHelper<'_, Bitcoin, Emily, Depositor>
+where
+    Depositor: Borrow<bitcoin::Address>,
+{
+    /// Gets the [`bitcoin::Address`] for the inner [`Recipient`] (depositor).
+    pub fn address(&self) -> &bitcoin::Address {
+        self.depositor.borrow()
+    }
+
+    /// Funds the inner [`Recipient`] from the faucet with the specified amount.
+    /// This does not implicitly create a bitcoin block, so the funding is not
+    /// immediately visible on the blockchain. You need to generate a block to
+    /// confirm the funding and thus make the new UTXO available.
+    pub fn fund_from<Amt>(&self, faucet: &Faucet, amount: Amt)
+    where
+        Amt: AsSatoshis,
+    {
+        faucet.send_to(amount.as_satoshis(), self.address());
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` and `Emilty` are any type,
+/// * `Depositor` is a [`Recipient`].
+impl<'a, Bitcoin, Emily> DepositHelper<'a, Bitcoin, Emily, Recipient> {
+    /// Prepares a deposit request for the specified UTXO, amount, and max fee,
+    /// returning the Bitcoin transaction, deposit request, and deposit info.
+    pub fn prepare_deposit_transaction_with_utxo<K, TxAmt, FeeAmt>(
+        &self,
+        utxo: impl AsUtxo,
+        amount_spec: AmountSpec<TxAmt, FeeAmt>,
+        signers_public_key: K,
+    ) -> PreparedDeposit<'a, Bitcoin, Emily, (), ()>
+    where
+        K: Into<XOnlyPublicKey>,
+        TxAmt: AsSatoshis,
+        FeeAmt: AsSatoshis,
+    {
+        let signers_public_key = signers_public_key.into();
+        let amount_sats = amount_spec.amount.as_satoshis();
+        let max_fee_sats = amount_spec.max_fee.as_satoshis();
+
+        let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
+        let deposit_inputs = DepositScriptInputs {
+            signers_public_key,
+            max_fee: max_fee_sats,
+            recipient: PrincipalData::from(StacksAddress::burn_address(false)),
+        };
+        let reclaim_inputs = ReclaimScriptInputs::try_new(50, ScriptBuf::new()).unwrap();
+
+        let deposit_script = deposit_inputs.deposit_script();
+        let reclaim_script = reclaim_inputs.reclaim_script();
+
+        let mut tx = Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(utxo.txid(), utxo.vout()),
+                sequence: Sequence::ZERO,
+                script_sig: ScriptBuf::new(),
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::from_sat(amount_sats),
+                    script_pubkey: sbtc::deposits::to_script_pubkey(
+                        deposit_script.clone(),
+                        reclaim_script.clone(),
+                    ),
+                },
+                TxOut {
+                    value: utxo.amount() - Amount::from_sat(amount_sats + fee),
+                    script_pubkey: self.depositor.address.script_pubkey(),
+                },
+            ],
+        };
+
+        regtest::p2tr_sign_transaction(&mut tx, 0, &[utxo], &self.depositor.keypair);
+
+        let create_req = CreateDepositRequest {
+            outpoint: OutPoint::new(tx.compute_txid(), 0),
+            deposit_script,
+            reclaim_script,
+        };
+
+        let info = create_req.validate_tx(&tx, false).unwrap();
+
+        let request = DepositRequest {
+            outpoint: info.outpoint,
+            max_fee: info.max_fee,
+            signer_bitmap: BitArray::ZERO,
+            amount: info.amount,
+            deposit_script: info.deposit_script.clone(),
+            reclaim_script: info.reclaim_script.clone(),
+            reclaim_script_hash: Some(TaprootScriptHash::from(&info.reclaim_script)),
+            signers_public_key: info.signers_public_key,
+        };
+
+        assert_eq!(tx.compute_txid(), request.outpoint.txid);
+
+        PreparedDeposit {
+            tx,
+            request,
+            info,
+            bitcoin: self.bitcoin,
+            emily: self.emily,
+            _bitcoin_txid: (),
+            _emily_deposit: (),
+        }
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` is a [`Faucet`],
+/// * `Emily` is any type,
+/// * `Depositor` is any type that implements `Borrow<bitcoin::Address>`.
+impl<Emily, Depositor> DepositHelper<'_, Faucet, Emily, Depositor>
+where
+    Depositor: Borrow<bitcoin::Address>,
+{
+    /// Funds the inner `Depositor` from the faucet with the specified amount.
+    pub fn fund<Amt>(&self, amount: Amt) -> OutPoint
+    where
+        Amt: AsSatoshis,
+    {
+        self.bitcoin
+            .send_to(amount.as_satoshis(), self.depositor.borrow())
+    }
+}
+
+/// Provides specialized functionality for `DepositHelper` when:
+/// * `Bitcoin` implements `Borrow<bitcoincore_rpc::Client>`,
+/// * `Emily` is any type,
+/// * `Depositor` is a [`Recipient`].
+impl<'a, Bitcoin, Emily> DepositHelper<'a, Bitcoin, Emily, Recipient>
+where
+    Bitcoin: Borrow<bitcoincore_rpc::Client>,
+{
+    /// Returns a reference to the inner [`Recipient`] (depositor).
+    pub fn depositor(&self) -> &Recipient {
+        &self.depositor
+    }
+
+    /// Gets the balance of the inner [`Recipient`] (depositor) as a [`bitcoin::Amount`].
+    pub fn get_balance(&self) -> Amount {
+        self.depositor.get_balance(self.bitcoin.borrow())
+    }
+
+    /// Finds a suitable UTXO for the depositor that covers the specified
+    /// amount.
+    fn find_suitable_utxo<TxAmt, FeeAmt>(
+        &self,
+        amount_spec: &AmountSpec<TxAmt, FeeAmt>,
+    ) -> Result<Utxo, TestUtilityError>
+    where
+        TxAmt: AsSatoshis,
+        FeeAmt: AsSatoshis,
+    {
+        let amount_sats = amount_spec.amount.as_satoshis();
+        let max_fee_sats = amount_spec.max_fee.as_satoshis();
+        let total_sats = amount_sats + max_fee_sats;
+
+        // Get the UTXOs for the depositor and filter them to find one that
+        // covers the amount. If no suitable UTXO is found, return an error.
+        let utxo = self
+            .depositor
+            .get_utxos(self.bitcoin.borrow(), Some(total_sats))
+            .pop()
+            .ok_or_else(|| {
+                format!(
+                    "No UTXO found for depositor '{address}' covering {total_sats} satoshis",
+                    address = self.depositor.address
+                )
+            })?;
+
+        Ok(utxo)
+    }
+
+    /// Prepares a deposit transaction for the specified amount and max fee,
+    /// using a suitable UTXO from the inner [`Recipient`] (depositor).
+    ///
+    /// ## Panics
+    ///
+    /// This function will panic if no suitable UTXO is found for the specified
+    /// amount and max fee.
+    #[track_caller]
+    pub fn prepare_deposit_transaction<AggKey, TxAmt, FeeAmt>(
+        &self,
+        amount_spec: AmountSpec<TxAmt, FeeAmt>,
+        aggregate_key: AggKey,
+    ) -> PreparedDeposit<'a, Bitcoin, Emily, (), ()>
+    where
+        AggKey: Into<XOnlyPublicKey>,
+        TxAmt: AsSatoshis,
+        FeeAmt: AsSatoshis,
+    {
+        // Find a suitable UTXO for the specified amount and max fee.
+        let utxo = self.find_suitable_utxo(&amount_spec).unwrap();
+
+        // Prepare the deposit transaction using the found UTXO.
+        self.prepare_deposit_transaction_with_utxo(utxo, amount_spec, aggregate_key)
+    }
+}
+
+/// Allows `DepositHelper` to be borrowed as a `bitcoin::Address` if the
+/// `depositor` field implements `Borrow<bitcoin::Address>` (e.g. a
+/// [`Recipient`]).
+impl<Bitcoin, Emily, Addr> Borrow<bitcoin::Address> for DepositHelper<'_, Bitcoin, Emily, Addr>
+where
+    Addr: Borrow<bitcoin::Address>,
+{
+    fn borrow(&self) -> &bitcoin::Address {
+        self.depositor.borrow()
+    }
+}

--- a/signer/src/testing/requests.rs
+++ b/signer/src/testing/requests.rs
@@ -179,16 +179,6 @@ where
     }
 }
 
-/// Represents a submitted deposit.
-pub struct SubmittedDeposit {
-    /// The Bitcoin transaction that was submitted for the deposit.
-    pub tx: Transaction,
-    /// The deposit request that was created for the deposit.
-    pub request: DepositRequest,
-    /// The deposit information.
-    pub info: DepositInfo,
-}
-
 /// Represents a prepared deposit which is ready to be submitted.
 pub struct PreparedDeposit<'a, Bitcoin, Emily, BitcoinTxid = (), EmilyDeposit = ()> {
     /// The Bitcoin transaction that was submitted for the deposit.

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -26,9 +26,7 @@ use sbtc::deposits::CreateDepositRequest;
 use sbtc::deposits::DepositScriptInputs;
 use sbtc::deposits::ReclaimScriptInputs;
 use sbtc::testing::regtest;
-use sbtc::testing::regtest::Faucet;
 use sbtc::testing::regtest::Recipient;
-use signer::bitcoin::utxo::DepositRequest;
 use signer::bitcoin::utxo::SbtcRequests;
 use signer::bitcoin::utxo::SignerBtcState;
 use signer::bitcoin::utxo::SignerUtxo;
@@ -52,7 +50,10 @@ use signer::storage::model::TxOutputType;
 use signer::storage::model::TxPrevout;
 use signer::storage::model::TxPrevoutType;
 use signer::storage::postgres::PgStore;
+use signer::testing::IterTestExt;
 use signer::testing::btc::get_canonical_chain_tip;
+use signer::testing::requests::AmountSpec;
+use signer::testing::requests::DepositHelper;
 use signer::testing::stacks::DUMMY_SORTITION_INFO;
 use signer::testing::stacks::DUMMY_TENURE_INFO;
 use testing_emily_client::apis::testing_api;
@@ -76,7 +77,6 @@ use crate::setup::IntoEmilyTestingConfig as _;
 use crate::setup::TestSweepSetup;
 use crate::setup::fetch_canonical_bitcoin_blockchain;
 use crate::transaction_coordinator::mock_reqwests_status_code_error;
-use crate::utxo_construction::make_deposit_request;
 use crate::zmq::BITCOIN_CORE_ZMQ_ENDPOINT;
 
 pub const GET_POX_INFO_JSON: &str =
@@ -528,37 +528,33 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     // For a real deposit we need to create a depositor and have them make
     // an actual deposit. For this step we create the sweep transaction
     // "manually".
-    let depositor = Recipient::new(AddressType::P2tr);
+    // Create and fund the depositor.
+    let depositor = DepositHelper::new_depositor(&mut rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
+    depositor.fund(50_000_000);
 
-    // Start off with some initial UTXOs to work with.
-    faucet.send_to(50_000_000, &depositor.address);
-
-    let chain_tip = faucet.generate_blocks(1).pop().unwrap().into();
+    let chain_tip = faucet.generate_block().into();
 
     let signal = signal_receiver.recv();
     let Ok(SignerSignal::Event(SignerEvent::BitcoinBlockObserved)) = signal.await else {
         panic!("Not the right signal")
     };
 
-    // Now lets make a deposit transaction and submit it. First we get some
-    // sats.
-    let depositor_utxo = depositor.get_utxos(rpc, None).pop().unwrap();
-
-    let deposit_amount = 2_500_000;
-    let max_fee = deposit_amount / 2;
+    // Now lets make a deposit transaction and submit it.
     let signers_public_key = shares.aggregate_key.into();
-    let (deposit_tx, deposit_request, _) = make_deposit_request(
-        &depositor,
-        deposit_amount,
-        depositor_utxo,
-        max_fee,
-        signers_public_key,
-    );
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
+
+    let deposit_amount_spec = AmountSpec::with_derived_max_fee(2_500_000, 0.50);
+    let deposit = depositor
+        .prepare_deposit_transaction(deposit_amount_spec, shares.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
+        .await
+        .unwrap();
 
     // Now build the struct with the outstanding peg-in and peg-out requests.
     let requests = SbtcRequests {
-        deposits: vec![deposit_request.clone()],
+        deposits: vec![deposit.request.clone()],
         withdrawals: Vec::new(),
         signer_state: SignerBtcState {
             utxo: db.get_signer_utxo(&chain_tip).await.unwrap().unwrap(),
@@ -573,9 +569,8 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
         max_deposits_per_bitcoin_tx: ctx.config().signer.max_deposits_per_bitcoin_tx.get(),
     };
 
-    let mut transactions = requests.construct_transactions().unwrap();
-    assert_eq!(transactions.len(), 1);
-    let mut unsigned = transactions.pop().unwrap();
+    let transactions = requests.construct_transactions().unwrap();
+    let mut unsigned = transactions.single();
 
     // Add the signature and/or other required information to the witness data.
     signer::testing::set_witness_data(&mut unsigned, signer.keypair);
@@ -587,11 +582,11 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     //
     // Inform emily about the deposit
     let body = CreateDepositRequestBody {
-        bitcoin_tx_output_index: deposit_request.outpoint.vout,
-        bitcoin_txid: deposit_request.outpoint.txid.to_string(),
-        deposit_script: deposit_request.deposit_script.to_hex_string(),
-        reclaim_script: deposit_request.reclaim_script.to_hex_string(),
-        transaction_hex: serialize_hex(&deposit_tx),
+        bitcoin_tx_output_index: deposit.request.outpoint.vout,
+        bitcoin_txid: deposit.request.outpoint.txid.to_string(),
+        deposit_script: deposit.request.deposit_script.to_hex_string(),
+        reclaim_script: deposit.request.reclaim_script.to_hex_string(),
+        transaction_hex: serialize_hex(&deposit.tx),
     };
     deposit_api::create_deposit(emily_client.config(), body)
         .await
@@ -600,7 +595,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     // ** Step 6 **
     //
     // Check that the block observer populates the tables correctly
-    faucet.generate_blocks(1);
+    faucet.generate_block();
 
     // Okay now there is a deposit, and it has been confirmed. We should
     // pick it up automatically.
@@ -643,36 +638,11 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
     let TxPrevout { txid, prevout_txid, amount, .. } =
         fetch_input(&db, TxPrevoutType::Deposit).await[0];
 
-    assert_eq!(amount, deposit_amount);
-    assert_eq!(prevout_txid.deref(), &deposit_tx.compute_txid());
+    assert_eq!(amount, deposit_amount_spec.amount);
+    assert_eq!(prevout_txid.deref(), &deposit.tx.compute_txid());
     assert_eq!(txid.deref(), &unsigned.tx.compute_txid());
 
     testing::storage::drop_db(db).await;
-}
-
-/// Generates a random deposit request transaction with the input amount
-/// that is locked by the given aggregate key.
-///
-/// Note: The deposit transaction will be in the mempool when this function
-/// returns.
-fn generate_deposit_request<R: rand::Rng>(
-    faucet: &Faucet,
-    amount: u64,
-    signers_public_key: bitcoin::XOnlyPublicKey,
-    rng: &mut R,
-) -> DepositRequest {
-    let depositor = Recipient::new_with_rng(AddressType::P2tr, rng);
-    faucet.send_to(amount + amount / 2, &depositor.address);
-    faucet.generate_block();
-
-    let utxo = depositor.get_utxos(faucet.rpc, None).pop().unwrap();
-    let max_fee = amount / 2;
-
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
-
-    faucet.rpc.send_raw_transaction(&deposit_tx).unwrap();
-    deposit_request
 }
 
 /// This tests that a new signer, when they are coming online, can
@@ -707,24 +677,34 @@ async fn block_observer_picks_up_chained_unordered_sweeps() {
     let new_signer = Recipient::new_with_rng(AddressType::P2tr, &mut rng);
     let signers_public_key2 = PublicKey::from(new_signer.keypair.public_key()).into();
 
+    let depositor1 = DepositHelper::new_depositor(&mut rng).with_bitcoin(rpc);
+    let depositor2 = DepositHelper::new_depositor(&mut rng).with_bitcoin(rpc);
+    let depositor3 = DepositHelper::new_depositor(&mut rng).with_bitcoin(rpc);
+
+    faucet.send_to_many(1_000_000, &[&depositor1, &depositor2, &depositor3]);
+    faucet.generate_block();
+
     // Now lets make three deposit transactions, one for each sweep
     // transaction.
-    let mut deposit_request1 =
-        generate_deposit_request(faucet, 950_000, signers_public_key1, &mut rng);
-    let mut deposit_request2 =
-        generate_deposit_request(faucet, 875_000, signers_public_key2, &mut rng);
-    let mut deposit_request3 =
-        generate_deposit_request(faucet, 725_000, signers_public_key2, &mut rng);
+    let mut deposit1 = depositor1
+        .prepare_deposit_transaction(AmountSpec::new(950_000, 50_000), signers_public_key1)
+        .submit_to_bitcoin();
+    let mut deposit2 = depositor2
+        .prepare_deposit_transaction(AmountSpec::new(875_000, 50_000), signers_public_key2)
+        .submit_to_bitcoin();
+    let mut deposit3 = depositor3
+        .prepare_deposit_transaction(AmountSpec::new(725_000, 50_000), signers_public_key2)
+        .submit_to_bitcoin();
 
     // We want to construct three sweep transactions in order to
     // demonstrate that the transactions are picked up, even in the case
     // where the scriptPubKey has changed for the first one.
-    deposit_request1.signer_bitmap.set(0, true);
-    deposit_request2.signer_bitmap.set(1, true);
-    deposit_request3.signer_bitmap.set(2, true);
+    deposit1.request.signer_bitmap.set(0, true);
+    deposit2.request.signer_bitmap.set(1, true);
+    deposit3.request.signer_bitmap.set(2, true);
 
     let requests = SbtcRequests {
-        deposits: vec![deposit_request1, deposit_request2, deposit_request3],
+        deposits: vec![deposit1.request, deposit2.request, deposit3.request],
         withdrawals: Vec::new(),
         signer_state: SignerBtcState {
             utxo: SignerUtxo {

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -580,20 +580,6 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
 
     // ** Step 5 **
     //
-    // Inform emily about the deposit
-    let body = CreateDepositRequestBody {
-        bitcoin_tx_output_index: deposit.request.outpoint.vout,
-        bitcoin_txid: deposit.request.outpoint.txid.to_string(),
-        deposit_script: deposit.request.deposit_script.to_hex_string(),
-        reclaim_script: deposit.request.reclaim_script.to_hex_string(),
-        transaction_hex: serialize_hex(&deposit.tx),
-    };
-    deposit_api::create_deposit(emily_client.config(), body)
-        .await
-        .unwrap();
-
-    // ** Step 6 **
-    //
     // Check that the block observer populates the tables correctly
     faucet.generate_block();
 

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -14,7 +14,6 @@ use bitcoin::BlockHash;
 use bitcoin::Transaction;
 use bitcoin::hashes::Hash as _;
 use bitcoincore_rpc::RpcApi as _;
-use bitvec::array::BitArray;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlock;
 use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
 use blockstack_lib::chainstate::stacks::StacksTransaction;
@@ -38,9 +37,7 @@ use lru::LruCache;
 use more_asserts::assert_lt;
 use rand::rngs::OsRng;
 
-use sbtc::deposits::CreateDepositRequest;
-use sbtc::deposits::DepositScriptInputs;
-use sbtc::deposits::ReclaimScriptInputs;
+use rand::RngCore;
 use sbtc::testing::regtest;
 use sbtc::testing::regtest::AsUtxo as _;
 use sbtc::testing::regtest::Recipient;
@@ -50,7 +47,6 @@ use secp256k1::SECP256K1;
 use signer::bitcoin::BitcoinInteract as _;
 use signer::bitcoin::rpc::BitcoinCoreClient;
 use signer::bitcoin::utxo::BitcoinInputsOutputs;
-use signer::bitcoin::utxo::DepositRequest;
 use signer::bitcoin::utxo::Fees;
 use signer::bitcoin::utxo::TxDeconstructor as _;
 use signer::bitcoin::validation::WithdrawalValidationResult;
@@ -67,6 +63,10 @@ use signer::storage::model::WithdrawalTxOutput;
 use signer::testing::btc::get_canonical_chain_tip;
 use signer::testing::get_rng;
 
+use signer::testing::requests::AmountSpec;
+use signer::testing::requests::DepositHelper;
+use signer::testing::requests::generate_withdrawal;
+use signer::testing::requests::make_deposit_requests;
 use signer::transaction_coordinator::should_coordinate_dkg;
 use signer::transaction_signer::STACKS_SIGN_REQUEST_LRU_SIZE;
 use signer::transaction_signer::assert_allow_dkg_begin;
@@ -155,8 +155,6 @@ use crate::setup::backfill_bitcoin_blocks;
 use crate::setup::fetch_canonical_bitcoin_blockchain;
 use crate::setup::set_deposit_completed;
 use crate::setup::set_deposit_incomplete;
-use crate::utxo_construction::generate_withdrawal;
-use crate::utxo_construction::make_deposit_request;
 use crate::zmq::BITCOIN_CORE_ZMQ_ENDPOINT;
 
 type IntegrationTestContext<Stacks> = TestContext<PgStore, BitcoinCoreClient, Stacks, EmilyClient>;
@@ -1795,12 +1793,14 @@ async fn sign_bitcoin_transaction() {
 
     faucet.send_to(100_000, &address);
 
-    let depositor = Recipient::new(AddressType::P2tr);
+    let depositor = DepositHelper::new_depositor(&mut rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
 
     // Start off with some initial UTXOs to work with.
 
-    faucet.send_to(50_000_000, &depositor.address);
-    faucet.generate_blocks(1);
+    depositor.fund(50_000_000);
+    faucet.generate_block();
 
     wait_for_signers(&signers).await;
 
@@ -1811,19 +1811,11 @@ async fn sign_bitcoin_transaction() {
     //   request transaction. Submit it and inform Emily about it.
     // =========================================================================
     // Now lets make a deposit transaction and submit it
-    let utxo = depositor.get_utxos(rpc, None).pop().unwrap();
-
-    let amount = 2_500_000;
-    let signers_public_key = shares.aggregate_key.into();
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    assert_eq!(deposit_tx.compute_txid(), deposit_request.outpoint.txid);
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    let _ = deposit_api::create_deposit(emily_client.config(), body)
+    let deposit_amount_spec = AmountSpec::with_derived_max_fee(2_500_000, 0.5);
+    depositor
+        .prepare_deposit_transaction(deposit_amount_spec, shares.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
@@ -1839,16 +1831,14 @@ async fn sign_bitcoin_transaction() {
     // - The coordinator should submit a sweep transaction. We check the
     //   mempool for its existence.
     // =========================================================================
-    faucet.generate_blocks(1);
-
+    faucet.generate_block();
     wait_for_signers(&signers).await;
 
     let (ctx, _, _, _) = signers.first().unwrap();
     let mut txids = ctx.bitcoin_client.inner_client().get_raw_mempool().unwrap();
     assert_eq!(txids.len(), 1);
 
-    let block_hash = faucet.generate_blocks(1).pop().unwrap();
-
+    let block_hash = faucet.generate_block();
     wait_for_signers(&signers).await;
 
     // =========================================================================
@@ -1952,10 +1942,10 @@ async fn sign_bitcoin_transaction() {
 /// then, once everything is up and running, run the test.
 #[test(tokio::test)]
 async fn sign_bitcoin_transaction_multiple_locking_keys() {
+    let rng = &mut get_rng();
     let (_, signer_key_pairs): (_, [Keypair; 3]) = testing::wallet::regtest_bootstrap_wallet();
     let (rpc, faucet) = regtest::initialize_blockchain();
 
-    let mut rng = get_rng();
     // We need to populate our databases, so let's fetch the data.
     let emily_client = EmilyClient::try_new(
         &Url::parse("http://testApiKey@localhost:3031").unwrap(),
@@ -2207,12 +2197,15 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     // - Give "depositors" some UTXOs so that they can make deposits for
     //   sBTC.
     // =========================================================================
-    let depositor1 = Recipient::new(AddressType::P2tr);
-    let depositor2 = Recipient::new(AddressType::P2tr);
+    let depositor1 = DepositHelper::new_depositor(rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
+    let depositor2 = DepositHelper::new_depositor(rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
 
     // Start off with some initial UTXOs to work with.
-    faucet.send_to(50_000_000, &depositor1.address);
-    faucet.send_to(50_000_000, &depositor2.address);
+    faucet.send_to_many(50_000_000, &[&depositor1, &depositor2]);
 
     // =========================================================================
     // Step 5 - Wait for DKG
@@ -2224,7 +2217,7 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     // =========================================================================
 
     // This should kick off DKG.
-    let chain_tip: BitcoinBlockHash = faucet.generate_blocks(1).pop().unwrap().into();
+    let chain_tip: BitcoinBlockHash = faucet.generate_block().into();
 
     // We first need to wait for bitcoin-core to send us all the
     // notifications so that we are up-to-date with the chain tip.
@@ -2239,7 +2232,7 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
 
         let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
         let event = KeyRotationEvent {
-            txid: fake::Faker.fake_with_rng(&mut rng),
+            txid: fake::Faker.fake_with_rng(rng),
             block_hash: stacks_chain_tip.block_hash,
             aggregate_key: shares.aggregate_key,
             signer_set: shares.signer_set_public_keys.clone(),
@@ -2272,19 +2265,13 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     //   request transaction. Submit it and inform Emily about it.
     // =========================================================================
     // Now lets make a deposit transaction and submit it
-    let utxo = depositor1.get_utxos(rpc, None).pop().unwrap();
 
-    let amount = 2_500_000;
-    let signers_public_key = shares1.aggregate_key.into();
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor1, amount, utxo, max_fee, signers_public_key);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    assert_eq!(deposit_tx.compute_txid(), deposit_request.outpoint.txid);
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    let _ = deposit_api::create_deposit(emily_client.config(), body)
+    // Deposit #1, locked by aggregate key #1
+    let deposit1_amount_spec = AmountSpec::with_derived_max_fee(2_500_000, 0.5);
+    depositor1
+        .prepare_deposit_transaction(deposit1_amount_spec, shares1.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
@@ -2301,16 +2288,14 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     // - The coordinator should submit a sweep transaction. We check the
     //   mempool for its existence.
     // =========================================================================
-    faucet.generate_blocks(1);
-
+    faucet.generate_block();
     wait_for_signers(&signers).await;
 
     let (ctx, _, _, _) = signers.first().unwrap();
     let mut txids = ctx.bitcoin_client.inner_client().get_raw_mempool().unwrap();
     assert_eq!(txids.len(), 1);
 
-    let block_hash = faucet.generate_blocks(1).pop().unwrap();
-
+    let block_hash = faucet.generate_block();
     wait_for_signers(&signers).await;
 
     // Now lets check the bitcoin transaction, first we get it.
@@ -2384,7 +2369,7 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
 
         let stacks_chain_tip = db.get_stacks_chain_tip(&chain_tip).await.unwrap().unwrap();
         let event = KeyRotationEvent {
-            txid: fake::Faker.fake_with_rng(&mut rng),
+            txid: fake::Faker.fake_with_rng(rng),
             block_hash: stacks_chain_tip.block_hash,
             aggregate_key: shares.aggregate_key,
             signer_set: shares.signer_set_public_keys.clone(),
@@ -2404,30 +2389,22 @@ async fn sign_bitcoin_transaction_multiple_locking_keys() {
     //   the old one and the new one.
     // =========================================================================
     // Now lets make a deposit transaction and submit it
-    let utxo = depositor2.get_utxos(rpc, None).pop().unwrap();
 
-    let amount = 3_500_000;
-    let signers_public_key2 = shares2.aggregate_key.into();
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor2, amount, utxo, max_fee, signers_public_key2);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    deposit_api::create_deposit(emily_client.config(), body)
+    // Deposit #2, locked with aggregate key #2.
+    let deposit2_amount_spec = AmountSpec::with_derived_max_fee(3_500_000, 0.5);
+    depositor2
+        .prepare_deposit_transaction(deposit2_amount_spec, shares2.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
-    let utxo = depositor1.get_utxos(rpc, None).pop().unwrap();
-    let amount = 4_500_000;
-    let signers_public_key1 = shares1.aggregate_key.into();
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor1, amount, utxo, max_fee, signers_public_key1);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    deposit_api::create_deposit(emily_client.config(), body)
+    // Deposit #3, locked with aggregate key #1.
+    let deposit3_amount_spec = AmountSpec::with_derived_max_fee(4_500_000, 0.5);
+    depositor1
+        .prepare_deposit_transaction(deposit3_amount_spec, shares1.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
@@ -2870,12 +2847,15 @@ async fn skip_signer_activites_after_key_rotation() {
     // - Give "depositors" some UTXOs so that they can make deposits for
     //   sBTC.
     // =========================================================================
-    let depositor1 = Recipient::new(AddressType::P2tr);
-    let depositor2 = Recipient::new(AddressType::P2tr);
+    let depositor1 = DepositHelper::new_depositor(&mut rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
+    let depositor2 = DepositHelper::new_depositor(&mut rng)
+        .with_bitcoin(faucet)
+        .with_emily(&emily_client);
 
     // Start off with some initial UTXOs to work with.
-    faucet.send_to(50_000_000, &depositor1.address);
-    faucet.send_to(50_000_000, &depositor2.address);
+    faucet.send_to_many(50_000_000, &[&depositor1, &depositor2]);
 
     // =========================================================================
     // Step 5 - Wait for DKG
@@ -2935,19 +2915,11 @@ async fn skip_signer_activites_after_key_rotation() {
     //   request transaction. Submit it and inform Emily about it.
     // =========================================================================
     // Now lets make a deposit transaction and submit it
-    let utxo = depositor1.get_utxos(rpc, None).pop().unwrap();
-
-    let amount = 2_500_000;
-    let signers_public_key = shares1.aggregate_key.into();
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor1, amount, utxo, max_fee, signers_public_key);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    assert_eq!(deposit_tx.compute_txid(), deposit_request.outpoint.txid);
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    let _ = deposit_api::create_deposit(emily_client.config(), body)
+    let deposit1_amount_spec = AmountSpec::with_derived_max_fee(2_500_000, 0.5);
+    depositor1
+        .prepare_deposit_transaction(deposit1_amount_spec, shares1.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
@@ -3032,16 +3004,11 @@ async fn skip_signer_activites_after_key_rotation() {
         assert_eq!(dkg_share_count, 1);
     }
 
-    let utxo = depositor2.get_utxos(rpc, None).pop().unwrap();
-
-    let amount = 3_500_000;
-    let max_fee = amount / 2;
-    let (deposit_tx, deposit_request, _) =
-        make_deposit_request(&depositor2, amount, utxo, max_fee, signers_public_key);
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
-
-    let body = deposit_request.as_emily_request(&deposit_tx);
-    deposit_api::create_deposit(emily_client.config(), body)
+    let deposit2_amount_spec = AmountSpec::with_derived_max_fee(3_500_000, 0.5);
+    depositor2
+        .prepare_deposit_transaction(deposit2_amount_spec, shares1.aggregate_key)
+        .submit_to_bitcoin()
+        .submit_to_emily()
         .await
         .unwrap();
 
@@ -3858,16 +3825,20 @@ fn create_signer_set(signers: &[Keypair], threshold: u32) -> (SignerSet, InMemor
     )
 }
 
-fn create_test_setup(
+fn create_test_setup<R>(
+    rng: &mut R,
     dkg_shares: &EncryptedDkgShares,
     signatures_required: u16,
     faucet: &regtest::Faucet,
     rpc: &bitcoincore_rpc::Client,
     bitcoin_client: &BitcoinCoreClient,
-) -> TestSweepSetup2 {
-    let depositor = Recipient::new(AddressType::P2tr);
-    faucet.send_to(50_000_000, &depositor.address);
-    faucet.generate_blocks(1);
+) -> TestSweepSetup2
+where
+    R: RngCore,
+{
+    let depositor = DepositHelper::new_depositor(rng).with_bitcoin(faucet);
+    depositor.fund(50_000_000);
+    faucet.generate_block();
 
     let signer_address = Address::from_script(
         &dkg_shares.script_pubkey,
@@ -3875,22 +3846,17 @@ fn create_test_setup(
     )
     .unwrap();
     let donation = faucet.send_to(100_000, &signer_address);
-    let donation_block_hash = faucet.generate_blocks(1)[0];
+    let donation_block_hash = faucet.generate_block();
 
-    let utxo = depositor.get_utxos(rpc, None).pop().unwrap();
-    let (deposit_tx, deposit_request, deposit_info) = make_deposit_request(
-        &depositor,
-        5_000_000,
-        utxo,
-        100_000,
-        dkg_shares.aggregate_key.x_only_public_key().0,
-    );
-    rpc.send_raw_transaction(&deposit_tx).unwrap();
+    let deposit_amount_spec = AmountSpec::new(5_000_000, 100_000);
+    let deposit = depositor
+        .prepare_deposit_transaction(deposit_amount_spec, dkg_shares.aggregate_key)
+        .submit_to_bitcoin();
 
     let deposit_block_hash = faucet.generate_blocks(1).pop().unwrap();
     let block_header = rpc.get_block_header_info(&deposit_block_hash).unwrap();
     let tx_info = bitcoin_client
-        .get_tx_info(&deposit_tx.compute_txid(), &deposit_block_hash)
+        .get_tx_info(&deposit.tx.compute_txid(), &deposit_block_hash)
         .unwrap()
         .unwrap();
     let test_signers = TestSignerSet {
@@ -3900,14 +3866,14 @@ fn create_test_setup(
     };
     let (request, recipient) = generate_withdrawal();
     let stacks_block = model::StacksBlock {
-        block_hash: Faker.fake_with_rng(&mut OsRng),
+        block_hash: Faker.fake_with_rng(rng),
         block_height: 0u64.into(),
         parent_hash: StacksBlockId::first_mined().into(),
         bitcoin_anchor: deposit_block_hash.into(),
     };
     TestSweepSetup2 {
         deposit_block_hash,
-        deposits: vec![(deposit_info, deposit_request, tx_info)],
+        deposits: vec![(deposit.info, deposit.request, tx_info)],
         sweep_tx_info: None,
         broadcast_info: None,
         donation,
@@ -4141,6 +4107,7 @@ async fn test_conservative_initial_sbtc_limits() {
     let dkg_shares = encrypted_shares.first().cloned().unwrap();
     let bitcoin_client = signers[0].0.clone().bitcoin_client;
     let setup = create_test_setup(
+        &mut rng,
         &dkg_shares,
         signatures_required,
         faucet,
@@ -5773,80 +5740,6 @@ async fn wait_next_stacks_block(stacks_client: &StacksClient) {
     })
     .await
     .unwrap()
-}
-
-fn make_deposit_requests<U>(
-    depositor: &Recipient,
-    amounts: &[u64],
-    utxo: U,
-    max_fee: u64,
-    signers_public_key: bitcoin::XOnlyPublicKey,
-) -> (Transaction, Vec<DepositRequest>)
-where
-    U: regtest::AsUtxo,
-{
-    let deposit_inputs = DepositScriptInputs {
-        signers_public_key,
-        max_fee,
-        recipient: PrincipalData::from(StacksAddress::burn_address(false)),
-    };
-    let reclaim_inputs = ReclaimScriptInputs::try_new(50, bitcoin::ScriptBuf::new()).unwrap();
-
-    let deposit_script = deposit_inputs.deposit_script();
-    let reclaim_script = reclaim_inputs.reclaim_script();
-
-    let mut outputs = vec![];
-    for amount in amounts {
-        outputs.push(bitcoin::TxOut {
-            value: Amount::from_sat(*amount),
-            script_pubkey: sbtc::deposits::to_script_pubkey(
-                deposit_script.clone(),
-                reclaim_script.clone(),
-            ),
-        })
-    }
-
-    let fee = regtest::BITCOIN_CORE_FALLBACK_FEE.to_sat();
-    outputs.push(bitcoin::TxOut {
-        value: utxo.amount() - Amount::from_sat(amounts.iter().sum::<u64>() + fee),
-        script_pubkey: depositor.address.script_pubkey(),
-    });
-
-    let mut deposit_tx = Transaction {
-        version: bitcoin::transaction::Version::ONE,
-        lock_time: bitcoin::absolute::LockTime::ZERO,
-        input: vec![bitcoin::TxIn {
-            previous_output: bitcoin::OutPoint::new(utxo.txid(), utxo.vout()),
-            sequence: bitcoin::Sequence::ZERO,
-            script_sig: bitcoin::ScriptBuf::new(),
-            witness: bitcoin::Witness::new(),
-        }],
-        output: outputs,
-    };
-
-    regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &[utxo], &depositor.keypair);
-
-    let mut requests = vec![];
-    for (index, amount) in amounts.iter().enumerate() {
-        let req = CreateDepositRequest {
-            outpoint: bitcoin::OutPoint::new(deposit_tx.compute_txid(), index as u32),
-            deposit_script: deposit_script.clone(),
-            reclaim_script: reclaim_script.clone(),
-        };
-
-        requests.push(DepositRequest {
-            outpoint: req.outpoint,
-            max_fee,
-            signer_bitmap: BitArray::ZERO,
-            amount: *amount,
-            deposit_script: deposit_script.clone(),
-            reclaim_script: reclaim_script.clone(),
-            reclaim_script_hash: Some(model::TaprootScriptHash::from(&reclaim_script)),
-            signers_public_key,
-        });
-    }
-
-    (deposit_tx, requests)
 }
 
 /// This test requires a running stacks node.


### PR DESCRIPTION
## Description

Additional test helpers, with a focus on the new `DepositHelper`, which I now extracted from PR #1726 and did a more complete refactor of tests which previously directly used `make_deposit_request`.

The helpers aim to be versatile and are compatible with all of our various "bitcoin client"-y implementations, using typestate to gate/provide functionality based on what you've provided to it (i.e. what you have available in the test - maybe you don't have a bitcoin client, or maybe you only have a `Client` and not a `Faucet`; maybe you have an `EmilyClient`, maybe not, etc. etc.).

## Changes

- New `DepositHelper` and `PreparedDeposit` helper types for working with deposits in tests and submitting to both Bitcoin and Emily.
- Moved/consolidated most of the "make request" helpers into `testing/requests.rs`.
- Refactored tests which used `make_deposit_request` helper function.
- Improvements to the `sbtc/regtest` file, particularly in regards to error handling, but also a few things that are used here.
- New `AsSatoshis` trait in `sbtc/testing`, which can be implemented for any type which can be converted into Satoshis (represented as a `u64`).
- The `TestUtilityError` type is duplicated here from #1726.

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
