### PR TITLE
fix: no more flaky `sign_bitcoin_transaction` integration test

### DIFF
--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -1975,6 +1975,9 @@ async fn sign_bitcoin_transaction() {
             .with_first_bitcoin_core_client()
             .with_emily_client(emily_client.clone())
             .with_mocked_stacks_client()
+            .modify_settings(|settings| {
+                settings.signer.bitcoin_processing_delay = Duration::from_millis(200);
+            })
             .build();
 
         backfill_bitcoin_blocks(&db, rpc, &chain_tip_info.hash).await;
@@ -2827,6 +2830,9 @@ async fn wsts_ids_set_during_dkg_and_signing_rounds() {
             .with_first_bitcoin_core_client()
             .with_emily_client(emily_client.clone())
             .with_mocked_stacks_client()
+            .modify_settings(|settings| {
+                settings.signer.bitcoin_processing_delay = Duration::from_millis(200);
+            })
             .build();
 
         backfill_bitcoin_blocks(&db, rpc, &chain_tip_info.hash).await;
@@ -3663,6 +3669,9 @@ async fn skip_smart_contract_deployment_and_key_rotation_if_up_to_date() {
             .with_first_bitcoin_core_client()
             .with_emily_client(emily_client.clone())
             .with_mocked_stacks_client()
+            .modify_settings(|settings| {
+                settings.signer.bitcoin_processing_delay = Duration::from_millis(200);
+            })
             .build();
 
         backfill_bitcoin_blocks(&db, rpc, &chain_tip_info.hash).await;
@@ -4702,6 +4711,9 @@ async fn sign_bitcoin_transaction_withdrawals() {
             .with_first_bitcoin_core_client()
             .with_emily_client(emily_client.clone())
             .with_mocked_stacks_client()
+            .modify_settings(|settings| {
+                settings.signer.bitcoin_processing_delay = Duration::from_millis(200);
+            })
             .build();
 
         backfill_bitcoin_blocks(&db, rpc, &chain_tip_info.hash).await;


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1810

I think the issue with the test was that the coordinator hasn't received everyone's votes for the deposit by the time that they go to process it. This meant that the coordinator don't see any deposits that have enough votes and move on. With a sleep, that gives everyone enough time to send their votes and for the coordinator to receive and process them before beginning their coordinator duties. Earlier versions of the signer wouldn't have this issue, because the coordinator would query the database for information (like the bitcoin chain tip for example), causing a delay and giving the signers more time to process the deposit in the test.

## Changes

* Add a coordinator delay to the `sign_bitcoin_transaction` and friends tests.


## Testing Information

After warming up bitcoin core by running `complete_deposit_validation_happy_path` 5 times in a row, I ran the `sign_bitcoin_transaction` test 10 times in a row and they all passed.

## Checklist

- [x] I have performed a self-review of my code
