### PR TITLE
[chore]: make compiler optimizations stronger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,6 @@ debug = false
 split-debuginfo = "unpacked"
 
 [profile.release]
-lto = "thin"
-codegen-units = 16
+lto = "fat"
+codegen-units = 1
 overflow-checks = true


### PR DESCRIPTION
## Description

Closes: no issue

## Changes

Fat lto allows cross-crate compiler optimizations while 1 codegen unit allows better cross-function compilation within single crate, sacrificing some compile time. I don't really know how to test performance increase, but probably it is some. OTOH I tested compile time, and `cargo build --bin signer --release --locked` shows around ~10 minutes locally (m2 with some other apps in background), so compile time seems not so bad (especially given the fact that I change settings only for release builds, which don't affect casual work).

docs about these settings: https://rustwiki.org/en/cargo/reference/profiles.html

Note: I'd check our release pipeline before merging

## Checklist

- [x] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
