### PR TITLE
feat: parallel tests - bitcoin validation

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -7,7 +7,6 @@ serial-integration = { max-threads = 1 }
 filter = """\
 binary(integration) and test(/::serial::/)
 
-or test(/^bitcoin_validation::/)
 or test(/^block_observer::/)
 or test(/^complete_deposit::/)
 or test(/^postgres::/)


### PR DESCRIPTION
## Description

Partial work for https://github.com/stacks-sbtc/sbtc/issues/1854
Breaking up https://github.com/stacks-sbtc/sbtc/pull/1875

## Changes

Use parallel testing setup for bitcoin validation tests.

## Testing Information

CI runs parallel tests.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
