### PR TITLE
fix: Fix the Git Commit Reference during image building

### DIFF
--- a/.github/workflows/image-build-and-draft-release.yaml
+++ b/.github/workflows/image-build-and-draft-release.yaml
@@ -96,7 +96,7 @@ jobs:
           target: ${{ matrix.docker_target }}
           push: true
           build-args: |
-            GIT_COMMIT=${{ github.ref_name }}
+            GIT_COMMIT=${{ github.event.client_payload.tag_name }}
 
       - name: Save digest as output
         id: save_digest


### PR DESCRIPTION
## Description

Fix the Git Commit Reference using the Tag Name

## Changes

Set the GIT_COMMIT to _github.event.client_payload.tag_name_

## Checklist:

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
