### PR TITLE
fix: release builds broken because of carelessly hidden impls

### DIFF
--- a/signer/src/storage/model.rs
+++ b/signer/src/storage/model.rs
@@ -792,7 +792,6 @@ impl From<BitcoinTxId> for bitcoin::Txid {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl From<[u8; 32]> for BitcoinTxId {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bitcoin::Txid::from_byte_array(bytes))
@@ -862,7 +861,6 @@ impl From<BitcoinBlockHash> for bitcoin::BlockHash {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl From<[u8; 32]> for BitcoinBlockHash {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bitcoin::BlockHash::from_byte_array(bytes))
@@ -989,7 +987,6 @@ impl From<&StacksBlockHash> for StacksBlockId {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl From<[u8; 32]> for StacksBlockHash {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bytes)
@@ -1178,7 +1175,6 @@ impl From<StacksTxId> for blockstack_lib::burnchains::Txid {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl From<[u8; 32]> for StacksTxId {
     fn from(bytes: [u8; 32]) -> Self {
         Self(bytes)
@@ -1291,7 +1287,6 @@ impl From<&ScriptPubKey> for TaprootScriptHash {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
 impl From<[u8; 32]> for TaprootScriptHash {
     fn from(bytes: [u8; 32]) -> Self {
         bitcoin::TapNodeHash::from_byte_array(bytes).into()


### PR DESCRIPTION
## Description

## Changes

Restores `impl`s that were marked as testing in https://github.com/stacks-sbtc/sbtc/pull/1851.

## Testing Information

I tested this with `cargo build --bin signer --release --locked`, which is the same command we use in our Dockerfile for release builds. It would be nice if CI would catch this kind of thing. Basically, our usual CI could be fine for debug builds but broken for release builds.

## Checklist

- [x] I have performed a self-review of my code