### PR TITLE
Update Emily Workflow Triggers

### DIFF
--- a/.github/workflows/deploy-emily.yaml
+++ b/.github/workflows/deploy-emily.yaml
@@ -47,6 +47,7 @@ jobs:
         id: set_env
         run: |
           ALLOWED_ENVS=("environment/sbtc-devnet" "environment/sbtc-testnet" "environment/sbtc-mainnet" "environment/sbtc-staging" "environment/sbtc-private-mainnet")
+          SHOULD_RUN=true
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             if [ "${GITHUB_REF_NAME}" != "main" ]; then
@@ -54,7 +55,6 @@ jobs:
               exit 1
             fi
 
-            SHOULD_RUN=true
             ENVIRONMENT="${{ github.event.inputs.environment }}"
 
             VALID=false


### PR DESCRIPTION
I've updated the emily deployment workflow to run on manual trigger on the main branch, as well as on pull requests that contain one of the allowed environment labels:
- `environment/sbtc-devnet`
- `environment/sbtc-testnet`
- `environment/sbtc-mainnet`
- `environment/sbtc-staging`
- `environment/sbtc-private-mainnet`

 The `stacks-sbtc/actions` versions used were also updated to the latest version.