### PR TITLE
feat: set the sign and dkg IDs in wsts coordinator state machines

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -1599,7 +1599,7 @@ where
     where
         Coordinator: WstsCoordinator,
     {
-        let outbound = coordinator.start_signing_round(msg, signature_type)?;
+        let outbound = coordinator.start_signing_round(msg, bitcoin_chain_tip, signature_type)?;
 
         // We create a signal stream before sending a message so that there
         // is no race condition with the steam and the getting a response.

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -338,7 +338,7 @@ where
         let should_coordinate_dkg =
             should_coordinate_dkg(&self.context, &bitcoin_chain_tip).await?;
         let aggregate_key = if should_coordinate_dkg {
-            match self.coordinate_dkg(bitcoin_chain_tip.as_ref()).await {
+            match self.coordinate_dkg(&bitcoin_chain_tip).await {
                 Ok(key) => key,
                 Err(error) => {
                     tracing::error!(%error, "failed to coordinate DKG; using existing aggregate key");
@@ -1632,9 +1632,10 @@ where
     #[tracing::instrument(skip_all)]
     async fn coordinate_dkg(
         &mut self,
-        chain_tip: &model::BitcoinBlockHash,
+        chain_tip: &model::BitcoinBlockRef,
     ) -> Result<PublicKey, Error> {
         tracing::info!("Coordinating DKG");
+        let block_hash = chain_tip.block_hash;
         // Get the current signer set for running DKG.
         let signer_set = self.context.config().signer.bootstrap_signing_set.clone();
 
@@ -1642,6 +1643,7 @@ where
 
         // Okay let's move the coordinator state machine to the beginning
         // of the DKG phase.
+        state_machine.current_dkg_id = *chain_tip.block_height;
         state_machine
             .move_to(WstsCoordinatorState::DkgPublicDistribute)
             .map_err(Error::wsts_coordinator)?;
@@ -1650,10 +1652,7 @@ where
             .start_public_shares()
             .map_err(Error::wsts_coordinator)?;
 
-        // We identify the DKG round by a 32-byte hash based on the coordinator
-        // identity and current bitcoin chain tip.
-        let identifier = self.coordinator_id(chain_tip);
-        let id = WstsMessageId::Dkg(identifier);
+        let id = WstsMessageId::Dkg(chain_tip.block_hash.into_bytes());
         let msg = message::WstsMessage { id, inner: outbound.msg };
 
         // We create a signal stream before sending a message so that there
@@ -1667,12 +1666,12 @@ where
         // running on the signers will pick up this message and act on it,
         // including our own. When they do they create a signing state
         // machine and begin DKG.
-        self.send_message(msg, chain_tip).await?;
+        self.send_message(msg, &block_hash).await?;
 
         // Now that DKG has "begun" we need to drive it to completion.
         let max_duration = self.dkg_max_duration;
         let dkg_fut =
-            self.drive_wsts_state_machine(signal_stream, chain_tip, &mut state_machine, id);
+            self.drive_wsts_state_machine(signal_stream, &block_hash, &mut state_machine, id);
 
         let operation_result = tokio::time::timeout(max_duration, dkg_fut)
             .await
@@ -2191,16 +2190,6 @@ where
             sbtc_limits,
             max_deposits_per_bitcoin_tx,
         }))
-    }
-
-    /// This function provides a deterministic 32-byte identifier for the
-    /// signer.
-    fn coordinator_id(&self, chain_tip: &model::BitcoinBlockHash) -> [u8; 32] {
-        sha2::Sha256::new_with_prefix("SIGNER_COORDINATOR_ID")
-            .chain_update(self.signer_public_key().serialize())
-            .chain_update(chain_tip.into_bytes())
-            .finalize()
-            .into()
     }
 
     /// Takes a [`Payload`], converts it to a [`Message`], signs it with the

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -94,12 +94,13 @@ fn construct_signing_round_id(message: &[u8], bitcoin_chain_tip: &BitcoinBlockHa
         .finalize()
         .into();
 
-    // Use the first 8 bytes of the digest to create a u64 index. Since `digest`
-    // is 64 bytes and we explicitly take the first 8 bytes, this is safe.
+    // Use the first 8 bytes of the digest to create a u64 index. Since
+    // `digest` is 32 bytes and we explicitly take the first 8 bytes, this
+    // is safe.
     #[allow(clippy::expect_used)]
     let u64_bytes: [u8; 8] = digest[..8]
         .try_into()
-        .expect("BUG: failed to take first 4 bytes of digest");
+        .expect("BUG: failed to take first 8 bytes of digest");
 
     u64::from_le_bytes(u64_bytes)
 }

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -88,7 +88,7 @@ impl From<SigHash> for StateMachineId {
 /// The signing round id is a u64 that is used to identify the signing round.
 /// It is constructed by hashing the message and bitcoin chain tip together.
 /// The first 8 bytes of the hash are used as the u64.
-fn construct_signing_round_id(message: &[u8], bitcoin_chain_tip: &BitcoinBlockHash) -> u64 {
+pub fn construct_signing_round_id(message: &[u8], bitcoin_chain_tip: &BitcoinBlockHash) -> u64 {
     let digest: [u8; 32] = Sha256::new()
         .chain_update(message)
         .chain_update(bitcoin_chain_tip.into_bytes())

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -57,7 +57,10 @@ use signer::bitcoin::utxo::Fees;
 use signer::bitcoin::utxo::TxDeconstructor as _;
 use signer::bitcoin::validation::WithdrawalValidationResult;
 use signer::block_observer;
+use signer::context::P2PEvent;
 use signer::context::RequestDeciderEvent;
+use signer::context::SignerEvent;
+use signer::context::SignerSignal;
 use signer::message::Payload;
 use signer::network::MessageTransfer;
 use signer::stacks::api::SignerSetInfo;
@@ -76,6 +79,7 @@ use signer::transaction_coordinator::given_key_is_coordinator;
 use signer::transaction_coordinator::should_coordinate_dkg;
 use signer::transaction_signer::STACKS_SIGN_REQUEST_LRU_SIZE;
 use signer::transaction_signer::assert_allow_dkg_begin;
+use signer::wsts_state_machine::construct_signing_round_id;
 use testing_emily_client::apis::chainstate_api;
 use testing_emily_client::apis::testing_api;
 use testing_emily_client::apis::withdrawal_api;
@@ -1470,6 +1474,352 @@ async fn run_subsequent_dkg() {
     assert_eq!(contract_call.function_args, rotate_keys.as_contract_args());
 
     for (_ctx, db, _, _) in signers {
+        testing::storage::drop_db(db).await;
+    }
+}
+
+/// Test that three dkg_id and sign_id are set correctly during DKG and
+/// signing rounds.
+///
+/// The test setup is as follows:
+/// 1. There are three "signers" contexts. Each context points to its own
+///    real postgres database, and they have their own private key. Each
+///    database is populated with the same data.
+/// 2. Each context is given to a block observer, a tx signer, and a tx
+///    coordinator, where these event loops are spawned as separate tasks.
+/// 3. The signers communicate with our in-memory network struct.
+/// 4. A real Emily server is running in the background.
+/// 5. A real bitcoin-core node is running in the background.
+/// 6. Stacks-core is mocked.
+///
+/// After the setup, the signers observe a bitcoin block and update their
+/// databases. The coordinator then constructs a bitcoin transaction and
+/// gets it signed. After it is signed the coordinator broadcasts it to
+/// bitcoin-core.
+///
+/// To start the test environment do:
+/// ```bash
+/// make integration-env-up-ci
+/// ```
+///
+/// then, once everything is up and running, run the test.
+#[tokio::test]
+async fn wsts_ids_set_during_dkg_and_signing_rounds() {
+    let (_, signer_key_pairs): (_, [Keypair; 3]) = testing::wallet::regtest_bootstrap_wallet();
+    let (rpc, faucet) = regtest::initialize_blockchain();
+
+    signer::logging::setup_logging("info,signer=debug", false);
+    // We need to populate our databases, so let's fetch the data.
+    let emily_client = EmilyClient::try_new(
+        &Url::parse("http://testApiKey@localhost:3031").unwrap(),
+        Duration::from_secs(1),
+        None,
+    )
+    .unwrap();
+
+    testing_api::wipe_databases(&emily_client.config().as_testing())
+        .await
+        .unwrap();
+
+    let network = WanNetwork::default();
+
+    let chain_tip_info = get_canonical_chain_tip(rpc);
+
+    // =========================================================================
+    // Step 1 - Create a database, an associated context, and a Keypair for
+    //          each of the signers in the signing set.
+    // -------------------------------------------------------------------------
+    // - We load the database with a bitcoin blocks going back to some
+    //   genesis block.
+    // =========================================================================
+    let mut signers = Vec::new();
+    for kp in signer_key_pairs.iter() {
+        let db = testing::storage::new_test_database().await;
+        let ctx = TestContext::builder()
+            .with_storage(db.clone())
+            .with_first_bitcoin_core_client()
+            .with_emily_client(emily_client.clone())
+            .with_mocked_stacks_client()
+            .build();
+
+        backfill_bitcoin_blocks(&db, rpc, &chain_tip_info.hash).await;
+
+        let network = network.connect(&ctx);
+
+        signers.push((ctx, db, kp, network));
+    }
+
+    // =========================================================================
+    // Step 2 - Setup the stacks client mocks.
+    // -------------------------------------------------------------------------
+    // - Set up the mocks to that the block observer fetches at least one
+    //   Stacks block. This is necessary because we need the stacks chain
+    //   tip in the transaction coordinator.
+    // - Set up the current-aggregate-key response to be `None`. This means
+    //   that each coordinator will broadcast a rotate keys transaction.
+    // =========================================================================
+    let (broadcast_stacks_tx, _rx) = tokio::sync::broadcast::channel(10);
+
+    for (ctx, db, _, _) in signers.iter_mut() {
+        let broadcast_stacks_tx = broadcast_stacks_tx.clone();
+        let db = db.clone();
+
+        mock_stacks_core(ctx, chain_tip_info.clone(), db, broadcast_stacks_tx).await;
+    }
+
+    // =========================================================================
+    // Step 3 - Start the TxCoordinatorEventLoop, TxSignerEventLoop and
+    //          BlockObserver processes for each signer.
+    // -------------------------------------------------------------------------
+    // - We only proceed with the test after all processes have started, and
+    //   we use a counter to notify us when that happens.
+    // =========================================================================
+    let start_count = Arc::new(AtomicU8::new(0));
+
+    for (ctx, _, kp, network) in signers.iter() {
+        ctx.state().set_sbtc_contracts_deployed();
+        let ev = TxCoordinatorEventLoop {
+            network: network.spawn(),
+            context: ctx.clone(),
+            context_window: 10000,
+            private_key: kp.secret_key().into(),
+            signing_round_max_duration: Duration::from_secs(10),
+            bitcoin_presign_request_max_duration: Duration::from_secs(10),
+            threshold: ctx.config().signer.bootstrap_signatures_required,
+            dkg_max_duration: Duration::from_secs(10),
+            is_epoch3: true,
+        };
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            ev.run().await
+        });
+
+        let ev = TxSignerEventLoop {
+            network: network.spawn(),
+            threshold: ctx.config().signer.bootstrap_signatures_required as u32,
+            context: ctx.clone(),
+            context_window: 10000,
+            wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
+            signer_private_key: kp.secret_key().into(),
+            rng: rand::rngs::OsRng,
+            last_presign_block: None,
+            dkg_begin_pause: None,
+            dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
+            stacks_sign_request: LruCache::new(STACKS_SIGN_REQUEST_LRU_SIZE),
+        };
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            ev.run().await
+        });
+
+        let ev = RequestDeciderEventLoop {
+            network: network.spawn(),
+            context: ctx.clone(),
+            context_window: 10000,
+            deposit_decisions_retry_window: 1,
+            withdrawal_decisions_retry_window: 1,
+            blocklist_checker: Some(()),
+            signer_private_key: kp.secret_key().into(),
+        };
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            ev.run().await
+        });
+
+        let block_observer = BlockObserver {
+            context: ctx.clone(),
+            bitcoin_blocks: testing::btc::new_zmq_block_hash_stream(BITCOIN_CORE_ZMQ_ENDPOINT)
+                .await,
+        };
+        let counter = start_count.clone();
+        tokio::spawn(async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            block_observer.run().await
+        });
+    }
+
+    while start_count.load(Ordering::SeqCst) < 12 {
+        Sleep::for_millis(10).await;
+    }
+
+    // =========================================================================
+    // Step 4 - Wait for DKG
+    // -------------------------------------------------------------------------
+    // - Once they are all running, generate a bitcoin block to kick off
+    //   the database updating process.
+    // - After they have the same view of the canonical bitcoin blockchain,
+    //   the signers should all participate in DKG.
+    // =========================================================================
+    let (ctx, db, _, _) = signers.first().unwrap();
+    let stream = BroadcastStream::new(ctx.get_signal_receiver());
+
+    let block_hash = faucet.generate_block();
+    wait_for_signers(&signers).await;
+
+    let wsts_message_filter = |msg| {
+        let Ok(SignerSignal::Event(SignerEvent::P2P(P2PEvent::MessageReceived(msg)))) = msg else {
+            return std::future::ready(None);
+        };
+
+        let Payload::WstsMessage(wsts_msg) = msg.inner.payload else {
+            return std::future::ready(None);
+        };
+
+        std::future::ready(Some(wsts_msg))
+    };
+
+    let wsts_messages = stream
+        .take_until(tokio::time::sleep(Duration::from_secs(1)))
+        .filter_map(wsts_message_filter)
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(!wsts_messages.is_empty());
+
+    let header = rpc.get_block_header_info(&block_hash).unwrap();
+
+    // Let's make sure the DKG ID matched what we expected it to be, which
+    // is the block height of the most recent bitcoin block. We do not
+    // check the sign ID here because these messages should pertain to DKG.
+    // Right now we use the FROST coordinator for the signing round of DKG
+    // and we do not set the sign ID for the FROST coordinator.
+    wsts_messages.iter().for_each(|msg| {
+        let dkg_id = match &msg.inner {
+            wsts::net::Message::DkgBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgEndBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgEnd(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPrivateBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPrivateShares(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPublicShares(msg) => msg.dkg_id,
+            wsts::net::Message::NonceRequest(msg) => msg.dkg_id,
+            wsts::net::Message::NonceResponse(msg) => msg.dkg_id,
+            wsts::net::Message::SignatureShareRequest(msg) => msg.dkg_id,
+            wsts::net::Message::SignatureShareResponse(msg) => msg.dkg_id,
+        };
+
+        assert_eq!(dkg_id, header.height as u64);
+    });
+
+    let shares = db.get_latest_encrypted_dkg_shares().await.unwrap().unwrap();
+
+    // =========================================================================
+    // Step 5 - Prepare for deposits
+    // -------------------------------------------------------------------------
+    // - Before the signers can process anything, they need a UTXO to call
+    //   their own. For that we make a donation, and confirm it. The
+    //   signers should pick it up.
+    // - Give a "depositor" some UTXOs so that they can make a deposit for
+    //   sBTC.
+    // =========================================================================
+    let script_pub_key = shares.aggregate_key.signers_script_pubkey();
+    let network = bitcoin::Network::Regtest;
+    let address = Address::from_script(&script_pub_key, network).unwrap();
+
+    faucet.send_to(100_000, &address);
+
+    let depositor = Recipient::new(AddressType::P2tr);
+
+    // Start off with some initial UTXOs to work with.
+
+    faucet.send_to(50_000_000, &depositor.address);
+    faucet.generate_block();
+    wait_for_signers(&signers).await;
+
+    // =========================================================================
+    // Step 6 - Make a proper deposit
+    // -------------------------------------------------------------------------
+    // - Use the UTXOs confirmed in step (5) to construct a proper deposit
+    //   request transaction. Submit it and inform Emily about it.
+    // =========================================================================
+    // Now lets make a deposit transaction and submit it
+    let utxo = depositor.get_utxos(rpc, None).pop().unwrap();
+
+    let amount = 2_500_000;
+    let signers_public_key = shares.aggregate_key.into();
+    let max_fee = amount / 2;
+    let (deposit_tx, deposit_request, _) =
+        make_deposit_request(&depositor, amount, utxo, max_fee, signers_public_key);
+    rpc.send_raw_transaction(&deposit_tx).unwrap();
+
+    assert_eq!(deposit_tx.compute_txid(), deposit_request.outpoint.txid);
+
+    let body = deposit_request.as_emily_request(&deposit_tx);
+    let _ = deposit_api::create_deposit(emily_client.config(), body)
+        .await
+        .unwrap();
+
+    // =========================================================================
+    // Step 7 - Confirm the deposit and wait for the signers to do their
+    //          job.
+    // -------------------------------------------------------------------------
+    // - Confirm the deposit request. This will trigger the block observer
+    //   to reach out to Emily about deposits. It will have one so the
+    //   signers should do basic validations and store the deposit request.
+    // - Each TxSigner process should vote on the deposit request and
+    //   submit the votes to each other.
+    // - The coordinator should submit a sweep transaction. We check the
+    //   mempool for its existence.
+    // =========================================================================
+    let stream = BroadcastStream::new(ctx.get_signal_receiver());
+    let block_hash: BitcoinBlockHash = faucet.generate_block().into();
+    wait_for_signers(&signers).await;
+
+    let txids = ctx.bitcoin_client.inner_client().get_raw_mempool().unwrap();
+    assert_eq!(txids.len(), 1);
+
+    // =========================================================================
+    // Step 8 - Check that the WSTS messages have the expected dkg_id and
+    //          sign_id
+    // =========================================================================
+    let wsts_messages = stream
+        .take_until(tokio::time::sleep(Duration::from_secs(1)))
+        .filter_map(wsts_message_filter)
+        .collect::<Vec<_>>()
+        .await;
+
+    assert!(!wsts_messages.is_empty());
+
+    let chain_tip_header = rpc.get_block_header_info(&block_hash).unwrap();
+
+    // Let's check that all of the sign IDs for these signing rounds are the
+    // expected value.
+    for msg in wsts_messages.iter() {
+        let dkg_id = match &msg.inner {
+            wsts::net::Message::DkgBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgEndBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgEnd(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPrivateBegin(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPrivateShares(msg) => msg.dkg_id,
+            wsts::net::Message::DkgPublicShares(msg) => msg.dkg_id,
+            wsts::net::Message::NonceRequest(msg) => msg.dkg_id,
+            wsts::net::Message::NonceResponse(msg) => msg.dkg_id,
+            wsts::net::Message::SignatureShareRequest(msg) => msg.dkg_id,
+            wsts::net::Message::SignatureShareResponse(msg) => msg.dkg_id,
+        };
+
+        // The DKG ID set here should be the height associated with the
+        // original block when DKG was run.
+        assert_eq!(dkg_id, header.height as u64);
+        more_asserts::assert_lt!(dkg_id, chain_tip_header.height as u64);
+
+        let (sign_id, message) = match &msg.inner {
+            wsts::net::Message::NonceRequest(msg) => (msg.sign_id, msg.message.clone()),
+            wsts::net::Message::NonceResponse(msg) => (msg.sign_id, msg.message.clone()),
+            wsts::net::Message::SignatureShareRequest(msg) => (msg.sign_id, msg.message.clone()),
+            _ => continue,
+        };
+
+        let expected_sign_id = construct_signing_round_id(&message, &block_hash);
+        // When the WSTS coordinator state machine starts a new signing
+        // round, it automatically increments the sign ID by 1. So we
+        // adjust our expectations here.
+        assert_eq!(sign_id - 1, expected_sign_id);
+    }
+
+    for (_, db, _, _) in signers {
         testing::storage::drop_db(db).await;
     }
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1177 and closes https://github.com/stacks-sbtc/sbtc/issues/1775.

## Changes

* Set the `dkg_id` in the WSTS state machines. The `dkg_id` is set to the bitcoin block height associated with the DKG round that generated the keys.
* Set the `sign_id` during all signing rounds. It is set to the first 8 bytes of the SHA-256 of the message and the bitcoin chain tip at the time that the signing round took place.

These values are only set in the coordinator state machine and are inherited in the signer state machine. This ends up being okay, since out checks in the tx-signer is validation that we would do in the state machine.

### Notes

We do not set the `sign_id` in the FROST coordinator because that field is private there. This is okay, because I want to remove our use of the FROST coordinator (and remove it generally https://github.com/stacks-sbtc/wsts/issues/180), which we can do once https://github.com/stacks-sbtc/wsts/issues/174 is done.

Also, WSTS internally changes the sign ID for you, which is kinda helpful but not at the same time. For us that means that the expected sign ID is always off by one.

## Testing Information

I added an integration test that checks that the values send over the wire have the expected `dkg_id` and `sign_id`.

## Checklist

- [x] I have performed a self-review of my code
