### PR TITLE
feat: move coordinator checks for smart contract deployment to block observer

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -736,7 +736,7 @@ where
     stacks.get_current_signer_set_info(address).await
 }
 
-/// Check if all the sBTC contracts are deployed.
+/// Check if all the sBTC smart contracts have been deployed.
 async fn are_sbtc_contracts_deployed<C>(ctx: &C) -> Result<bool, Error>
 where
     C: Context,
@@ -757,6 +757,9 @@ where
         }
     }
 
+    // If we get here, then all the smart contracts have been deployed.
+    // Let's store that fact so that we don't need to query our Stacks node
+    // again.
     ctx.state().set_sbtc_contracts_deployed();
     Ok(true)
 }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -38,6 +38,7 @@ use crate::stacks::api::GetNakamotoStartHeight as _;
 use crate::stacks::api::SignerSetInfo;
 use crate::stacks::api::StacksInteract;
 use crate::stacks::api::TenureBlockHeaders;
+use crate::stacks::contracts::SMART_CONTRACTS;
 use crate::storage::DbRead;
 use crate::storage::DbWrite;
 use crate::storage::Transactable;
@@ -726,13 +727,38 @@ where
     let address = &ctx.config().signer.deployer;
     // If the sBTC contracts have not been deployed, then we don't have any
     // signer set info in the registry.
-    if !ctx.state().sbtc_contracts_deployed() {
+    if !are_sbtc_contracts_deployed(ctx).await? {
         return Ok(None);
     }
 
     // This returns Ok(None) if API call returns a response with values
     // that are only set when we first deploy the sBTC contracts.
     stacks.get_current_signer_set_info(address).await
+}
+
+/// Check if all the sBTC contracts are deployed.
+async fn are_sbtc_contracts_deployed<C>(ctx: &C) -> Result<bool, Error>
+where
+    C: Context,
+{
+    // First check if we already know if the contracts have been deployed.
+    // If we get false, then it could be that we are just starting the
+    // application, so we'll need to check our node.
+    if ctx.state().sbtc_contracts_deployed() {
+        return Ok(true);
+    }
+
+    let stacks = ctx.get_stacks_client();
+    let deployer = ctx.config().signer.deployer;
+
+    for contract in SMART_CONTRACTS {
+        if !contract.is_deployed(&stacks, &deployer).await? {
+            return Ok(false);
+        }
+    }
+
+    ctx.state().set_sbtc_contracts_deployed();
+    Ok(true)
 }
 
 #[cfg(test)]

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -317,7 +317,7 @@ impl StacksInteract for TestHarness {
         &self,
         _contract_principal: &StacksAddress,
     ) -> Result<Option<SignerSetInfo>, Error> {
-        todo!()
+        Ok(None)
     }
     async fn get_current_signers_aggregate_key(
         &self,

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2803,7 +2803,11 @@ mod tests {
             .with_in_memory_storage()
             .with_mocked_clients()
             .modify_settings(|settings| {
-                // If we are the coordinator then we will wait for 10 seconds.
+                // If we are the coordinator then we will wait for 10
+                // seconds. However, in this test we shouldn't be the
+                // coordinator, so we should exit early. If there is a bug
+                // and we are the coordinator then we'll end up waiting 1
+                // second due to the timeout below.
                 settings.signer.bitcoin_processing_delay = Duration::from_secs(10);
             })
             .build();

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2806,8 +2806,8 @@ mod tests {
                 // If we are the coordinator then we will wait for 10
                 // seconds. However, in this test we shouldn't be the
                 // coordinator, so we should exit early. If there is a bug
-                // and we are the coordinator then we'll end up waiting 1
-                // second due to the timeout below.
+                // and we are the coordinator then we'll end up waiting for
+                // one second due to the timeout below.
                 settings.signer.bitcoin_processing_delay = Duration::from_secs(10);
             })
             .build();

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -154,6 +154,14 @@ async fn load_latest_deposit_requests_persists_requests_from_past(blocks_ago: u6
         client
             .expect_get_sortition_info()
             .returning(move |_| Box::pin(std::future::ready(Ok(DUMMY_SORTITION_INFO.clone()))));
+
+        client.expect_get_contract_source().returning(|_, _| {
+            Box::pin(async {
+                Err(Error::StacksNodeResponse(
+                    mock_reqwests_status_code_error(404).await,
+                ))
+            })
+        });
     })
     .await;
 
@@ -397,6 +405,7 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
         .with_mocked_stacks_client()
         .build();
 
+    ctx.state().set_sbtc_contracts_deployed();
     let mut signal_receiver = ctx.get_signal_receiver();
 
     // The block observer reaches out to the stacks node to get the most
@@ -419,6 +428,11 @@ async fn block_observer_stores_donation_and_sbtc_utxos() {
                 .map_err(Error::JsonSerialize);
             Box::pin(std::future::ready(response))
         });
+
+        // The signer set info is not necessary for this test.
+        client
+            .expect_get_current_signer_set_info()
+            .returning(|_| Box::pin(std::future::ready(Ok(None))));
     })
     .await;
 
@@ -1108,10 +1122,10 @@ async fn next_headers_to_process_ignores_known_headers() {
     testing::storage::drop_db(db).await;
 }
 
