### PR TITLE
feat: parallel tests - transaction signer

### DIFF
--- a/nextest.toml
+++ b/nextest.toml
@@ -13,7 +13,6 @@ or test(/^complete_deposit::/)
 or test(/^postgres::/)
 or test(/^request_decider::/)
 or test(/^transaction_coordinator::/)
-or test(/^transaction_signer::/)
 or test(/^withdrawal_accept::/)
 or test(/^withdrawal_reject::/)
 """

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -8,6 +8,7 @@ use fake::Fake as _;
 use fake::Faker;
 use lru::LruCache;
 use rand::rngs::OsRng;
+use sbtc::testing::containers::TestContainersBuilder;
 use signer::bitcoin::MockBitcoinInteract;
 use signer::bitcoin::rpc::BitcoinCoreClient;
 use signer::emily_client::MockEmilyInteract;
@@ -61,6 +62,7 @@ use wsts::net::DkgBegin;
 use wsts::net::Message as WstsNetMessage;
 use wsts::net::NonceRequest;
 
+use crate::containers::BitcoinContainerExt as _;
 use crate::setup::SweepAmounts;
 use crate::setup::TestSignerSet;
 use crate::setup::TestSweepSetup;
@@ -89,21 +91,24 @@ async fn signing_set_validation_check_for_stacks_transactions() {
 
     let mut rng = get_rng();
 
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
+
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
-        .with_first_bitcoin_core_client()
+        .with_bitcoin_client(bitcoin.get_client())
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .modify_settings(|settings| {
             settings.signer.bootstrap_signatures_required = 2;
         })
         .build();
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
     // This confirms a deposit transaction, and has a nice helper function
     // for storing a real deposit.
-    let mut setup =
-        TestSweepSetup::new_setup(BitcoinCoreClient::new_regtest(), faucet, 10000, &mut rng);
+    let mut setup = TestSweepSetup::new_setup(bitcoin.get_client(), faucet, 10000, &mut rng);
 
     // Let's get the blockchain data into the database.
     let chain_tip = BitcoinBlockRef {
@@ -188,21 +193,24 @@ async fn signing_set_validation_ignores_aggregate_key_in_request() {
 
     let mut rng = get_rng();
 
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
+
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
-        .with_first_bitcoin_core_client()
+        .with_bitcoin_client(bitcoin.get_client())
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .modify_settings(|settings| {
             settings.signer.bootstrap_signatures_required = 2;
         })
         .build();
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
     // This confirms a deposit transaction, and has a nice helper function
     // for storing a real deposit.
-    let mut setup =
-        TestSweepSetup::new_setup(BitcoinCoreClient::new_regtest(), faucet, 10000, &mut rng);
+    let mut setup = TestSweepSetup::new_setup(bitcoin.get_client(), faucet, 10000, &mut rng);
 
     // Let's get the blockchain data into the database.
     let chain_tip = BitcoinBlockRef {
@@ -289,9 +297,14 @@ async fn signer_rejects_stacks_txns_with_too_high_a_fee(
 
     let mut rng = get_rng();
 
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
+
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
-        .with_first_bitcoin_core_client()
+        .with_bitcoin_client(bitcoin.get_client())
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .modify_settings(|settings| {
@@ -303,12 +316,9 @@ async fn signer_rejects_stacks_txns_with_too_high_a_fee(
     // unrelated error, since we mock reaching out to the stacks node.
     set_deposit_incomplete(&mut ctx).await;
 
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
-
     // This confirms a deposit transaction, and has a nice helper function
     // for storing a real deposit.
-    let mut setup =
-        TestSweepSetup::new_setup(BitcoinCoreClient::new_regtest(), faucet, 10000, &mut rng);
+    let mut setup = TestSweepSetup::new_setup(bitcoin.get_client(), faucet, 10000, &mut rng);
 
     // Let's get the blockchain data into the database.
     let chain_tip = BitcoinBlockRef {
@@ -385,9 +395,14 @@ async fn signer_rejects_multiple_attempts_in_tenure() {
 
     let mut rng = get_rng();
 
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
+
     let mut ctx = TestContext::builder()
         .with_storage(db.clone())
-        .with_first_bitcoin_core_client()
+        .with_bitcoin_client(bitcoin.get_client())
         .with_mocked_emily_client()
         .with_mocked_stacks_client()
         .modify_settings(|settings| {
@@ -399,12 +414,9 @@ async fn signer_rejects_multiple_attempts_in_tenure() {
     // unrelated error, since we mock reaching out to the stacks node.
     set_deposit_incomplete(&mut ctx).await;
 
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
-
     // This confirms a deposit transaction, and has a nice helper function
     // for storing a real deposit.
-    let mut setup =
-        TestSweepSetup::new_setup(BitcoinCoreClient::new_regtest(), faucet, 10000, &mut rng);
+    let mut setup = TestSweepSetup::new_setup(bitcoin.get_client(), faucet, 10000, &mut rng);
 
     // Let's get the blockchain data into the database.
     let chain_tip = BitcoinBlockRef {
@@ -534,11 +546,13 @@ async fn assert_should_be_able_to_handle_sbtc_requests() {
         .build();
     ctx.state().update_current_limits(SbtcLimits::unlimited());
 
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
 
     // Create a test setup with a confirmed deposit transaction
-    let setup =
-        TestSweepSetup::new_setup(BitcoinCoreClient::new_regtest(), faucet, 10000, &mut rng);
+    let setup = TestSweepSetup::new_setup(bitcoin.get_client(), faucet, 10000, &mut rng);
     // Backfill the blockchain data into the database
     let chain_tip = BitcoinBlockRef {
         block_hash: setup.sweep_block_hash.into(),
@@ -679,7 +693,10 @@ async fn presign_requests_with_dkg_shares_status(status: DkgSharesStatus, is_ok:
         })
         .build();
 
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
 
     let signers = TestSignerSet::new(&mut rng);
     // Create a test setup object so that we can easily create proper DKG
@@ -690,12 +707,7 @@ async fn presign_requests_with_dkg_shares_status(status: DkgSharesStatus, is_ok:
         max_fee: 10000,
         is_deposit: true,
     };
-    let setup = TestSweepSetup2::new_setup(
-        signers,
-        BitcoinCoreClient::new_regtest(),
-        faucet,
-        &[amounts],
-    );
+    let setup = TestSweepSetup2::new_setup(signers, bitcoin.get_client(), faucet, &[amounts]);
 
     let block_header = rpc
         .get_block_header_info(&setup.deposit_block_hash)
@@ -785,7 +797,10 @@ pub async fn presign_request_ignore_request_if_already_processed_this_block() {
         .with_mocked_clients()
         .build();
 
-    let (rpc, faucet) = sbtc::testing::regtest::initialize_blockchain();
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+    let faucet = &bitcoin.get_faucet();
 
     let signers = TestSignerSet::new(&mut rng);
     // Create a test setup object so that we can easily create proper DKG
@@ -796,12 +811,7 @@ pub async fn presign_request_ignore_request_if_already_processed_this_block() {
         max_fee: 10000,
         is_deposit: true,
     };
-    let setup = TestSweepSetup2::new_setup(
-        signers,
-        BitcoinCoreClient::new_regtest(),
-        faucet,
-        &[amounts],
-    );
+    let setup = TestSweepSetup2::new_setup(signers, bitcoin.get_client(), faucet, &[amounts]);
 
     let block_header = rpc
         .get_block_header_info(&setup.deposit_block_hash)
@@ -903,302 +913,308 @@ pub async fn presign_request_ignore_request_if_already_processed_this_block() {
     testing::storage::drop_db(db).await;
 }
 
-#[test_log::test(tokio::test)]
-async fn new_state_machine_per_valid_sighash() {
-    let db = testing::storage::new_test_database().await;
+mod serial {
+    use super::*;
 
-    let mut rng = get_rng();
-    // Build the test context with mocked clients
-    let ctx = TestContext::builder()
-        .with_storage(db.clone())
-        .with_mocked_clients()
-        .modify_settings(|settings| {
-            settings.signer.bootstrap_signatures_required = 2;
-        })
-        .build();
+    #[test_log::test(tokio::test)]
+    async fn new_state_machine_per_valid_sighash() {
+        let db = testing::storage::new_test_database().await;
 
-    let (_, faucet) = sbtc::testing::regtest::initialize_blockchain();
+        let mut rng = get_rng();
+        // Build the test context with mocked clients
+        let ctx = TestContext::builder()
+            .with_storage(db.clone())
+            .with_mocked_clients()
+            .modify_settings(|settings| {
+                settings.signer.bootstrap_signatures_required = 2;
+            })
+            .build();
 
-    let signers = TestSignerSet::new(&mut rng);
-    // Create a test setup object so that we can easily create proper DKG
-    // shares in the database. Note that calling TestSweepSetup2::new_setup
-    // creates two bitcoin blocks.
-    let setup = TestSweepSetup2::new_setup(signers, BitcoinCoreClient::new_regtest(), faucet, &[]);
+        let (_, faucet) = sbtc::testing::regtest::initialize_blockchain();
 
-    setup.store_dkg_shares(&db).await;
+        let signers = TestSignerSet::new(&mut rng);
+        // Create a test setup object so that we can easily create proper DKG
+        // shares in the database. Note that calling TestSweepSetup2::new_setup
+        // creates two bitcoin blocks.
+        let setup =
+            TestSweepSetup2::new_setup(signers, BitcoinCoreClient::new_regtest(), faucet, &[]);
 
-    // Initialize the transaction signer event loop
-    let network = WanNetwork::default();
+        setup.store_dkg_shares(&db).await;
 
-    let net = network.connect(&ctx);
-    let mut tx_signer = TxSignerEventLoop {
-        network: net.spawn(),
-        context: ctx.clone(),
-        context_window: 10000,
-        wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
-        // We use this private key because it needs to be associated with
-        // one of the public keys that we stored in the DKG shares table.
-        signer_private_key: setup.signers.private_key(),
-        last_presign_block: None,
-        dkg_begin_pause: None,
-        dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
-        stacks_sign_request: LruCache::new(STACKS_SIGN_REQUEST_LRU_SIZE),
-    };
+        // Initialize the transaction signer event loop
+        let network = WanNetwork::default();
 
-    // We need to convince the signer event loop that it should accept the
-    // message that we are going to send it.
-    let report = MsgChainTipReport {
-        sender_is_coordinator: true,
-        chain_tip_status: ChainTipStatus::Canonical,
-        chain_tip: BitcoinBlockRef {
-            block_hash: BitcoinBlockHash::from([0; 32]),
-            block_height: 0u64.into(),
-        },
-    };
-
-    // The message that we will send is for the following sighash. We'll
-    // need to make sure that it is in our database first
-    let txid: BitcoinTxId = Faker.fake_with_rng(&mut rng);
-    let sighash: SigHash = Faker.fake_with_rng(&mut rng);
-
-    let row = BitcoinTxSigHash {
-        txid,
-        chain_tip: BitcoinBlockHash::from([0; 32]),
-        prevout_txid: BitcoinTxId::from([0; 32]),
-        prevout_output_index: 0,
-        sighash,
-        prevout_type: model::TxPrevoutType::Deposit,
-        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
-        is_valid_tx: true,
-        will_sign: true,
-        aggregate_key: PublicKey::from_private_key(&tx_signer.signer_private_key).into(),
-    };
-
-    db.write_bitcoin_txs_sighashes(&[row]).await.unwrap();
-
-    // Now for the nonce request message
-    let mut nonce_request_msg = WstsMessage {
-        id: WstsMessageId::Sweep(*txid),
-        inner: wsts::net::Message::NonceRequest(NonceRequest {
-            dkg_id: 1,
-            sign_id: 1,
-            sign_iter_id: 1,
-            message: sighash.to_byte_array().to_vec(),
-            signature_type: wsts::net::SignatureType::Schnorr,
-        }),
-    };
-    let msg_public_key = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
-
-    // Sanity check, the state machines cache should be empty.
-    assert!(tx_signer.wsts_state_machines.is_empty());
-
-    tx_signer
-        .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
-        .await
-        .unwrap();
-
-    // We should have a state machine associated with the sighash nonce
-    // request message that we just received.
-    let id1 = StateMachineId::BitcoinSign(sighash);
-    assert!(tx_signer.wsts_state_machines.contains(&id1));
-    assert_eq!(tx_signer.wsts_state_machines.len(), 1);
-
-    // Now let's see what happens when we receive a nonce request message
-    // for a sighash that we do not know about. Since the nonce request is
-    // not in the database we should return an error, and the state machine
-    // should not be in the local cache.
-    let random_sighash: SigHash = Faker.fake_with_rng(&mut rng);
-    match &mut nonce_request_msg.inner {
-        wsts::net::Message::NonceRequest(NonceRequest { message, .. }) => {
-            *message = random_sighash.as_byte_array().to_vec();
-        }
-        _ => panic!("You forgot to update the variant"),
-    };
-
-    let response = tx_signer
-        .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
-        .await;
-
-    let id2 = StateMachineId::BitcoinSign(random_sighash);
-    assert!(response.is_err());
-    assert!(tx_signer.wsts_state_machines.contains(&id1));
-    assert!(!tx_signer.wsts_state_machines.contains(&id2));
-    assert_eq!(tx_signer.wsts_state_machines.len(), 1);
-
-    testing::storage::drop_db(db).await;
-}
-
-/// Let's check that we always generate unique nonces for each sign
-/// request.
-#[test_log::test(tokio::test)]
-async fn nonce_response_unique_nonces() {
-    let db = testing::storage::new_test_database().await;
-
-    let mut rng = get_rng();
-    // Build the test context with mocked clients
-    let ctx = TestContext::builder()
-        .with_storage(db.clone())
-        .with_mocked_clients()
-        .build();
-
-    let (_, faucet) = sbtc::testing::regtest::initialize_blockchain();
-
-    let signers = TestSignerSet::new(&mut rng);
-    // Create a test setup object so that we can simply create proper DKG
-    // shares in the database. Note that calling TestSweepSetup2::new_setup
-    // creates two bitcoin blocks.
-    let setup = TestSweepSetup2::new_setup(signers, BitcoinCoreClient::new_regtest(), faucet, &[]);
-
-    setup.store_dkg_shares(&db).await;
-
-    // Initialize the transaction signer event loop
-    let network = WanNetwork::default();
-
-    let net = network.connect(&ctx);
-    let mut tx_signer = TxSignerEventLoop {
-        network: net.spawn(),
-        context: ctx.clone(),
-        context_window: 10000,
-        wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
-        // We use this private key because it needs to be associated with
-        // one of the public keys that we stored in the DKG shares table.
-        signer_private_key: setup.signers.private_key(),
-        dkg_begin_pause: None,
-        last_presign_block: None,
-        dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
-        stacks_sign_request: LruCache::new(STACKS_SIGN_REQUEST_LRU_SIZE),
-    };
-
-    // We need to convince the signer event loop that it should accept the
-    // message that we are going to send it.
-    let report = MsgChainTipReport {
-        sender_is_coordinator: true,
-        chain_tip_status: ChainTipStatus::Canonical,
-        chain_tip: BitcoinBlockRef {
-            block_hash: BitcoinBlockHash::from([0; 32]),
-            block_height: 0u64.into(),
-        },
-    };
-
-    // The message that we will send is for the following sighash. We'll
-    // need to make sure that it is in our database first
-    let txid: BitcoinTxId = Faker.fake_with_rng(&mut rng);
-    let sighash: SigHash = Faker.fake_with_rng(&mut rng);
-
-    let row = BitcoinTxSigHash {
-        txid,
-        chain_tip: BitcoinBlockHash::from([0; 32]),
-        prevout_txid: BitcoinTxId::from([0; 32]),
-        prevout_output_index: 0,
-        sighash,
-        prevout_type: model::TxPrevoutType::Deposit,
-        validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
-        is_valid_tx: true,
-        will_sign: true,
-        aggregate_key: PublicKey::from_private_key(&tx_signer.signer_private_key).into(),
-    };
-
-    db.write_bitcoin_txs_sighashes(&[row]).await.unwrap();
-
-    // Now for the nonce request message
-    let nonce_request_msg = WstsMessage {
-        id: WstsMessageId::Sweep(*txid),
-        inner: wsts::net::Message::NonceRequest(NonceRequest {
-            dkg_id: 1,
-            sign_id: 1,
-            sign_iter_id: 1,
-            message: sighash.to_byte_array().to_vec(),
-            signature_type: wsts::net::SignatureType::Schnorr,
-        }),
-    };
-    let msg_public_key = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
-
-    // Sanity check, the state machines cache should be empty.
-    assert!(tx_signer.wsts_state_machines.is_empty());
-
-    // This function listens for WSTS NonceResponse messages broadcast from
-    // the TxSignerEventLoop and returns them.
-    let func = |mut handle: SignerNetworkInstance| async move {
-        let signed_message = handle.receive().await.unwrap();
-        let Payload::WstsMessage(WstsMessage {
-            inner: WstsNetMessage::NonceResponse(response),
-            ..
-        }) = signed_message.inner.payload
-        else {
-            panic!("incorrect payload, test creator error");
+        let net = network.connect(&ctx);
+        let mut tx_signer = TxSignerEventLoop {
+            network: net.spawn(),
+            context: ctx.clone(),
+            context_window: 10000,
+            wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
+            // We use this private key because it needs to be associated with
+            // one of the public keys that we stored in the DKG shares table.
+            signer_private_key: setup.signers.private_key(),
+            last_presign_block: None,
+            dkg_begin_pause: None,
+            dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
+            stacks_sign_request: LruCache::new(STACKS_SIGN_REQUEST_LRU_SIZE),
         };
 
-        response
-    };
+        // We need to convince the signer event loop that it should accept the
+        // message that we are going to send it.
+        let report = MsgChainTipReport {
+            sender_is_coordinator: true,
+            chain_tip_status: ChainTipStatus::Canonical,
+            chain_tip: BitcoinBlockRef {
+                block_hash: BitcoinBlockHash::from([0; 32]),
+                block_height: 0u64.into(),
+            },
+        };
 
-    // Let's create a handle to listen to any messages generated during the
-    // handle_wsts_message call.
-    let handle = network.connect(&ctx).spawn();
+        // The message that we will send is for the following sighash. We'll
+        // need to make sure that it is in our database first
+        let txid: BitcoinTxId = Faker.fake_with_rng(&mut rng);
+        let sighash: SigHash = Faker.fake_with_rng(&mut rng);
 
-    tx_signer
-        .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
-        .await
-        .unwrap();
+        let row = BitcoinTxSigHash {
+            txid,
+            chain_tip: BitcoinBlockHash::from([0; 32]),
+            prevout_txid: BitcoinTxId::from([0; 32]),
+            prevout_output_index: 0,
+            sighash,
+            prevout_type: model::TxPrevoutType::Deposit,
+            validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+            is_valid_tx: true,
+            will_sign: true,
+            aggregate_key: PublicKey::from_private_key(&tx_signer.signer_private_key).into(),
+        };
 
-    // Let's listen for the nonce response.
-    let response1 = tokio::time::timeout(Duration::from_secs(2), func(handle))
-        .await
-        .unwrap();
+        db.write_bitcoin_txs_sighashes(&[row]).await.unwrap();
 
-    // Okay, let's try this again using the same message. This checks the
-    // case where we may be using a state machine stored in the
-    // TxSignerEventLoop. Although we currently do not reuse an existing
-    // state machine when we receive a nonce request, this is a check for
-    // any future code.
-    let handle = network.connect(&ctx).spawn();
-    tx_signer
-        .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
-        .await
-        .unwrap();
+        // Now for the nonce request message
+        let mut nonce_request_msg = WstsMessage {
+            id: WstsMessageId::Sweep(*txid),
+            inner: wsts::net::Message::NonceRequest(NonceRequest {
+                dkg_id: 1,
+                sign_id: 1,
+                sign_iter_id: 1,
+                message: sighash.to_byte_array().to_vec(),
+                signature_type: wsts::net::SignatureType::Schnorr,
+            }),
+        };
+        let msg_public_key = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
 
-    // Okay this one could be using the same signer state machine as the
-    // previous call; although, as mentioned above, it shouldn't.
-    let response2 = tokio::time::timeout(Duration::from_secs(2), func(handle))
-        .await
-        .unwrap();
+        // Sanity check, the state machines cache should be empty.
+        assert!(tx_signer.wsts_state_machines.is_empty());
 
-    // Let's clear all state machines so that we know that a new one is
-    // being created.
-    tx_signer.wsts_state_machines.clear();
+        tx_signer
+            .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
+            .await
+            .unwrap();
 
-    let handle = network.connect(&ctx).spawn();
-    tx_signer
-        .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
-        .await
-        .unwrap();
+        // We should have a state machine associated with the sighash nonce
+        // request message that we just received.
+        let id1 = StateMachineId::BitcoinSign(sighash);
+        assert!(tx_signer.wsts_state_machines.contains(&id1));
+        assert_eq!(tx_signer.wsts_state_machines.len(), 1);
 
-    // This one is for nonces generated by a fresh state machine.
-    let response3 = tokio::time::timeout(Duration::from_secs(2), func(handle))
-        .await
-        .unwrap();
+        // Now let's see what happens when we receive a nonce request message
+        // for a sighash that we do not know about. Since the nonce request is
+        // not in the database we should return an error, and the state machine
+        // should not be in the local cache.
+        let random_sighash: SigHash = Faker.fake_with_rng(&mut rng);
+        match &mut nonce_request_msg.inner {
+            wsts::net::Message::NonceRequest(NonceRequest { message, .. }) => {
+                *message = random_sighash.as_byte_array().to_vec();
+            }
+            _ => panic!("You forgot to update the variant"),
+        };
 
-    // The signer has only one key ID for their DKG shares, so they should
-    // only generate one nonce in their nonce response.
-    let nonces1 = response1.nonces.single();
-    let nonces2 = response2.nonces.single();
-    let nonces3 = response3.nonces.single();
-    // All of these nonces should be unique, so let's check. We compress
-    // the public nonces so that we can easily hash them in a set.
-    let nonces_list: [[u8; 33]; 6] = [
-        nonces1.D.compress().data,
-        nonces1.E.compress().data,
-        nonces2.D.compress().data,
-        nonces2.E.compress().data,
-        nonces3.D.compress().data,
-        nonces3.E.compress().data,
-    ];
-    let nonces_set = nonces_list.iter().copied().collect::<BTreeSet<[u8; 33]>>();
+        let response = tx_signer
+            .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
+            .await;
 
-    // If we have duplicates then we should have fewer entries in the set
-    // than in the list.
-    assert_eq!(nonces_set.len(), nonces_list.len());
+        let id2 = StateMachineId::BitcoinSign(random_sighash);
+        assert!(response.is_err());
+        assert!(tx_signer.wsts_state_machines.contains(&id1));
+        assert!(!tx_signer.wsts_state_machines.contains(&id2));
+        assert_eq!(tx_signer.wsts_state_machines.len(), 1);
 
-    testing::storage::drop_db(db).await;
+        testing::storage::drop_db(db).await;
+    }
+
+    /// Let's check that we always generate unique nonces for each sign
+    /// request.
+    #[test_log::test(tokio::test)]
+    async fn nonce_response_unique_nonces() {
+        let db = testing::storage::new_test_database().await;
+
+        let mut rng = get_rng();
+        // Build the test context with mocked clients
+        let ctx = TestContext::builder()
+            .with_storage(db.clone())
+            .with_mocked_clients()
+            .build();
+
+        let (_, faucet) = sbtc::testing::regtest::initialize_blockchain();
+
+        let signers = TestSignerSet::new(&mut rng);
+        // Create a test setup object so that we can simply create proper DKG
+        // shares in the database. Note that calling TestSweepSetup2::new_setup
+        // creates two bitcoin blocks.
+        let setup =
+            TestSweepSetup2::new_setup(signers, BitcoinCoreClient::new_regtest(), faucet, &[]);
+
+        setup.store_dkg_shares(&db).await;
+
+        // Initialize the transaction signer event loop
+        let network = WanNetwork::default();
+
+        let net = network.connect(&ctx);
+        let mut tx_signer = TxSignerEventLoop {
+            network: net.spawn(),
+            context: ctx.clone(),
+            context_window: 10000,
+            wsts_state_machines: LruCache::new(NonZeroUsize::new(100).unwrap()),
+            // We use this private key because it needs to be associated with
+            // one of the public keys that we stored in the DKG shares table.
+            signer_private_key: setup.signers.private_key(),
+            dkg_begin_pause: None,
+            last_presign_block: None,
+            dkg_verification_state_machines: LruCache::new(NonZeroUsize::new(5).unwrap()),
+            stacks_sign_request: LruCache::new(STACKS_SIGN_REQUEST_LRU_SIZE),
+        };
+
+        // We need to convince the signer event loop that it should accept the
+        // message that we are going to send it.
+        let report = MsgChainTipReport {
+            sender_is_coordinator: true,
+            chain_tip_status: ChainTipStatus::Canonical,
+            chain_tip: BitcoinBlockRef {
+                block_hash: BitcoinBlockHash::from([0; 32]),
+                block_height: 0u64.into(),
+            },
+        };
+
+        // The message that we will send is for the following sighash. We'll
+        // need to make sure that it is in our database first
+        let txid: BitcoinTxId = Faker.fake_with_rng(&mut rng);
+        let sighash: SigHash = Faker.fake_with_rng(&mut rng);
+
+        let row = BitcoinTxSigHash {
+            txid,
+            chain_tip: BitcoinBlockHash::from([0; 32]),
+            prevout_txid: BitcoinTxId::from([0; 32]),
+            prevout_output_index: 0,
+            sighash,
+            prevout_type: model::TxPrevoutType::Deposit,
+            validation_result: signer::bitcoin::validation::InputValidationResult::Ok,
+            is_valid_tx: true,
+            will_sign: true,
+            aggregate_key: PublicKey::from_private_key(&tx_signer.signer_private_key).into(),
+        };
+
+        db.write_bitcoin_txs_sighashes(&[row]).await.unwrap();
+
+        // Now for the nonce request message
+        let nonce_request_msg = WstsMessage {
+            id: WstsMessageId::Sweep(*txid),
+            inner: wsts::net::Message::NonceRequest(NonceRequest {
+                dkg_id: 1,
+                sign_id: 1,
+                sign_iter_id: 1,
+                message: sighash.to_byte_array().to_vec(),
+                signature_type: wsts::net::SignatureType::Schnorr,
+            }),
+        };
+        let msg_public_key = PublicKey::from_private_key(&PrivateKey::new(&mut rng));
+
+        // Sanity check, the state machines cache should be empty.
+        assert!(tx_signer.wsts_state_machines.is_empty());
+
+        // This function listens for WSTS NonceResponse messages broadcast from
+        // the TxSignerEventLoop and returns them.
+        let func = |mut handle: SignerNetworkInstance| async move {
+            let signed_message = handle.receive().await.unwrap();
+            let Payload::WstsMessage(WstsMessage {
+                inner: WstsNetMessage::NonceResponse(response),
+                ..
+            }) = signed_message.inner.payload
+            else {
+                panic!("incorrect payload, test creator error");
+            };
+
+            response
+        };
+
+        // Let's create a handle to listen to any messages generated during the
+        // handle_wsts_message call.
+        let handle = network.connect(&ctx).spawn();
+
+        tx_signer
+            .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
+            .await
+            .unwrap();
+
+        // Let's listen for the nonce response.
+        let response1 = tokio::time::timeout(Duration::from_secs(2), func(handle))
+            .await
+            .unwrap();
+
+        // Okay, let's try this again using the same message. This checks the
+        // case where we may be using a state machine stored in the
+        // TxSignerEventLoop. Although we currently do not reuse an existing
+        // state machine when we receive a nonce request, this is a check for
+        // any future code.
+        let handle = network.connect(&ctx).spawn();
+        tx_signer
+            .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
+            .await
+            .unwrap();
+
+        // Okay this one could be using the same signer state machine as the
+        // previous call; although, as mentioned above, it shouldn't.
+        let response2 = tokio::time::timeout(Duration::from_secs(2), func(handle))
+            .await
+            .unwrap();
+
+        // Let's clear all state machines so that we know that a new one is
+        // being created.
+        tx_signer.wsts_state_machines.clear();
+
+        let handle = network.connect(&ctx).spawn();
+        tx_signer
+            .handle_wsts_message(&nonce_request_msg, msg_public_key, &report)
+            .await
+            .unwrap();
+
+        // This one is for nonces generated by a fresh state machine.
+        let response3 = tokio::time::timeout(Duration::from_secs(2), func(handle))
+            .await
+            .unwrap();
+
+        // The signer has only one key ID for their DKG shares, so they should
+        // only generate one nonce in their nonce response.
+        let nonces1 = response1.nonces.single();
+        let nonces2 = response2.nonces.single();
+        let nonces3 = response3.nonces.single();
+        // All of these nonces should be unique, so let's check. We compress
+        // the public nonces so that we can easily hash them in a set.
+        let nonces_list: [[u8; 33]; 6] = [
+            nonces1.D.compress().data,
+            nonces1.E.compress().data,
+            nonces2.D.compress().data,
+            nonces2.E.compress().data,
+            nonces3.D.compress().data,
+            nonces3.E.compress().data,
+        ];
+        let nonces_set = nonces_list.iter().copied().collect::<BTreeSet<[u8; 33]>>();
+
+        // If we have duplicates then we should have fewer entries in the set
+        // than in the list.
+        assert_eq!(nonces_set.len(), nonces_list.len());
+
+        testing::storage::drop_db(db).await;
+    }
 }
 
 #[tokio::test]
@@ -1216,7 +1232,10 @@ async fn max_one_state_machine_per_bitcoin_block_hash_for_dkg() {
         .build();
 
     // Let's make sure that the database has the chain tip.
-    let (rpc, _) = sbtc::testing::regtest::initialize_blockchain();
+    let stack = TestContainersBuilder::start_bitcoin().await;
+    let bitcoin = stack.bitcoin().await;
+    let rpc = bitcoin.rpc();
+
     let headers = &get_canonical_chain_tip(rpc);
     let chain_tip = BitcoinBlockRef {
         block_hash: headers.hash.into(),


### PR DESCRIPTION
## Description

Partial work for https://github.com/stacks-sbtc/sbtc/issues/1854
Breaking up https://github.com/stacks-sbtc/sbtc/pull/1875

Consider hiding whitespaces for a sane review experience.

## Changes

Use parallel testing setup for transaction signer tests. Two tests that were already pretty fast were marked as serial.

## Testing Information

CI runs parallel tests.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
