### PR TITLE
Avoid Rerunning DKG (draft)

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2547,7 +2547,9 @@ pub async fn should_coordinate_dkg(
     // instead of doing new DKG rounds. If we fail to do so they will eventually
     // be marked as failed, and we will resume DKG-ing.
     let latest_dkg_shares = storage.get_latest_encrypted_dkg_shares().await?;
-    if latest_dkg_shares.map(|s| s.dkg_shares_status) == Some(model::DkgSharesStatus::Unverified) {
+    if latest_dkg_shares.as_ref().map(|s| s.dkg_shares_status)
+        == Some(model::DkgSharesStatus::Unverified)
+    {
         tracing::debug!("latest shares are unverified; skipping DKG");
         return Ok(false);
     }


### PR DESCRIPTION
## Description
This PR aims to reduce the amount of unnecessary DKGs ran while rotating keys. If there's a rotate key event & we have already verified those shares, then we should skip DKG.

This is currently in draft as a WIP for a sanity check, will add tests shortly.

Closes: #1720 

## Changes
For now the sole change is to the 'should_coordinate_dkg' function found in signer/src/transaction_coordinator.rs.

## Testing Information
No tests for now, in draft as a sanity check.

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
