### PR TITLE
feat: make key exchange public key required

### DIFF
--- a/protobufs/crypto/wsts/wsts.proto
+++ b/protobufs/crypto/wsts/wsts.proto
@@ -28,6 +28,22 @@ message SignerDkgPublicShares {
   crypto.Point kex_public_key = 4;
 }
 
+// DKG public shares message from a signer to all signers and coordinator.
+// This type is used by the signers for reading polynomial commitments from
+// the database. For sBTC, this vector should always have a length of 1.
+// This maps to this type:
+// <https://github.com/Trust-Machines/wsts/blob/2d6cb87218bb8dd9ed0519356afe57a0b9a697cb/src/net.rs#L137-L146>
+message DkgSignerCommitment {
+  // List of (signer_id, commitment)
+  repeated PartyCommitment commitment = 3;
+}
+
+// All of the polynomial commitments received by a signer during a DKG
+// round.
+message DkgPolynomialCommitments {
+  map<uint32, DkgSignerCommitment> commitments = 1;
+}
+
 // The public polynomial committed to by one of the party members who are
 // participating in distributed key generation.
 // This maps to this type <https://github.com/Trust-Machines/wsts/blob/2d6cb87218bb8dd9ed0519356afe57a0b9a697cb/src/net.rs#L144-L145>

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -68,6 +68,7 @@ use crate::storage::model::QualifiedRequestId;
 use crate::storage::model::StacksBlockHash;
 use crate::storage::model::StacksPrincipal;
 use crate::storage::model::StacksTxId;
+use crate::wsts_state_machine::DkgPublicSharesDb;
 
 use super::wsts_message;
 
