### PR TITLE
feat: log presign on send and validate

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -53,7 +53,7 @@ x-sbtc-signer: &sbtc-signer
     target: signer
   entrypoint: "/bin/bash -c '/usr/local/bin/signer -c /signer-config.toml --migrate-db --output-format json'"
   environment: &sbtc-signer-environment
-    RUST_LOG: info
+    RUST_LOG: info,signer=debug
     SIGNER_SIGNER__P2P__LISTEN_ON: tcp://0.0.0.0:4122
   volumes:
     - ./sbtc/signer/signer-config.toml:/signer-config.toml

--- a/signer/src/bitcoin/validation.rs
+++ b/signer/src/bitcoin/validation.rs
@@ -76,6 +76,26 @@ pub struct TxRequestIds {
     pub withdrawals: Vec<QualifiedRequestId>,
 }
 
+impl std::fmt::Display for TxRequestIds {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "TxRequestIds(deposits=[")?;
+        for (i, value) in self.deposits.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{value}")?;
+        }
+        write!(f, "], withdrawals=[")?;
+        for (i, value) in self.withdrawals.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{value}")?;
+        }
+        write!(f, "])")
+    }
+}
+
 impl From<&Requests<'_>> for TxRequestIds {
     fn from(requests: &Requests) -> Self {
         let mut deposits = Vec::new();

--- a/signer/src/message.rs
+++ b/signer/src/message.rs
@@ -233,6 +233,23 @@ pub struct BitcoinPreSignRequest {
     pub last_fees: Option<Fees>,
 }
 
+impl std::fmt::Display for BitcoinPreSignRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "BitcoinPreSignRequest(request_package=[")?;
+        for (i, value) in self.request_package.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, "{value}")?;
+        }
+        write!(
+            f,
+            "], fee_rate={}, last_fees={:?})",
+            self.fee_rate, self.last_fees
+        )
+    }
+}
+
 /// An acknowledgment of a [`BitcoinPreSignRequest`].
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BitcoinPreSignAck;

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -551,6 +551,7 @@ where
         let signal_stream = self.context.as_signal_stream(presign_ack_filter);
 
         // Send the presign request message
+        tracing::debug!(request = %sbtc_requests, "sending pre-sign request");
         self.send_message(sbtc_requests, bitcoin_chain_tip).await?;
 
         tokio::pin!(signal_stream);

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -466,7 +466,7 @@ where
             aggregate_key,
         };
 
-        tracing::debug!("validating bitcoin transaction pre-sign");
+        tracing::debug!(%request, "validating bitcoin transaction pre-sign");
         let sighashes = request
             .construct_package_sighashes(&self.context, &btc_ctx)
             .await?;


### PR DESCRIPTION
## Description

Add a debug log for pre-sign requests on sending and validating them.

## Changes

## Testing Information

Tested on devenv:
```text
"request": "BitcoinPreSignRequest(request_package=[TxRequestIds(deposits=[614a6de701290a1a55c17ea399877f0b11c474c9c1999facb5b0067deda92f70:0], withdrawals=[])], fee_rate=54.065, last_fees=None)"
...
"request": "BitcoinPreSignRequest(request_package=[TxRequestIds(deposits=[], withdrawals=[1:2853e5ad3e9bf78fc74867b8ded44c104235d0849cf1eac8ff1385860015a461])], fee_rate=54.055, last_fees=None)",
```

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
