### PR TITLE
Remove Verification If Past Verification Window (draft)

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -351,6 +351,12 @@ where
                 }
             }
         } else {
+            // If we do not have signer set info in the registry, then we
+            // are in the bootstrap phase. Our latest DKG shares may be
+            // 'Unverified', but if we are here then they were not 'Failed'
+            // when we made to call to `should_coordinate_dkg`, since we
+            // will coordinate DKG if our last DKG shares are 'Failed'. But
+            // we could be loading 'Failed' shares here.
             registry_aggregate_key
                 .ok_or(Error::MissingAggregateKey(*bitcoin_chain_tip.block_hash))?
         };


### PR DESCRIPTION
## Description
Currently, during a key rotation, we verify shares *twice.* Here, if we're past the verification window we forgo verifying again since it'd fail & further delay rotating to the new key.

Closes: #1721 

## Changes
signer/src/transaction_coordinator.rs, specifically the 'assert_rotate_key_action.'

## Testing Information
Three new tests were added.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
