### PR TITLE
fix: specify the event name in the wait-list of wait-other-jobs

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -288,6 +288,7 @@ jobs:
               {
                 "workflowFile": "on-push.yaml",
                 "jobName": "Build Test Artifacts",
+                "eventName": "${{ github.event_name }}",
                 "optional": false,
                 "startupGracePeriod": {
                   "minutes": 5


### PR DESCRIPTION
## Description

This may fix that issue that we've been seeing in CI. Doesn't address the warnings though.

The underlying action can be found here https://github.com/kachick/wait-other-jobs/tree/215c93f93f91e8f9a5ccb7fc0cc78220c9fd8a99?tab=readme-ov-file#usage, while our use of it can be found here https://github.com/stacks-sbtc/actions/blob/181f8c67da2707c66b5e31f24e7418c47adefdd1/wait-other-jobs/action.yml

## Changes

1. Specify the `eventName` in the wait list, in the same way that the usage docs demonstrate. But I'm not 100% sure that this fixes it, also not sure whether this introduces other issues.

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
