### PR TITLE
feat: skip running DKG if config differs from registry but latest shares matches config

### DIFF
--- a/signer/src/storage/memory/read.rs
+++ b/signer/src/storage/memory/read.rs
@@ -342,6 +342,19 @@ impl DbRead for SharedStore {
             .map(|(_, shares)| shares.clone()))
     }
 
+    async fn get_latest_non_failed_dkg_shares(
+        &self,
+    ) -> Result<Option<model::EncryptedDkgShares>, Error> {
+        Ok(self
+            .lock()
+            .await
+            .encrypted_dkg_shares
+            .values()
+            .filter(|(_, shares)| shares.dkg_shares_status != DkgSharesStatus::Failed)
+            .max_by_key(|(time, _)| time)
+            .map(|(_, shares)| shares.clone()))
+    }
+
     async fn get_encrypted_dkg_shares_count(&self) -> Result<u32, Error> {
         Ok(self
             .lock()
@@ -996,6 +1009,12 @@ impl DbRead for InMemoryTransaction {
         &self,
     ) -> Result<Option<model::EncryptedDkgShares>, Error> {
         self.store.get_latest_verified_dkg_shares().await
+    }
+
+    async fn get_latest_non_failed_dkg_shares(
+        &self,
+    ) -> Result<Option<model::EncryptedDkgShares>, Error> {
+        self.store.get_latest_non_failed_dkg_shares().await
     }
 
     async fn get_encrypted_dkg_shares_count(&self) -> Result<u32, Error> {

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -308,6 +308,12 @@ pub trait DbRead {
         &self,
     ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Error>> + Send;
 
+    /// Return the most recent DKG shares with a non failed status, or None if
+    /// no such shares exist.
+    fn get_latest_non_failed_dkg_shares(
+        &self,
+    ) -> impl Future<Output = Result<Option<model::EncryptedDkgShares>, Error>> + Send;
+
     /// Returns the number of non-failed DKG shares entries in the database.
     fn get_encrypted_dkg_shares_count(&self) -> impl Future<Output = Result<u32, Error>> + Send;
 

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2537,32 +2537,46 @@ pub async fn should_coordinate_dkg(
     let storage = context.get_storage();
     let config = context.config();
 
+    let latest_dkg_shares = storage.get_latest_non_failed_dkg_shares().await?;
+    let Some(latest_dkg_shares) = latest_dkg_shares else {
+        tracing::info!("no non-failed DKG shares exist; proceeding with DKG");
+        return Ok(true);
+    };
+
     // If the latest shares are unverified, we want to prioritize verifying them
     // instead of doing new DKG rounds. If we fail to do so they will eventually
     // be marked as failed, and we will resume DKG-ing.
-    let latest_dkg_shares = storage.get_latest_encrypted_dkg_shares().await?;
-    if latest_dkg_shares.map(|s| s.dkg_shares_status) == Some(model::DkgSharesStatus::Unverified) {
+    if latest_dkg_shares.dkg_shares_status == model::DkgSharesStatus::Unverified {
         tracing::debug!("latest shares are unverified; skipping DKG");
         return Ok(false);
     }
 
-    // If we do not have a key rotation event in the database, we will
-    // allow DKG below if we have not run DKG yet.
+    // If the registry has signer set info, we may need to run DKG based on it
     if let Some(registry_signer_info) = context.state().registry_signer_set_info() {
-        // Trigger DKG if signatures_required has changed
-        if registry_signer_info.signatures_required != config.signer.bootstrap_signatures_required {
-            tracing::info!("signatures required has changed; proceeding with DKG");
-            return Ok(true);
-        }
-
-        // Trigger DKG if signer set changes
-        if registry_signer_info.signer_set != config.signer.bootstrap_signing_set {
-            tracing::info!("signer set has changed; proceeding with DKG");
-            return Ok(true);
+        // If the registry differs from the config we may need to run DKG
+        if registry_signer_info.signatures_required != config.signer.bootstrap_signatures_required
+            || registry_signer_info.signer_set != config.signer.bootstrap_signing_set
+        {
+            // If we don't have new shares for the config already, we need DKG
+            if latest_dkg_shares.signature_share_threshold
+                != config.signer.bootstrap_signatures_required
+                || latest_dkg_shares.signer_set_public_keys() != config.signer.bootstrap_signing_set
+            {
+                tracing::info!(
+                    "signer set config differs from registry and latest DKG shares; proceeding with DKG"
+                );
+                return Ok(true);
+            } else {
+                tracing::debug!(
+                    "signer set config differs from registry, but we alreay have verified shares for it; checking other conditions"
+                );
+            }
         }
     }
 
-    // Get the number of DKG shares that have been stored
+    // Finally, we may need to run DKG because of config target rounds.
+
+    // Get the number of non-failed DKG shares that have been stored
     let dkg_shares_entry_count = storage.get_encrypted_dkg_shares_count().await?;
 
     // Get DKG configuration parameters
@@ -2575,14 +2589,6 @@ pub async fn should_coordinate_dkg(
         dkg_target_rounds,
         dkg_min_bitcoin_block_height,
     ) {
-        (0, _, _) => {
-            tracing::info!(
-                ?dkg_min_bitcoin_block_height,
-                %dkg_target_rounds,
-                "no DKG shares exist; proceeding with DKG"
-            );
-            Ok(true)
-        }
         (current, target, Some(dkg_min_height))
             if current < target.get() && bitcoin_chain_tip.block_height >= dkg_min_height =>
         {

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -1588,32 +1588,46 @@ pub async fn assert_allow_dkg_begin(
     let storage = context.get_storage();
     let config = context.config();
 
+    let latest_dkg_shares = storage.get_latest_non_failed_dkg_shares().await?;
+    let Some(latest_dkg_shares) = latest_dkg_shares else {
+        tracing::info!("no non-failed DKG shares exist; proceeding with DKG");
+        return Ok(());
+    };
+
     // If the latest shares are unverified, we want to prioritize verifying them
     // instead of doing new DKG rounds. If we fail to do so they will eventually
     // be marked as failed, and we will resume DKG-ing.
-    let latest_dkg_shares = storage.get_latest_encrypted_dkg_shares().await?;
-    if latest_dkg_shares.map(|s| s.dkg_shares_status) == Some(model::DkgSharesStatus::Unverified) {
+    if latest_dkg_shares.dkg_shares_status == model::DkgSharesStatus::Unverified {
         tracing::warn!("latest shares are unverified; aborting");
         return Err(Error::DkgHasAlreadyRun);
     }
 
-    // If we do not have a key rotation event in the database, we will
-    // allow DKG below if we have not run DKG yet.
+    // If the registry has signer set info, we may need to run DKG based on it
     if let Some(registry_signer_info) = context.state().registry_signer_set_info() {
-        // Trigger DKG if signatures_required has changed
-        if registry_signer_info.signatures_required != config.signer.bootstrap_signatures_required {
-            tracing::info!("signatures required has changed; proceeding with DKG");
-            return Ok(());
-        }
-
-        // Trigger DKG if signer set changes
-        if registry_signer_info.signer_set != config.signer.bootstrap_signing_set {
-            tracing::info!("signer set has changed; proceeding with DKG");
-            return Ok(());
+        // If the registry differs from the config we may need to run DKG
+        if registry_signer_info.signatures_required != config.signer.bootstrap_signatures_required
+            || registry_signer_info.signer_set != config.signer.bootstrap_signing_set
+        {
+            // If we don't have new shares for the config already, we need DKG
+            if latest_dkg_shares.signature_share_threshold
+                != config.signer.bootstrap_signatures_required
+                || latest_dkg_shares.signer_set_public_keys() != config.signer.bootstrap_signing_set
+            {
+                tracing::info!(
+                    "signer set config differs from registry and latest DKG shares; proceeding with DKG"
+                );
+                return Ok(());
+            } else {
+                tracing::debug!(
+                    "signer set config differs from registry, but we alreay have verified shares for it; checking other conditions"
+                );
+            }
         }
     }
 
-    // Get the number of DKG shares that have been stored
+    // Finally, we may need to run DKG because of config target rounds.
+
+    // Get the number of non-failed DKG shares that have been stored
     let dkg_shares_entry_count = storage.get_encrypted_dkg_shares_count().await?;
 
     // Get DKG configuration parameters
@@ -1626,13 +1640,6 @@ pub async fn assert_allow_dkg_begin(
         dkg_target_rounds,
         dkg_min_bitcoin_block_height,
     ) {
-        (0, _, _) => {
-            tracing::info!(
-                ?dkg_min_bitcoin_block_height,
-                %dkg_target_rounds,
-                "no DKG shares exist; proceeding with DKG"
-            );
-        }
         (current, target, Some(dkg_min_height)) => {
             if current >= target.get() {
                 tracing::warn!(
@@ -1659,7 +1666,8 @@ pub async fn assert_allow_dkg_begin(
                 "DKG rerun height has been met and we are below the target number of rounds; proceeding with DKG"
             );
         }
-        // Note that we account for all (0, _, _) cases above (i.e. first DKG round)
+        // Note that we account for all (0, _, _) cases in the early return when
+        // we fetch the latest non failed DKG shares
         (_, _, None) => {
             tracing::warn!(
                 ?dkg_min_bitcoin_block_height,

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -2064,6 +2064,74 @@ async fn get_last_verified_dkg_shares_does_whats_advertised() {
     signer::testing::storage::drop_db(db).await;
 }
 
+/// The [`DbRead::get_latest_non_failed_dkg_shares`] function is supposed to
+/// fetch the last encrypted DKG shares with status not 'failed' from the
+/// database.
+#[tokio::test]
+async fn get_latest_non_failed_dkg_shares_does_whats_advertised() {
+    let db = testing::storage::new_test_database().await;
+
+    let mut rng = get_rng();
+
+    // We have an empty database, so we don't have any DKG shares there.
+    let no_shares = db.get_latest_encrypted_dkg_shares().await.unwrap();
+    assert!(no_shares.is_none());
+
+    let no_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert!(no_shares.is_none());
+
+    // Add some failed shares
+    let mut shares: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    shares.dkg_shares_status = model::DkgSharesStatus::Failed;
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    let stored_shares = db.get_latest_encrypted_dkg_shares().await.unwrap();
+    assert_eq!(stored_shares.as_ref(), Some(&shares));
+
+    let no_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert!(no_shares.is_none());
+
+    // Now some unverified shares
+    let mut shares: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    shares.dkg_shares_status = model::DkgSharesStatus::Unverified;
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    let stored_shares = db.get_latest_encrypted_dkg_shares().await.unwrap();
+    assert_eq!(stored_shares.as_ref(), Some(&shares));
+
+    let unverified_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert_eq!(unverified_shares.as_ref(), Some(&shares));
+
+    // And now some verified shares
+    let mut shares: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    shares.dkg_shares_status = model::DkgSharesStatus::Verified;
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    let stored_shares = db.get_latest_encrypted_dkg_shares().await.unwrap();
+    assert_eq!(stored_shares.as_ref(), Some(&shares));
+
+    let verified_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert_eq!(verified_shares.as_ref(), Some(&shares));
+
+    // Now we add some failed again, we should still get the previous one
+    let mut shares_tmp: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    shares_tmp.dkg_shares_status = model::DkgSharesStatus::Failed;
+    db.write_encrypted_dkg_shares(&shares_tmp).await.unwrap();
+
+    let some_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert_eq!(some_shares.as_ref(), Some(&shares));
+
+    // And finally some unverified again
+    let mut shares: model::EncryptedDkgShares = fake::Faker.fake_with_rng(&mut rng);
+    shares.dkg_shares_status = model::DkgSharesStatus::Unverified;
+    db.write_encrypted_dkg_shares(&shares).await.unwrap();
+
+    let some_shares = db.get_latest_non_failed_dkg_shares().await.unwrap();
+    assert_eq!(some_shares.as_ref(), Some(&shares));
+
+    signer::testing::storage::drop_db(db).await;
+}
+
 /// The [`DbRead::deposit_request_exists`] function is return true we have
 /// a record of the deposit request and false otherwise.
 #[tokio::test]

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -37,6 +37,7 @@ use fake::Fake;
 use fake::Faker;
 use futures::StreamExt as _;
 use lru::LruCache;
+use more_asserts::assert_gt;
 use more_asserts::assert_lt;
 use rand::rngs::OsRng;
 
@@ -1072,11 +1073,54 @@ async fn run_dkg_from_scratch() {
     }
 }
 
+struct RunDkgSignerSetScenario {
+    pub signer_set_changed: bool,
+    pub threshold_changed: bool,
+    pub latest_shares_matches: bool,
+}
 /// Tests that dkg will be triggered if signer set changes
-#[test_case(true; "signatures_required_changed")]
-#[test_case(false; "signatures_required_unchanged")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: false,
+    threshold_changed: false,
+    latest_shares_matches: false,
+}, false; "no changes, latest don't match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: false,
+    threshold_changed: false,
+    latest_shares_matches: true,
+}, false; "no changes, latest match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: true,
+    threshold_changed: false,
+    latest_shares_matches: false,
+}, true; "set changed, latest don't match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: true,
+    threshold_changed: false,
+    latest_shares_matches: true,
+}, false; "set changed, latest match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: false,
+    threshold_changed: true,
+    latest_shares_matches: false,
+}, true; "threshold changed, latest don't match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: false,
+    threshold_changed: true,
+    latest_shares_matches: true,
+}, false; "threshold changed, latest match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: true,
+    threshold_changed: true,
+    latest_shares_matches: false,
+}, true; "both changed, latest don't match")]
+#[test_case(RunDkgSignerSetScenario {
+    signer_set_changed: true,
+    threshold_changed: true,
+    latest_shares_matches: true,
+}, false; "both changed, latest match")]
 #[tokio::test]
-async fn run_dkg_if_signer_set_changes(signer_set_changed: bool) {
+async fn run_dkg_if_signer_set_changes(scenario: RunDkgSignerSetScenario, expect_dkg: bool) {
     let mut rng = get_rng();
     let db = testing::storage::new_test_database().await;
     let ctx = TestContext::builder()
@@ -1087,16 +1131,22 @@ async fn run_dkg_if_signer_set_changes(signer_set_changed: bool) {
         })
         .build();
 
-    let mut config_signer_set = ctx.config().signer.bootstrap_signing_set.clone();
+    let chaintip: model::BitcoinBlockRef = Faker.fake_with_rng(&mut rng);
+
     // Sanity check
-    assert!(!config_signer_set.is_empty());
+    assert!(!ctx.config().signer.bootstrap_signing_set.is_empty());
+    assert_gt!(ctx.config().signer.bootstrap_signatures_required, 1);
 
-    // Make sure that in very beginning of the test config and context signer sets are same.
-    ctx.inner
-        .state()
-        .update_current_signer_set(config_signer_set.iter().cloned().collect());
+    // Initially the config and registry matches
+    let mut signer_set_info = SignerSetInfo {
+        aggregate_key: Faker.fake_with_rng(&mut rng),
+        signatures_required: ctx.config().signer.bootstrap_signatures_required,
+        signer_set: ctx.config().signer.bootstrap_signing_set.clone(),
+    };
+    ctx.state()
+        .update_registry_signer_set_info(signer_set_info.clone());
 
-    // Write dkg shares so it won't be a reason to trigger dkg.
+    // Write some verified DKG shares so it won't be a reason to trigger DKG
     let dkg_shares = model::EncryptedDkgShares {
         dkg_shares_status: model::DkgSharesStatus::Verified,
         ..Faker.fake_with_rng(&mut rng)
@@ -1105,90 +1155,45 @@ async fn run_dkg_if_signer_set_changes(signer_set_changed: bool) {
         .await
         .expect("failed to write dkg shares");
 
-    // Remove one signer
-    if signer_set_changed {
-        let _removed_signer = config_signer_set
+    // Before any change DKG shouldn't be triggered
+    assert!(!should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
+    assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_err());
+
+    // Alter the registry based on the test
+    if scenario.signer_set_changed {
+        signer_set_info
+            .signer_set
             .pop_first()
             .expect("This signer set should not be empty");
     }
-    // Create chaintip
-    let chaintip: model::BitcoinBlockRef = Faker.fake_with_rng(&mut rng);
-
-    prevent_dkg_on_changed_signer_set_info(&ctx, dkg_shares.aggregate_key);
-
-    // Before we actually change the signer set, the DKG won't be triggered
-    assert!(!should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
-    assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_err());
-
-    // Now we change context signer set.
-    let signer_set_info = SignerSetInfo {
-        aggregate_key: dkg_shares.aggregate_key,
-        signatures_required: ctx.config().signer.bootstrap_signatures_required,
-        signer_set: config_signer_set,
-    };
-
-    ctx.state().update_registry_signer_set_info(signer_set_info);
-
-    if signer_set_changed {
-        assert!(should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
-        assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_ok());
-    } else {
-        assert!(!should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
-        assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_err());
+    if scenario.threshold_changed {
+        signer_set_info.signatures_required -= 1;
     }
-    testing::storage::drop_db(db).await;
-}
-
-/// Tests that dkg will be triggered if signatures required parameter changes
-#[test_case(true; "signatures_required_changed")]
-#[test_case(false; "signatures_required_unchanged")]
-#[tokio::test]
-async fn run_dkg_if_signatures_required_changes(change_signatures_required: bool) {
-    let mut rng = get_rng();
-    let db = testing::storage::new_test_database().await;
-    let mut ctx = TestContext::builder()
-        .with_storage(db.clone())
-        .with_mocked_clients()
-        .modify_settings(|settings| {
-            settings.signer.dkg_target_rounds = std::num::NonZero::<u32>::new(1).unwrap();
-            settings.signer.bootstrap_signatures_required = 1;
-        })
-        .build();
-    let config_signer_set = ctx.config().signer.bootstrap_signing_set.clone();
-
-    // Sanity check, since we want change bootstrap_signatures_required during this test
-    // we need at least two valid values.
-    assert!(config_signer_set.len() > 1);
-
-    // Write dkg shares so it won't be a reason to trigger dkg.
-    let dkg_shares = model::EncryptedDkgShares {
-        dkg_shares_status: model::DkgSharesStatus::Verified,
-        ..Faker.fake_with_rng(&mut rng)
-    };
-    db.write_encrypted_dkg_shares(&dkg_shares)
-        .await
-        .expect("failed to write dkg shares");
-
-    let signer_set_info = SignerSetInfo {
-        aggregate_key: dkg_shares.aggregate_key,
-        // This matches the value we set for the bootstrap_signatures_required
-        signatures_required: ctx.config().signer.bootstrap_signatures_required,
-        signer_set: config_signer_set,
-    };
-
     ctx.state().update_registry_signer_set_info(signer_set_info);
 
-    // Create chaintip
-    let chaintip: model::BitcoinBlockRef = Faker.fake_with_rng(&mut rng);
+    if scenario.latest_shares_matches {
+        // Latest shares must match the config
+        let mut signer_set: Vec<PublicKey> = ctx
+            .config()
+            .signer
+            .bootstrap_signing_set
+            .iter()
+            .copied()
+            .collect();
+        signer_set.sort();
 
-    // Before we actually change the signatures_required, the DKG won't be triggered
-    assert!(!should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
-    assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_err());
+        let dkg_shares = model::EncryptedDkgShares {
+            dkg_shares_status: model::DkgSharesStatus::Verified,
+            signer_set_public_keys: signer_set,
+            signature_share_threshold: ctx.config().signer.bootstrap_signatures_required,
+            ..Faker.fake_with_rng(&mut rng)
+        };
+        db.write_encrypted_dkg_shares(&dkg_shares)
+            .await
+            .expect("failed to write dkg shares");
+    }
 
-    // Change bootstrap_signatures_required to trigger dkg
-    if change_signatures_required {
-        ctx.config_mut().signer.bootstrap_signatures_required = 2;
-
+    if expect_dkg {
         assert!(should_coordinate_dkg(&ctx, &chaintip).await.unwrap());
         assert!(assert_allow_dkg_begin(&ctx, &chaintip).await.is_ok());
     } else {


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-sbtc/sbtc/issues/1720
Superseeds: https://github.com/stacks-sbtc/sbtc/pull/1773

## Changes

If the config doesn't match the registry we run DKG, but only if latest shares do not match already the new config. Also ignores failed shares.

Add `get_latest_non_failed_dkg_shares` which does what you can guess.

## Testing Information

Add tests for `get_latest_non_failed_dkg_shares`, refactored a test to include the new condition.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
