### PR TITLE
[chore]: exclude codegen from clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,11 @@ test-build:
 	cargo $(CARGO_FLAGS) test build --features "testing"  $(CARGO_EXCLUDES) --no-run --locked ${CARGO_BUILD_ARGS}
 
 CARGO_FMT = cargo $(CARGO_FLAGS) fmt --all
-CARGO_CLIPPY_BASE = cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps
+CARGO_CLIPPY_BASE = cargo $(CARGO_FLAGS) clippy --workspace --all-targets --all-features --no-deps \
+    --exclude blocklist-api \
+    --exclude private-emily-client \
+    --exclude emily-client \
+    --exclude testing-emily-client
 CLIPPY_FLAGS = -D warnings
 
 lint:


### PR DESCRIPTION
## Description

It seems this can help to land #1783

Closes: no issue

## Changes

Exclude all crates in `.generated-sources` from clippy lints

## Testing Information

No new tests needed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
