### PR TITLE
fix: do not fetch bitcoin chain tip from db

### DIFF
--- a/signer/src/api/info.rs
+++ b/signer/src/api/info.rs
@@ -126,11 +126,12 @@ pub async fn info_handler<C: Context>(state: State<ApiState<C>>) -> InfoResponse
     let stacks_client = state.ctx.get_stacks_client();
     let storage = state.ctx.get_storage();
     let config = state.ctx.config();
+    let ctx = &state.ctx;
 
     let mut response = InfoResponse::default();
 
     response.populate_config_info(config);
-    response.populate_local_chain_info(&storage).await;
+    response.populate_local_chain_info(&storage, ctx).await;
     response.populate_bitcoin_node_info(&bitcoin_client).await;
     response.populate_stacks_node_info(&stacks_client).await;
     response
@@ -163,25 +164,11 @@ impl InfoResponse {
     }
 
     /// Populates the local Bitcoin and Stacks chain tip information.
-    async fn populate_local_chain_info(&mut self, storage: &impl DbRead) {
-        let bitcoin_tip = storage.get_bitcoin_canonical_chain_tip().await;
+    async fn populate_local_chain_info<C: Context, R: DbRead>(&mut self, storage: &R, ctx: &C) {
+        let bitcoin_tip = ctx.state().bitcoin_chain_tip();
 
         match bitcoin_tip {
-            Ok(Some(local_bitcoin_chain_tip)) => {
-                let bitcoin_block = storage
-                    .get_bitcoin_block(&local_bitcoin_chain_tip)
-                    .await
-                    .inspect_err(|error| {
-                        tracing::error!(%error, "error reading bitcoin block from the database")
-                    });
-
-                let Ok(Some(bitcoin_block)) = bitcoin_block else {
-                    tracing::error!(
-                        "canonical tip found but could not retrieve block from the database"
-                    );
-                    return;
-                };
-
+            Some(bitcoin_block) => {
                 self.bitcoin.signer_tip = Some(ChainTipInfo {
                     block_hash: bitcoin_block.block_hash,
                     block_height: bitcoin_block.block_height,
@@ -206,11 +193,8 @@ impl InfoResponse {
                     }
                 }
             }
-            Ok(None) => {
-                tracing::debug!("no local bitcoin tip found in the database.");
-            }
-            Err(error) => {
-                tracing::error!(%error, "error reading bitcoin tip from the database");
+            None => {
+                tracing::debug!("no local bitcoin tip found in the state");
             }
         }
     }

--- a/signer/src/api/info.rs
+++ b/signer/src/api/info.rs
@@ -194,7 +194,7 @@ impl InfoResponse {
                 }
             }
             None => {
-                tracing::debug!("no local bitcoin tip found in the state");
+                tracing::debug!("no local bitcoin tip found in the signer's state");
             }
         }
     }

--- a/signer/src/api/info.rs
+++ b/signer/src/api/info.rs
@@ -327,7 +327,7 @@ mod tests {
         error::Error,
         storage::{
             DbWrite,
-            model::{BitcoinBlock, StacksBlock},
+            model::{BitcoinBlock, BitcoinBlockRef, StacksBlock},
         },
         testing::context::*,
     };
@@ -446,6 +446,9 @@ mod tests {
 
         let bitcoin_block: BitcoinBlock = Faker.fake();
         storage.write_bitcoin_block(&bitcoin_block).await.unwrap();
+        context
+            .state()
+            .set_bitcoin_chain_tip(BitcoinBlockRef::from(&bitcoin_block));
 
         let stacks_block = StacksBlock {
             bitcoin_anchor: bitcoin_block.block_hash,

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -74,12 +74,10 @@ impl SignerState {
 
     /// Set the current bitcoin chain tip.
     pub fn set_bitcoin_chain_tip(&self, chain_tip: BitcoinBlockRef) {
-        let mut block = self
-            .bitcoin_chain_tip
+        self.bitcoin_chain_tip
             .write()
-            .expect("BUG: Failed to acquire write lock");
-
-        *block = Some(chain_tip);
+            .expect("BUG: Failed to acquire write lock")
+            .replace(chain_tip);
     }
 
     /// Get the current sBTC limits.

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -12,7 +12,6 @@ use libp2p::PeerId;
 
 use crate::keys::PublicKey;
 use crate::stacks::api::SignerSetInfo;
-use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinBlockHeight;
 use crate::storage::model::BitcoinBlockRef;
 
@@ -29,7 +28,7 @@ pub struct SignerState {
     is_sbtc_bitcoin_start_height_set: AtomicBool,
     // The current bitcoin chain tip. This gets updated at the end of the
     // block observer's duties when it observes a new bitcoin block.
-    bitcoin_chain_tip: RwLock<BitcoinBlockRef>,
+    bitcoin_chain_tip: RwLock<Option<BitcoinBlockRef>>,
 }
 
 impl SignerState {
@@ -66,7 +65,7 @@ impl SignerState {
     }
 
     /// Get the current bitcoin chain tip.
-    pub fn bitcoin_chain_tip(&self) -> BitcoinBlockRef {
+    pub fn bitcoin_chain_tip(&self) -> Option<BitcoinBlockRef> {
         self.bitcoin_chain_tip
             .read()
             .expect("BUG: Failed to acquire read lock")
@@ -80,7 +79,7 @@ impl SignerState {
             .write()
             .expect("BUG: Failed to acquire write lock");
 
-        *block = chain_tip;
+        *block = Some(chain_tip);
     }
 
     /// Get the current sBTC limits.
@@ -142,10 +141,7 @@ impl Default for SignerState {
             is_sbtc_bitcoin_start_height_set: Default::default(),
             // The block hash here is often used as the parent block hash
             // of the genesis block on bitcoin.
-            bitcoin_chain_tip: RwLock::new(BitcoinBlockRef {
-                block_height: 0u64.into(),
-                block_hash: BitcoinBlockHash::from([0; 32]),
-            }),
+            bitcoin_chain_tip: RwLock::new(None),
         }
     }
 }

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -65,6 +65,7 @@ impl SignerState {
     }
 
     /// Get the current bitcoin chain tip.
+    #[allow(clippy::unwrap_in_result)]
     pub fn bitcoin_chain_tip(&self) -> Option<BitcoinBlockRef> {
         self.bitcoin_chain_tip
             .read()

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -680,6 +680,11 @@ pub enum Error {
     #[error("no bitcoin chain tip")]
     NoChainTip,
 
+    /// The given block hash could not be found in the database when doing
+    /// a DbRead::get_bitcoin_block call.
+    #[error("the given block hash could not be found in the database: {0}")]
+    UnknownBitcoinBlock(bitcoin::BlockHash),
+
     /// No stacks chain tip found.
     #[error("no stacks chain tip")]
     NoStacksChainTip,

--- a/signer/src/request_decider.rs
+++ b/signer/src/request_decider.rs
@@ -134,10 +134,12 @@ where
         }
 
         let db = self.context.get_storage();
-        let chain_tip = db
-            .get_bitcoin_canonical_chain_tip()
-            .await?
-            .ok_or(Error::NoChainTip)?;
+        let chain_tip = self
+            .context
+            .state()
+            .bitcoin_chain_tip()
+            .ok_or(Error::NoChainTip)?
+            .block_hash;
 
         let signer_public_key = self.signer_public_key();
 

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -66,11 +66,13 @@ pub trait DbRead {
     ) -> impl Future<Output = Result<Option<model::StacksBlock>, Error>> + Send;
 
     /// Get the bitcoin canonical chain tip.
+    #[cfg(any(test, feature = "testing"))]
     fn get_bitcoin_canonical_chain_tip(
         &self,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlockHash>, Error>> + Send;
 
     /// Get the bitcoin canonical chain tip.
+    #[cfg(any(test, feature = "testing"))]
     fn get_bitcoin_canonical_chain_tip_ref(
         &self,
     ) -> impl Future<Output = Result<Option<model::BitcoinBlockRef>, Error>> + Send;

--- a/signer/src/storage/postgres/read.rs
+++ b/signer/src/storage/postgres/read.rs
@@ -721,6 +721,7 @@ impl PgRead {
         .map_err(Error::SqlxQuery)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     pub async fn get_bitcoin_canonical_chain_tip<'e, E>(
         executor: &'e mut E,
     ) -> Result<Option<model::BitcoinBlockHash>, Error>
@@ -742,6 +743,7 @@ impl PgRead {
         .map_err(Error::SqlxQuery)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_bitcoin_canonical_chain_tip_ref<'e, E>(
         executor: &'e mut E,
     ) -> Result<Option<model::BitcoinBlockRef>, Error>
@@ -2531,12 +2533,14 @@ impl DbRead for PgStore {
         PgRead::get_stacks_block(self.get_connection().await?.as_mut(), block_hash).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_bitcoin_canonical_chain_tip(
         &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Error> {
         PgRead::get_bitcoin_canonical_chain_tip(self.get_connection().await?.as_mut()).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_bitcoin_canonical_chain_tip_ref(
         &self,
     ) -> Result<Option<model::BitcoinBlockRef>, Error> {
@@ -2955,6 +2959,7 @@ impl DbRead for PgTransaction<'_> {
         PgRead::get_stacks_block(self.tx.lock().await.as_mut(), block_hash).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_bitcoin_canonical_chain_tip(
         &self,
     ) -> Result<Option<model::BitcoinBlockHash>, Error> {
@@ -2962,6 +2967,7 @@ impl DbRead for PgTransaction<'_> {
         PgRead::get_bitcoin_canonical_chain_tip(tx.as_mut()).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_bitcoin_canonical_chain_tip_ref(
         &self,
     ) -> Result<Option<model::BitcoinBlockRef>, Error> {

--- a/signer/src/testing/request_decider.rs
+++ b/signer/src/testing/request_decider.rs
@@ -177,6 +177,15 @@ where
         let test_data = self.generate_test_data(&mut rng, signer_set);
         Self::write_test_data(&handle.context.get_storage_mut(), &test_data).await;
 
+        let chain_tip_ref = handle
+            .context
+            .get_storage()
+            .get_bitcoin_canonical_chain_tip_ref()
+            .await
+            .unwrap()
+            .unwrap();
+        handle.context.state().set_bitcoin_chain_tip(chain_tip_ref);
+
         let group_key = PublicKey::combine_keys(signer_set).unwrap();
         store_dummy_dkg_shares(
             &mut rng,
@@ -262,6 +271,15 @@ where
         let signer_set = &coordinator_signer_info.signer_public_keys;
         let test_data = self.generate_test_data(&mut rng, signer_set);
         Self::write_test_data(&handle.context.get_storage_mut(), &test_data).await;
+
+        let chain_tip_ref = handle
+            .context
+            .get_storage()
+            .get_bitcoin_canonical_chain_tip_ref()
+            .await
+            .unwrap()
+            .unwrap();
+        handle.context.state().set_bitcoin_chain_tip(chain_tip_ref);
 
         handle
             .context
@@ -350,6 +368,15 @@ where
         let test_data = self.generate_test_data(&mut rng, signer_set);
         for handle in event_loop_handles.iter_mut() {
             test_data.write_to(&handle.context.get_storage_mut()).await;
+
+            let chain_tip_ref = handle
+                .context
+                .get_storage()
+                .get_bitcoin_canonical_chain_tip_ref()
+                .await
+                .unwrap()
+                .unwrap();
+            handle.context.state().set_bitcoin_chain_tip(chain_tip_ref);
 
             let group_key = PublicKey::combine_keys(signer_set).unwrap();
             store_dummy_dkg_shares(

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -786,7 +786,7 @@ where
         );
 
         for req in swept_deposits {
-            if &self.context.state().bitcoin_chain_tip() != chain_tip {
+            if self.context.state().bitcoin_chain_tip().as_ref() != Some(chain_tip) {
                 tracing::info!("new bitcoin chain tip, stopping coordinator activities");
                 return Ok(());
             }
@@ -886,7 +886,7 @@ where
         );
 
         for swept_request in swept_withdrawals {
-            if &self.context.state().bitcoin_chain_tip() != chain_tip {
+            if self.context.state().bitcoin_chain_tip().as_ref() != Some(chain_tip) {
                 tracing::info!("new bitcoin chain tip, stopping coordinator activities");
                 return Ok(());
             }
@@ -909,7 +909,7 @@ where
         }
 
         for withdrawal in rejected_withdrawals {
-            if &self.context.state().bitcoin_chain_tip() != chain_tip {
+            if self.context.state().bitcoin_chain_tip().as_ref() != Some(chain_tip) {
                 tracing::info!("new bitcoin chain tip, stopping coordinator activities");
                 return Ok(());
             }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -304,9 +304,8 @@ where
 
         let bitcoin_chain_tip = self
             .context
-            .get_storage()
-            .get_bitcoin_canonical_chain_tip_ref()
-            .await?
+            .state()
+            .bitcoin_chain_tip()
             .ok_or(Error::NoChainTip)?;
 
         let span = tracing::Span::current();

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -385,9 +385,10 @@ where
     ) -> Result<MsgChainTipReport, Error> {
         let storage = self.context.get_storage();
 
-        let chain_tip = storage
-            .get_bitcoin_canonical_chain_tip_ref()
-            .await?
+        let chain_tip = self
+            .context
+            .state()
+            .bitcoin_chain_tip()
             .ok_or(Error::NoChainTip)?;
 
         let is_known = storage

--- a/signer/tests/integration/request_decider.rs
+++ b/signer/tests/integration/request_decider.rs
@@ -452,6 +452,13 @@ async fn blocklist_client_retry(num_failures: u8, failing_iters: u8) {
     let chain_tip: BitcoinBlockHash = setup.sweep_block_hash.into();
     backfill_bitcoin_blocks(&db, rpc, &chain_tip).await;
 
+    let chain_tip_ref = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+    ctx.state().set_bitcoin_chain_tip(chain_tip_ref);
+
     // We need to store the deposit request because of the foreign key
     // constraint on the deposit_signers table.
     setup.store_deposit_request(&db).await;
@@ -572,6 +579,13 @@ async fn do_not_procceed_with_blocked_addresses(is_withdrawal: bool, is_blocked:
     // Let's get the blockchain data into the database.
     let chain_tip: BitcoinBlockHash = setup.sweep_block_hash.into();
     backfill_bitcoin_blocks(&db, rpc, &chain_tip).await;
+
+    let chain_tip_ref = db
+        .get_bitcoin_canonical_chain_tip_ref()
+        .await
+        .unwrap()
+        .unwrap();
+    ctx.state().set_bitcoin_chain_tip(chain_tip_ref);
 
     if is_withdrawal {
         // For withdrawals we can store only request and dkg shares

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -938,6 +938,13 @@ async fn run_dkg_from_scratch() {
 
         let network = network.connect(&ctx);
 
+        let chain_tip_ref = db
+            .get_bitcoin_canonical_chain_tip_ref()
+            .await
+            .unwrap()
+            .unwrap();
+        ctx.state().set_bitcoin_chain_tip(chain_tip_ref);
+
         signers.push((ctx, db, kp, network));
     }
 
@@ -1335,6 +1342,13 @@ async fn run_subsequent_dkg() {
         .await;
 
         let network = network.connect(&ctx);
+
+        let chain_tip_ref = db
+            .get_bitcoin_canonical_chain_tip_ref()
+            .await
+            .unwrap()
+            .unwrap();
+        ctx.state().set_bitcoin_chain_tip(chain_tip_ref);
 
         signers.push((ctx, db, kp, network));
     }
@@ -5142,6 +5156,7 @@ async fn should_handle_dkg_coordination_failure() {
     context
         .state()
         .update_current_signer_set(signer_keys.clone());
+    context.state().set_bitcoin_chain_tip(chain_tip);
 
     // Mock the stacks client to handle contract source checks
     context


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1770

## Changes

* Change the state object for the bitcoin chain tip to be an `Option<BitcoinBlockRef>` instead of a `BitcoinBlockRef`.
* Make it so that the `get_bitcoin_canonical_chain_tip_ref` and `get_bitcoin_canonical_chain_tip` queries only compile during our tests.
* Use the `SignerState` object for getting the bitcoin chain tip.

## Testing Information

I will spin up devenv and check that everything works as expected.

## Checklist

- [x] I have performed a self-review of my code
