### PR TITLE
feat: forgo unnecessary db query when fetching pending deposits

### DIFF
--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -102,7 +102,7 @@ pub trait DbRead {
     /// that generated the aggregate key locking the deposit.
     fn get_pending_accepted_deposit_requests(
         &self,
-        chain_tip: &model::BitcoinBlockHash,
+        chain_tip: &model::BitcoinBlockRef,
         context_window: u16,
         signatures_required: u16,
     ) -> impl Future<Output = Result<Vec<model::DepositRequest>, Error>> + Send;

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2092,7 +2092,7 @@ where
         // done by the storage layer.
         let pending_deposit_requests = storage
             .get_pending_accepted_deposit_requests(
-                params.bitcoin_chain_tip.as_ref(),
+                params.bitcoin_chain_tip,
                 context_window,
                 params.signature_threshold,
             )


### PR DESCRIPTION
## Description

I just noticed that we made an unnecessary database call. It happens at most once per bitcoin block, so no big deal, but figured we should do without it anyway.

## Changes

* Changed the type signature of `get_pending_accepted_deposit_requests` to take a `BitcoinBlockRef` instead of a `BitcoinBlockHash` so that we can forgo the database call.

## Testing Information

I'm not sure what tests should be added. If I think of something, I'll add it.

## Checklist

- [x] I have performed a self-review of my code
