### PR TITLE
chore: bump rust to 1.90

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-slim-bookworm AS build
+FROM rust:1.90.0-slim-bookworm AS build
 
 ARG CARGO_BUILD_ARGS="--release --locked"
 

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-slim-bookworm AS build
+FROM rust:1.90.0-slim-bookworm AS build
 
 ARG GIT_COMMIT
 RUN test -n "$GIT_COMMIT" || (echo "GIT_COMMIT not set" && false)

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ Below is the output on a machine that is able to build and run all the sources a
 
 ```text
 --- sBTC tool versions ---
-cargo 1.89.0 (c24e10642 2025-06-23)
+cargo 1.90.0 (840b83a10 2025-07-30)
 cargo-lambda 1.6.2 (2025-01-17Z)
 pnpm 9.1.0
 GNU Make 3.81
-uv 0.7.3 (Homebrew 2025-05-07)
+uv 0.8.13 (Homebrew 2025-08-21)
 ```
 
 ### Building

--- a/docker/sbtc/Dockerfile
+++ b/docker/sbtc/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.89.0-slim-bookworm AS builder
+FROM rust:1.90.0-slim-bookworm AS builder
 
 # Install dependencies.
 RUN apt-get update

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 components = ["rustfmt", "clippy"]
 targets = ["x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 profile = "minimal"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -55,7 +55,7 @@ who = "Nick Fitzgerald <fitzgen@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 696 # Nick Fitzgerald (fitzgen)
 start = "2019-03-16"
-end = "2025-07-30"
+end = "2026-08-21"
 
 [[audits.bytecodealliance.audits.adler]]
 who = "Alex Crichton <alex@alexcrichton.com>"


### PR DESCRIPTION
## Description

Bumps Rust to 1.90.0 and updates the usual code/docs references.

There were no new clippy warnings generated for this bump.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
