### PR TITLE
Test Backfill Fix (draft)

### DIFF
--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1345,16 +1345,12 @@ where
 
 // Helper function for backfill testnet logic, checks if an
 // error indicates we're trying to fetch a pre-Nakamoto block
-fn is_pre_nakamoto_block_error(
-    error: &Error,
-    network: NetworkKind,
-) -> bool {
+fn is_pre_nakamoto_block_error(error: &Error, network: NetworkKind) -> bool {
     match error {
         // If we get a 404, it's likely because the block ID refers to a pre-Nakamoto block
         // But only if we're not on mainnet (since this is a testnet-specific issue)
         Error::StacksNodeResponse(req_error) => {
-            req_error.status() == Some(reqwest::StatusCode::NOT_FOUND)
-                && !network.is_mainnet()
+            req_error.status() == Some(reqwest::StatusCode::NOT_FOUND) && !network.is_mainnet()
         }
         // For other errors, we're not sure so we don't assume it's pre-Nakamoto
         _ => false,


### PR DESCRIPTION
## Description
This PR introduces a check into the signer/stacks/api that verifies whether there is a large gap in pre-Nakamoto anchor blocks. As seen in #1749, these gaps in testnet require a manual massage / inserting to continue syncing. 

This initial lay down contains logical checks for *when* blocks should be manually inserted for a successful testnet run.

Closes: #1749 

## Changes
The 'fetch_unknown_ancestor' in the signer/stacks/api.rs file.

## Testing Information
No tests as of now but this will change.

## Checklist

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
