### PR TITLE
feat: add metrics for smart contract read requests

### DIFF
--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -83,6 +83,30 @@ impl From<Metrics> for metrics::KeyName {
     }
 }
 
+impl From<SmartContract> for metrics::SharedString {
+    fn from(value: SmartContract) -> Self {
+        metrics::SharedString::const_str(value.contract_name())
+    }
+}
+
+impl From<ReadOnlyFnName> for metrics::SharedString {
+    fn from(value: ReadOnlyFnName) -> Self {
+        metrics::SharedString::const_str(value.into())
+    }
+}
+
+impl From<ClarityMapName> for metrics::SharedString {
+    fn from(value: ClarityMapName) -> Self {
+        metrics::SharedString::const_str(value.into())
+    }
+}
+
+impl From<DataVarName> for metrics::SharedString {
+    fn from(value: DataVarName) -> Self {
+        metrics::SharedString::const_str(value.into())
+    }
+}
+
 impl Metrics {
     /// Increment the deposit request counter for incoming deposit requests
     pub fn increment_deposit_total(deposit: &Result<Option<Deposit>, Error>) {
@@ -187,15 +211,12 @@ impl Metrics {
 
     /// Record the amount of time it took to complete a
     /// /v2/contracts/call-read request from the stacks node.
-    pub fn record_call_read_duration(
+    pub fn record_call_read(
         elapsed: Duration,
         contract_name: SmartContract,
         function_name: ReadOnlyFnName,
         response: &Response,
     ) {
-        let contract_name: &'static str = contract_name.contract_name();
-        let function_name: &'static str = function_name.into();
-
         metrics::histogram!(
             Metrics::CallReadOnlyDurationSeconds,
             "contract_name" => contract_name,
@@ -217,15 +238,12 @@ impl Metrics {
 
     /// Record the amount of time it took to complete a /v2/data_var
     /// request from the stacks node.
-    pub fn record_data_var_duration(
+    pub fn record_data_var(
         elapsed: Duration,
         contract_name: SmartContract,
         variable_name: DataVarName,
         response: &Response,
     ) {
-        let contract_name: &'static str = contract_name.contract_name();
-        let variable_name: &'static str = variable_name.into();
-
         metrics::histogram!(
             Metrics::ReadDataVarDurationSeconds,
             "contract_name" => contract_name,
@@ -247,15 +265,12 @@ impl Metrics {
 
     /// Record the amount of time it took to complete a /v2/map_entry
     /// request from the stacks node.
-    pub fn record_map_entry_duration(
+    pub fn record_map_entry(
         elapsed: Duration,
         contract_name: SmartContract,
         map_name: ClarityMapName,
         response: &Response,
     ) {
-        let contract_name: &'static str = contract_name.contract_name();
-        let map_name: &'static str = map_name.into();
-
         metrics::histogram!(
             Metrics::ReadMapEntryDurationSeconds,
             "contract_name" => contract_name,

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -61,6 +61,9 @@ pub enum Metrics {
     /// The amount of time, in seconds, it took for to read a data variable
     /// in a smart contract by making a request to the stacks node.
     ReadDataVarDurationSeconds,
+    /// The amount of time, in seconds, it took read a map entry in a smart
+    /// contract by making a request to the stacks node.
+    ReadMapEntryDurationSeconds,
 }
 
 impl From<Metrics> for metrics::KeyName {
@@ -207,6 +210,27 @@ impl Metrics {
             Metrics::ReadDataVarDurationSeconds,
             "contract_name" => contract_name,
             "variable_name" => variable_name,
+            "status_code" => response.status().as_u16().to_string(),
+            "blockchain" => STACKS_BLOCKCHAIN,
+        )
+        .record(elapsed);
+    }
+
+    /// Record the amount of time it took to complete a /v2/data_map
+    /// request from the stacks node.
+    pub fn record_map_entry_duration(
+        elapsed: Duration,
+        contract_name: ContractName,
+        map_name: ClarityName,
+        response: &Response,
+    ) {
+        let contract_name: String = contract_name.into();
+        let map_name: String = map_name.into();
+
+        metrics::histogram!(
+            Metrics::ReadMapEntryDurationSeconds,
+            "contract_name" => contract_name,
+            "map_name" => map_name,
             "status_code" => response.status().as_u16().to_string(),
             "blockchain" => STACKS_BLOCKCHAIN,
         )

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -10,9 +10,7 @@ use reqwest::Response;
 use crate::block_observer::Deposit;
 use crate::error::Error;
 use crate::message::StacksTransactionSignRequest;
-use crate::stacks::api::ClarityMapName;
-use crate::stacks::api::DataVarName;
-use crate::stacks::api::ReadOnlyFnName;
+use crate::stacks::api::ClarityName;
 use crate::stacks::contracts::SmartContract;
 use crate::transaction_signer::AcceptedSigHash;
 
@@ -89,20 +87,8 @@ impl From<SmartContract> for metrics::SharedString {
     }
 }
 
-impl From<ReadOnlyFnName> for metrics::SharedString {
-    fn from(value: ReadOnlyFnName) -> Self {
-        metrics::SharedString::const_str(value.0)
-    }
-}
-
-impl From<ClarityMapName> for metrics::SharedString {
-    fn from(value: ClarityMapName) -> Self {
-        metrics::SharedString::const_str(value.0)
-    }
-}
-
-impl From<DataVarName> for metrics::SharedString {
-    fn from(value: DataVarName) -> Self {
+impl From<ClarityName> for metrics::SharedString {
+    fn from(value: ClarityName) -> Self {
         metrics::SharedString::const_str(value.0)
     }
 }
@@ -214,7 +200,7 @@ impl Metrics {
     pub fn record_call_read(
         elapsed: Duration,
         contract_name: SmartContract,
-        function_name: ReadOnlyFnName,
+        function_name: ClarityName,
         response: &Response,
     ) {
         metrics::histogram!(
@@ -241,7 +227,7 @@ impl Metrics {
     pub fn record_data_var(
         elapsed: Duration,
         contract_name: SmartContract,
-        variable_name: DataVarName,
+        variable_name: ClarityName,
         response: &Response,
     ) {
         metrics::histogram!(
@@ -268,7 +254,7 @@ impl Metrics {
     pub fn record_map_entry(
         elapsed: Duration,
         contract_name: SmartContract,
-        map_name: ClarityMapName,
+        map_name: ClarityName,
         response: &Response,
     ) {
         metrics::histogram!(

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -58,6 +58,9 @@ pub enum Metrics {
     /// The amount of time, in seconds, it took for a call-read request to
     /// return from the stacks node.
     CallReadOnlyDurationSeconds,
+    /// The amount of time, in seconds, it took for to read a data variable
+    /// in a smart contract by making a request to the stacks node.
+    ReadDataVarDurationSeconds,
 }
 
 impl From<Metrics> for metrics::KeyName {
@@ -183,6 +186,27 @@ impl Metrics {
             Metrics::CallReadOnlyDurationSeconds,
             "contract_name" => contract_name,
             "function_name" => function_name,
+            "status_code" => response.status().as_u16().to_string(),
+            "blockchain" => STACKS_BLOCKCHAIN,
+        )
+        .record(elapsed);
+    }
+
+    /// Record the amount of time it took to complete a /v2/data_var
+    /// request from the stacks node.
+    pub fn record_data_var_duration(
+        elapsed: Duration,
+        contract_name: ContractName,
+        variable_name: ClarityName,
+        response: &Response,
+    ) {
+        let contract_name: String = contract_name.into();
+        let variable_name: String = variable_name.into();
+
+        metrics::histogram!(
+            Metrics::ReadDataVarDurationSeconds,
+            "contract_name" => contract_name,
+            "variable_name" => variable_name,
             "status_code" => response.status().as_u16().to_string(),
             "blockchain" => STACKS_BLOCKCHAIN,
         )

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -91,19 +91,19 @@ impl From<SmartContract> for metrics::SharedString {
 
 impl From<ReadOnlyFnName> for metrics::SharedString {
     fn from(value: ReadOnlyFnName) -> Self {
-        metrics::SharedString::const_str(value.into())
+        metrics::SharedString::const_str(value.0)
     }
 }
 
 impl From<ClarityMapName> for metrics::SharedString {
     fn from(value: ClarityMapName) -> Self {
-        metrics::SharedString::const_str(value.into())
+        metrics::SharedString::const_str(value.0)
     }
 }
 
 impl From<DataVarName> for metrics::SharedString {
     fn from(value: DataVarName) -> Self {
-        metrics::SharedString::const_str(value.into())
+        metrics::SharedString::const_str(value.0)
     }
 }
 

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -495,7 +495,7 @@ impl From<SmartContract> for proto::SmartContract {
             SmartContract::SbtcToken => proto::SmartContract::SbtcToken,
             SmartContract::SbtcDeposit => proto::SmartContract::SbtcDeposit,
             SmartContract::SbtcWithdrawal => proto::SmartContract::SbtcWithdrawal,
-            SmartContract::SbtcBootstrap => proto::SmartContract::SbtcBootstrap,
+            SmartContract::SbtcBootstrapSigners => proto::SmartContract::SbtcBootstrap,
         }
     }
 }
@@ -508,7 +508,7 @@ impl TryFrom<proto::SmartContract> for SmartContract {
             proto::SmartContract::SbtcToken => SmartContract::SbtcToken,
             proto::SmartContract::SbtcDeposit => SmartContract::SbtcDeposit,
             proto::SmartContract::SbtcWithdrawal => SmartContract::SbtcWithdrawal,
-            proto::SmartContract::SbtcBootstrap => SmartContract::SbtcBootstrap,
+            proto::SmartContract::SbtcBootstrap => SmartContract::SbtcBootstrapSigners,
             proto::SmartContract::Unspecified => return Err(Error::TypeConversion),
         })
     }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -97,29 +97,9 @@ const DUMMY_STX_TRANSFER_PAYLOAD: TransactionPayload = TransactionPayload::Token
 /// The names of all the read-only functions used in the signers for any of
 /// the sbtc smart contracts.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct ReadOnlyFnName(pub &'static str);
+pub struct ClarityName(pub &'static str);
 
-impl std::fmt::Display for ReadOnlyFnName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// A wrapper around the contract name string.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct ClarityMapName(pub &'static str);
-
-impl std::fmt::Display for ClarityMapName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-/// A wrapper around the contract name string.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct DataVarName(pub &'static str);
-
-impl std::fmt::Display for DataVarName {
+impl std::fmt::Display for ClarityName {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.0)
     }
@@ -689,7 +669,7 @@ impl StacksClient {
         &self,
         contract_principal: &StacksAddress,
         contract_name: SmartContract,
-        fn_name: ReadOnlyFnName,
+        fn_name: ClarityName,
         sender: &StacksAddress,
         arguments: &[Value],
     ) -> Result<Value, Error> {
@@ -757,7 +737,7 @@ impl StacksClient {
         &self,
         contract_principal: &StacksAddress,
         contract_name: SmartContract,
-        var_name: DataVarName,
+        var_name: ClarityName,
     ) -> Result<Value, Error> {
         let path = format!("/v2/data_var/{contract_principal}/{contract_name}/{var_name}?proof=0");
 
@@ -807,7 +787,7 @@ impl StacksClient {
         &self,
         contract_principal: &StacksAddress,
         contract_name: SmartContract,
-        map_name: ClarityMapName,
+        map_name: ClarityName,
         map_entry: &Value,
     ) -> Result<Option<Value>, Error> {
         let path = format!("/v2/map_entry/{contract_principal}/{contract_name}/{map_name}?proof=0");
@@ -1429,7 +1409,7 @@ impl StacksInteract for StacksClient {
             .call_read(
                 contract_principal,
                 SmartContract::SbtcRegistry,
-                ReadOnlyFnName(GET_SIGNER_SET_DATA_FN_NAME),
+                ClarityName(GET_SIGNER_SET_DATA_FN_NAME),
                 contract_principal,
                 &[],
             )
@@ -1477,7 +1457,7 @@ impl StacksInteract for StacksClient {
             .get_data_var(
                 contract_principal,
                 SmartContract::SbtcRegistry,
-                DataVarName(CURRENT_AGGREGATE_PUBKEY_DATA_VAR_NAME),
+                ClarityName(CURRENT_AGGREGATE_PUBKEY_DATA_VAR_NAME),
             )
             .await?;
 
@@ -1490,7 +1470,7 @@ impl StacksInteract for StacksClient {
         outpoint: &OutPoint,
     ) -> Result<bool, Error> {
         let contract_name = SmartContract::SbtcRegistry;
-        let fn_name = ReadOnlyFnName(GET_DEPOSIT_STATUS_FN_NAME);
+        let fn_name = ClarityName(GET_DEPOSIT_STATUS_FN_NAME);
 
         // The transaction IDs are written in little endian format when
         // making the contract call that sets the deposit status, so we
@@ -1522,7 +1502,7 @@ impl StacksInteract for StacksClient {
         request_id: u64,
     ) -> Result<bool, Error> {
         let contract_name = SmartContract::SbtcRegistry;
-        let map_name = ClarityMapName(WITHDRAWAL_STATUS_MAP_NAME);
+        let map_name = ClarityName(WITHDRAWAL_STATUS_MAP_NAME);
 
         let map_entry = Value::UInt(request_id as u128);
         let result = self
@@ -1686,7 +1666,7 @@ impl StacksInteract for StacksClient {
             .call_read(
                 deployer,
                 SmartContract::SbtcToken,
-                ReadOnlyFnName(GET_TOTAL_SUPPLY_FN_NAME),
+                ClarityName(GET_TOTAL_SUPPLY_FN_NAME),
                 deployer,
                 &[],
             )
@@ -2349,7 +2329,7 @@ mod tests {
                 &StacksAddress::from_string("ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM")
                     .expect("failed to parse stacks address"),
                 SmartContract::SbtcRegistry,
-                DataVarName("current-signer-set"),
+                ClarityName("current-signer-set"),
             )
             .await
             .unwrap();

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -94,8 +94,8 @@ const DUMMY_STX_TRANSFER_PAYLOAD: TransactionPayload = TransactionPayload::Token
     TokenTransferMemo([0; 34]),
 );
 
-/// The names of all the read-only functions used in the signers for any of
-/// the sbtc smart contracts.
+/// The names of all the read-only functions, data variables, and map names
+/// used in the signers for any of the sbtc smart contracts.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct ClarityName(pub &'static str);
 

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -77,7 +77,7 @@ const DUMMY_STX_TRANSFER_PAYLOAD: TransactionPayload = TransactionPayload::Token
 /// The names of all the read-only functions used in the signers for any of
 /// the sbtc smart contracts.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
-#[strum(serialize_all = "kebab_case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum ReadOnlyFnName {
     /// This is the name of the read-only function in the sbtc-registry smart
     /// contract that returns the status of a deposit request.
@@ -96,7 +96,7 @@ pub enum ReadOnlyFnName {
 
 /// A wrapper around the contract name string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
-#[strum(serialize_all = "kebab_case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum ClarityMapName {
     /// The name of the map in the sbtc-registry smart contract that
     /// stores the status of a withdrawal request.
@@ -105,7 +105,7 @@ pub enum ClarityMapName {
 
 /// A wrapper around the contract name string.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, strum::Display, strum::IntoStaticStr)]
-#[strum(serialize_all = "kebab_case")]
+#[strum(serialize_all = "kebab-case")]
 pub enum DataVarName {
     /// The name of the data variable in the sbtc-registry smart contract
     /// that stores the current aggregate public key of the signers.
@@ -725,7 +725,7 @@ impl StacksClient {
             .await
             .map_err(Error::StacksNodeRequest)?;
 
-        Metrics::record_call_read_duration(instant.elapsed(), contract_name, fn_name, &response);
+        Metrics::record_call_read(instant.elapsed(), contract_name, fn_name, &response);
 
         response
             .error_for_status()
@@ -772,7 +772,7 @@ impl StacksClient {
             .await
             .map_err(Error::StacksNodeRequest)?;
 
-        Metrics::record_data_var_duration(instant.elapsed(), contract_name, var_name, &response);
+        Metrics::record_data_var(instant.elapsed(), contract_name, var_name, &response);
 
         response
             .error_for_status()
@@ -829,7 +829,7 @@ impl StacksClient {
             .await
             .map_err(Error::StacksNodeRequest)?;
 
-        Metrics::record_map_entry_duration(instant.elapsed(), contract_name, map_name, &response);
+        Metrics::record_map_entry(instant.elapsed(), contract_name, map_name, &response);
         // It looks like the stacks node returns a 404 if the data is not
         // available, see
         // https://github.com/stacks-network/stacks-core/blob/c1a1f50fddcbc11054fae537103423e21221665a/stackslib/src/net/api/getmapentry.rs#L223-L225C22

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -687,7 +687,6 @@ impl StacksClient {
         );
 
         let instant = Instant::now();
-
         let response = self
             .client
             .post(url)

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1465,8 +1465,7 @@ impl RotateKeysErrorMsg {
 
 /// A wrapper type for smart contract deployment that implements
 /// AsTxPayload.
-#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, strum::Display)]
-#[strum(serialize_all = "kebab_case")]
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub enum SmartContract {
     /// The sbtc-registry contract. This contract needs to be deployed
@@ -1484,6 +1483,12 @@ pub enum SmartContract {
     /// The sbtc-bootstrap-signers contract. Can be deployed after the
     /// sbtc-token contract.
     SbtcBootstrapSigners,
+}
+
+impl std::fmt::Display for SmartContract {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.contract_name())
+    }
 }
 
 impl AsTxPayload for SmartContract {

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -72,7 +72,7 @@ pub const SMART_CONTRACTS: [SmartContract; 5] = [
     SmartContract::SbtcToken,
     SmartContract::SbtcDeposit,
     SmartContract::SbtcWithdrawal,
-    SmartContract::SbtcBootstrap,
+    SmartContract::SbtcBootstrapSigners,
 ];
 
 /// This struct is used as supplemental data to help validate a request to
@@ -1466,7 +1466,7 @@ impl RotateKeysErrorMsg {
 /// A wrapper type for smart contract deployment that implements
 /// AsTxPayload.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, strum::Display)]
-#[strum(serialize_all = "snake_case")]
+#[strum(serialize_all = "kebab_case")]
 #[cfg_attr(feature = "testing", derive(fake::Dummy))]
 pub enum SmartContract {
     /// The sbtc-registry contract. This contract needs to be deployed
@@ -1483,7 +1483,7 @@ pub enum SmartContract {
     SbtcWithdrawal,
     /// The sbtc-bootstrap-signers contract. Can be deployed after the
     /// sbtc-token contract.
-    SbtcBootstrap,
+    SbtcBootstrapSigners,
 }
 
 impl AsTxPayload for SmartContract {
@@ -1520,7 +1520,7 @@ impl SmartContract {
             SmartContract::SbtcRegistry => "sbtc-registry",
             SmartContract::SbtcDeposit => "sbtc-deposit",
             SmartContract::SbtcWithdrawal => "sbtc-withdrawal",
-            SmartContract::SbtcBootstrap => "sbtc-bootstrap-signers",
+            SmartContract::SbtcBootstrapSigners => "sbtc-bootstrap-signers",
         }
     }
 
@@ -1539,7 +1539,7 @@ impl SmartContract {
             SmartContract::SbtcWithdrawal => {
                 include_str!("../../../contracts/contracts/sbtc-withdrawal.clar")
             }
-            SmartContract::SbtcBootstrap => {
+            SmartContract::SbtcBootstrapSigners => {
                 include_str!("../../../contracts/contracts/sbtc-bootstrap-signers.clar")
             }
         }
@@ -1675,7 +1675,7 @@ mod tests {
         let _ = call.as_contract_call();
     }
 
-    #[test_case::test_case(SmartContract::SbtcBootstrap; "sbtc-bootstrap")]
+    #[test_case::test_case(SmartContract::SbtcBootstrapSigners; "sbtc-bootstrap")]
     #[test_case::test_case(SmartContract::SbtcRegistry; "sbtc-registry")]
     #[test_case::test_case(SmartContract::SbtcDeposit; "sbtc-deposit")]
     #[test_case::test_case(SmartContract::SbtcWithdrawal; "sbtc-withdrawal")]

--- a/signer/tests/devenv/devenv.rs
+++ b/signer/tests/devenv/devenv.rs
@@ -283,8 +283,8 @@ async fn get_sbtc_balance(
     let result = stacks_client
         .call_read(
             deployer,
-            &ContractName::from(SmartContract::SbtcToken.contract_name()),
-            &ClarityName::from("get-balance"),
+            ContractName::from(SmartContract::SbtcToken.contract_name()),
+            ClarityName::from("get-balance"),
             deployer,
             &[Value::Principal(address.clone())],
         )

--- a/signer/tests/devenv/devenv.rs
+++ b/signer/tests/devenv/devenv.rs
@@ -22,8 +22,6 @@ use bitcoin::XOnlyPublicKey;
 use bitcoin::absolute::LockTime;
 use bitcoin::transaction::Version;
 use bitvec::array::BitArray;
-use clarity::vm::ClarityName;
-use clarity::vm::ContractName;
 use clarity::vm::Value;
 use clarity::vm::types::PrincipalData;
 use fake::Fake as _;
@@ -39,6 +37,7 @@ use serde::de::DeserializeOwned;
 use serde_json::to_value;
 use signer::bitcoin::utxo::DepositRequest;
 use signer::error::Error;
+use signer::stacks::api::ReadOnlyFnName;
 use signer::stacks::contracts::SmartContract;
 use signer::storage::model::TaprootScriptHash;
 use std::sync::Arc;
@@ -283,8 +282,8 @@ async fn get_sbtc_balance(
     let result = stacks_client
         .call_read(
             deployer,
-            ContractName::from(SmartContract::SbtcToken.contract_name()),
-            ClarityName::from("get-balance"),
+            SmartContract::SbtcToken,
+            ReadOnlyFnName::GetBalance,
             deployer,
             &[Value::Principal(address.clone())],
         )

--- a/signer/tests/devenv/devenv.rs
+++ b/signer/tests/devenv/devenv.rs
@@ -37,7 +37,7 @@ use serde::de::DeserializeOwned;
 use serde_json::to_value;
 use signer::bitcoin::utxo::DepositRequest;
 use signer::error::Error;
-use signer::stacks::api::ReadOnlyFnName;
+use signer::stacks::api::ClarityName;
 use signer::stacks::contracts::SmartContract;
 use signer::storage::model::TaprootScriptHash;
 use std::sync::Arc;
@@ -283,7 +283,7 @@ async fn get_sbtc_balance(
         .call_read(
             deployer,
             SmartContract::SbtcToken,
-            ReadOnlyFnName("get-balance"),
+            ClarityName("get-balance"),
             deployer,
             &[Value::Principal(address.clone())],
         )

--- a/signer/tests/devenv/devenv.rs
+++ b/signer/tests/devenv/devenv.rs
@@ -283,7 +283,7 @@ async fn get_sbtc_balance(
         .call_read(
             deployer,
             SmartContract::SbtcToken,
-            ReadOnlyFnName::GetBalance,
+            ReadOnlyFnName("get-balance"),
             deployer,
             &[Value::Principal(address.clone())],
         )


### PR DESCRIPTION
## Description

## Changes

* Adds metrics around requests to the stacks node that call read-only functions, read data variables, and read map entries.
* Changed the function signatures to take ownership of the string types, since it should be slightly more efficient.

## Testing Information

~~I still need to check that this works on devenv.~~ Ran this branch on devenv and everything looked fine. The only thing that is not tested is the new `Metrics::record_data_var`, because we no longer read data variables after https://github.com/stacks-sbtc/sbtc/pull/1734. Also, we can probably remove that function, as well as remove `get_current_signers_aggregate_key`. Let's do that another day.

## Checklist

- [x] I have performed a self-review of my code