-/// The [`get_signer_set_and_aggregate_key`] function is supposed to fetch
-/// the signing set that is in the sbtc-registry by querying the stacks
-/// node if the smart contracts have been deployed and returning None if
-/// they have not.
+/// The [`get_signer_set_info`] function is supposed to fetch the signing
+/// set that is in the sbtc-registry by querying the stacks node if the
+/// smart contracts have been deployed and returning None if they have not
+/// or if the smart contract contains only null data.
 #[tokio::test]
 async fn get_signer_set_info_falls_back() {
     let db = testing::storage::new_test_database().await;
@@ -1141,18 +1155,23 @@ async fn get_signer_set_info_falls_back() {
         client
             .expect_get_current_signer_set_info()
             .returning(move |_| Box::pin(std::future::ready(Ok(Some(signer_set_info2.clone())))));
+
+        client.expect_get_contract_source().returning(|_, _| {
+            Box::pin(async {
+                Err(Error::StacksNodeResponse(
+                    mock_reqwests_status_code_error(404).await,
+                ))
+            })
+        });
     })
     .await;
 
-    // We have no rows in the DKG shares table and no rotate-keys
-    // transactions, so there should be no aggregate key, since that only
-    // happens after DKG, but we should always know the current signer set.
-    // Signatures required should fall back to config value.
     let info = get_signer_set_info(&ctx).await.unwrap();
     assert!(info.is_none());
 
-    // Alright, now that we have a rotate-keys transaction, we can check if
-    // it is preferred over the DKG shares table.
+    // Alright, now we set that the contracts have been deployed, so we no
+    // longer ask the stacks node about whether the they have been deployed
+    // or not and just query the smart contract.
     ctx.state().set_sbtc_contracts_deployed();
     let info = get_signer_set_info(&ctx).await.unwrap().unwrap();
 
@@ -1220,6 +1239,14 @@ async fn block_observer_updates_state_after_observing_bitcoin_block() {
                     Ok(info.map(Into::into))
                 })
             });
+
+        client.expect_get_contract_source().returning(|_, _| {
+            Box::pin(async {
+                Err(Error::StacksNodeResponse(
+                    mock_reqwests_status_code_error(404).await,
+                ))
+            })
+        });
     })
     .await;
 
@@ -1386,6 +1413,14 @@ async fn block_observer_updates_dkg_shares_after_observing_bitcoin_block() {
         client
             .expect_get_sortition_info()
             .returning(|_| Box::pin(std::future::ready(Ok(DUMMY_SORTITION_INFO.clone()))));
+
+        client.expect_get_contract_source().returning(|_, _| {
+            Box::pin(async {
+                Err(Error::StacksNodeResponse(
+                    mock_reqwests_status_code_error(404).await,
+                ))
+            })
+        });
     })
     .await;
 
@@ -1562,7 +1597,7 @@ async fn block_observer_updates_dkg_shares_after_observing_bitcoin_block() {
     testing::storage::drop_db(db).await;
 }
 
-#[test_log::test(tokio::test)]
+#[tokio::test]
 async fn block_observer_ignores_coinbase() {
     let mut rng = get_rng();
     let (rpc, faucet) = regtest::initialize_blockchain();
@@ -1593,6 +1628,7 @@ async fn block_observer_ignores_coinbase() {
         .with_mocked_stacks_client()
         .build();
 
+    ctx.state().set_sbtc_contracts_deployed();
     let mut signal_receiver = ctx.get_signal_receiver();
 
     // The block observer reaches out to the stacks node to get the most
@@ -1615,6 +1651,10 @@ async fn block_observer_ignores_coinbase() {
                 .map_err(Error::JsonSerialize);
             Box::pin(std::future::ready(response))
         });
+
+        client
+            .expect_get_current_signer_set_info()
+            .returning(|_| Box::pin(std::future::ready(Ok(None))));
     })
     .await;
 

--- a/signer/tests/integration/block_observer.rs
+++ b/signer/tests/integration/block_observer.rs
@@ -1127,7 +1127,7 @@ async fn next_headers_to_process_ignores_known_headers() {
 /// smart contracts have been deployed and returning None if they have not
 /// or if the smart contract contains only null data.
 #[tokio::test]
-async fn get_signer_set_info_falls_back() {
+async fn get_signer_set_info_checks_for_contract_deployment() {
     let db = testing::storage::new_test_database().await;
 
     let mut rng = get_rng();


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1811

## Changes

* Move the check for smart contract deployment to the block observer. It's more natural here, and doesn't result in a noisy start when starting the application.
* Updated the tests affected by the change.

## Testing Information

I repurposed one of our existing tests to test some of the new functionality. This is the new `get_signer_set_info_checks_for_contract_deployment` test. ~~I'm going to test this on devenv, just waiting for the build at the moment~~ I ran this on devenv and things seemed mostly fine. I saw some "concurrent WSTS activity observed" logs early on and also saw that my first deposit took two bitcoin block to be swept instead of one. The later deposits were promptly swept and those logs didn't show up after a while. I think this is an artifact of the 1 second bitcoin blocks pre-Nakamoto and 5 second polling of bitcoin core.

## Checklist

- [x] I have performed a self-review of my code