@@ -1584,6 +1585,19 @@ impl TryFrom<proto::PartyCommitment> for (u32, PolyCommitment) {
     type Error = Error;
     fn try_from(value: proto::PartyCommitment) -> Result<Self, Self::Error> {
         Ok((value.signer_id, value.commitment.required()?.try_into()?))
+    }
+}
+
+impl TryFrom<proto::DkgSignerCommitment> for DkgPublicSharesDb {
+    type Error = Error;
+    fn try_from(value: proto::DkgSignerCommitment) -> Result<Self, Self::Error> {
+        let commitments = value
+            .commitment
+            .into_iter()
+            .map(TryInto::try_into)
+            .collect::<Result<Vec<_>, Error>>()?;
+
+        Ok(DkgPublicSharesDb { comms: commitments })
     }
 }
 

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -1615,17 +1615,8 @@ impl From<DkgPublicShares> for proto::SignerDkgPublicShares {
 impl TryFrom<proto::SignerDkgPublicShares> for DkgPublicShares {
     type Error = Error;
     fn try_from(value: proto::SignerDkgPublicShares) -> Result<Self, Self::Error> {
-        let kex_public_key = match value.kex_public_key {
-            Some(key) => Point::try_from(key)?,
-            // If the protobuf doesn't have a kex_public_key, that means it's an artifact
-            // from an old DKG round before we had ephemeral DKG encryption keys.  Using the
-            // point at infinity allows us to distinguish this case in code if desired, and
-            // also prevents us from accidentally using these shares in a future DKG round,
-            // since the point at infinity will not deserialize if sent over the wire.
-            None => Point::identity(),
-        };
         Ok(DkgPublicShares {
-            kex_public_key,
+            kex_public_key: value.kex_public_key.required()?.try_into()?,
             dkg_id: value.dkg_id,
             signer_id: value.signer_id,
             comms: value

--- a/signer/src/proto/generated/crypto.wsts.rs
+++ b/signer/src/proto/generated/crypto.wsts.rs
@@ -99,9 +99,27 @@ pub struct SignerDkgPublicShares {
     /// List of (signer_id, commitment)
     #[prost(message, repeated, tag = "3")]
     pub commitments: ::prost::alloc::vec::Vec<PartyCommitment>,
-    /// kex exchange public key
+    /// The public key used for exchanging secret shares during DKG
     #[prost(message, optional, tag = "4")]
     pub kex_public_key: ::core::option::Option<super::Point>,
+}
+/// DKG public shares message from a signer to all signers and coordinator.
+/// This type is used by the signers for reading polynomial commitments from
+/// the database. For sBTC, this vector should always have a length of 1.
+/// This maps to this type:
+/// <<https://github.com/Trust-Machines/wsts/blob/2d6cb87218bb8dd9ed0519356afe57a0b9a697cb/src/net.rs#L137-L146>>
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DkgSignerCommitment {
+    /// List of (signer_id, commitment)
+    #[prost(message, repeated, tag = "3")]
+    pub commitment: ::prost::alloc::vec::Vec<PartyCommitment>,
+}
+/// All of the polynomial commitments received by a signer during a DKG
+/// round.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DkgPolynomialCommitments {
+    #[prost(btree_map = "uint32, message", tag = "1")]
+    pub commitments: ::prost::alloc::collections::BTreeMap<u32, DkgSignerCommitment>,
 }
 /// The public polynomial committed to by one of the party members who are
 /// participating in distributed key generation.

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -86,6 +86,7 @@ use crate::storage::model::StacksTxId;
 use crate::storage::model::TaprootScriptHash;
 use crate::storage::model::WithdrawalAcceptEvent;
 use crate::storage::model::WithdrawalRejectEvent;
+use crate::wsts_state_machine::DkgPublicSharesDb;
 
 /// Dummy block
 pub fn block<R: rand::RngCore + ?Sized>(
@@ -1143,6 +1144,17 @@ impl Dummy<Unit> for DkgPublicShares {
             kex_public_key: config.fake_with_rng(rng),
             dkg_id: Faker.fake_with_rng(rng),
             signer_id: Faker.fake_with_rng(rng),
+            comms: fake::vec![(); 0..20]
+                .into_iter()
+                .map(|_| config.fake_with_rng(rng))
+                .collect(),
+        }
+    }
+}
+
+impl Dummy<Unit> for DkgPublicSharesDb {
+    fn dummy_with_rng<R: rand::Rng + ?Sized>(config: &Unit, rng: &mut R) -> Self {
+        DkgPublicSharesDb {
             comms: fake::vec![(); 0..20]
                 .into_iter()
                 .map(|_| config.fake_with_rng(rng))

--- a/signer/src/wsts_state_machine.rs
+++ b/signer/src/wsts_state_machine.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::future::Future;
 
+use crate::codec::CodecError;
 use crate::codec::Decode as _;
 use crate::codec::Encode as _;
 use crate::error;
@@ -11,6 +12,7 @@ use crate::keys::PrivateKey;
 use crate::keys::PublicKey;
 use crate::keys::PublicKeyXOnly;
 use crate::keys::SignerScriptPubKey as _;
+use crate::proto;
 use crate::storage;
 use crate::storage::model;
 use crate::storage::model::BitcoinBlockHash;
@@ -21,6 +23,7 @@ use crate::storage::model::SigHash;
 
 use hashbrown::HashMap;
 use hashbrown::HashSet;
+use prost::Message as _;
 use rand::SeedableRng as _;
 use rand::rngs::OsRng;
 use rand_chacha::ChaCha20Rng;
@@ -39,6 +42,31 @@ use wsts::state_machine::coordinator::fire;
 use wsts::state_machine::coordinator::frost;
 use wsts::traits::Signer as _;
 use wsts::v2::Aggregator;
+
+/// A database model for storing DKG public shares.
+///
+/// This is used to store the DKG public shares in the database.
+#[derive(Clone, Debug, PartialEq, Default)]
+pub struct DkgPublicSharesDb {
+    /// List of (party_id, commitment)
+    pub comms: Vec<(u32, PolyCommitment)>,
+}
+
+impl crate::codec::Decode for BTreeMap<u32, DkgPublicSharesDb> {
+    fn decode<R: std::io::Read>(mut reader: R) -> Result<Self, Error> {
+        let mut buf = Vec::new();
+        reader
+            .read_to_end(&mut buf)
+            .map_err(CodecError::DecodeIOError)?;
+
+        proto::DkgPolynomialCommitments::decode(&*buf)
+            .map_err(CodecError::DecodeError)?
+            .commitments
+            .into_iter()
+            .map(|(id, comms)| Ok((id, comms.try_into()?)))
+            .collect::<Result<BTreeMap<u32, DkgPublicSharesDb>, Error>>()
+    }
+}
 
 /// An identifier for signer state machines.
 ///
@@ -314,7 +342,7 @@ impl WstsCoordinator for FireCoordinator {
             .await?
             .ok_or(Error::MissingDkgShares(aggregate_key))?;
 
-        let public_dkg_shares: BTreeMap<u32, wsts::net::DkgPublicShares> =
+        let public_dkg_shares: BTreeMap<u32, DkgPublicSharesDb> =
             BTreeMap::decode(encrypted_shares.public_shares.as_slice())?;
         let party_polynomials = public_dkg_shares
             .iter()
@@ -442,7 +470,7 @@ impl WstsCoordinator for FrostCoordinator {
             .await?
             .ok_or(Error::MissingDkgShares(aggregate_key))?;
 
-        let public_dkg_shares: BTreeMap<u32, wsts::net::DkgPublicShares> =
+        let public_dkg_shares: BTreeMap<u32, DkgPublicSharesDb> =
             BTreeMap::decode(encrypted_shares.public_shares.as_slice())?;
         let party_polynomials = public_dkg_shares
             .iter()
@@ -749,5 +777,41 @@ impl SignerStateMachine {
             started_at_bitcoin_block_hash: self.started_at.block_hash,
             started_at_bitcoin_block_height: self.started_at.block_height,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fake::Fake as _;
+    use wsts::net::DkgPublicShares;
+
+    use crate::testing::dummy::Unit;
+    use crate::testing::get_rng;
+
+    use super::*;
+
+    /// Test that we can decode DKG public shares
+    ///
+    /// During normal operation the signers encode the full DKG public
+    /// shares object as a protobuf. Public shares start out as a
+    /// `BTreeMap<u32, DkgPublicShares>` and is serialized as a
+    /// `proto::DkgPublicShares`. When decoding, we only decode the one
+    /// field that we care about, the `comms` field in each
+    /// `DkgPublicShares`. We do this to allow the WSTS types to evolve
+    /// independently of what the signers store in their database. So long
+    /// as the protobuf type that we stored, the `proto::DkgPublicShares`,
+    /// is compatible with the `BTreeMap<u32, DkgPublicSharesDb>` type,
+    /// then we are fine.
+    #[test]
+    fn test_dkg_public_shares_db_decoding() {
+        let mut rng = get_rng();
+        let shares: BTreeMap<u32, DkgPublicShares> = Unit.fake_with_rng(&mut rng);
+        let encoded = shares.clone().encode_to_vec();
+        let decoded_shares = BTreeMap::<u32, DkgPublicSharesDb>::decode(&*encoded).unwrap();
+
+        for (original, decoded) in shares.iter().zip(decoded_shares.iter()) {
+            assert_eq!(original.0, decoded.0);
+            assert_eq!(original.1.comms, decoded.1.comms);
+        }
     }
 }


### PR DESCRIPTION
## Description

This builds off of https://github.com/stacks-sbtc/sbtc/pull/1789. The goal here was to make the key exchange public key required during DKG.

The issue is that we cannot just require key exchange public key on our existing types, since that wouldn't allow us to read existing shares from the database. So, to solve that issues, we read a protobuf type that is different from the one that is written. This allows us to better separate the relevant WSTS type during DKG from is read from in the database.

Let me know if you don't think that going down this route is a good idea. We can keep https://github.com/stacks-sbtc/sbtc/pull/1789 as is or do something else. I don't feel strongly about it.

## Changes

* Add new protobuf types that are used when reading from the database.
* Make the key exchange public key a required field in `wsts::net::DkgPublicShares`.

## Testing Information

I added a unit test that checks the relevant logic of serializing one thing and deserializing another. Also, the existing unit tests should exercise this easily enough.

## Checklist

- [x] I have performed a self-review of my code
