### PR TITLE
chore: remove retries from integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,8 @@ nextest-archive: emily-cdk-synth
 
 # Runs nextest archives
 nextest-archive-run:
-	cargo $(CARGO_FLAGS) nextest --config-file nextest.toml run --no-fail-fast --retries 2 --archive-file $(NEXTEST_ARCHIVE_FILE)
-	cargo $(CARGO_FLAGS) nextest --config-file nextest.toml run --no-fail-fast --retries 2 --archive-file $(NEXTEST_SERIAL_ARCHIVE_FILE)
+	cargo $(CARGO_FLAGS) nextest --config-file nextest.toml run --no-fail-fast --archive-file $(NEXTEST_ARCHIVE_FILE)
+	cargo $(CARGO_FLAGS) nextest --config-file nextest.toml run --no-fail-fast --archive-file $(NEXTEST_SERIAL_ARCHIVE_FILE)
 
 nextest-archive-clean:
 	rm -f $(NEXTEST_ARCHIVE_FILE) $(NEXTEST_SERIAL_ARCHIVE_FILE)


### PR DESCRIPTION
## Description

Closes: #?

## Changes

Removes `--retries 2` from integration tests.

As we don't get any alert from the GH action, even if it detects flaky tests we would not notice unless we manually inspect the (green) job output. Removing it we will surface such tests by failing; if it ends up we have unfixable flaky tests or too much noise we can introduce it back.

## Refs
 - https://nexte.st/docs/features/retries/#retries-and-flaky-tests