### PR TITLE
Do Not Require Interactive Approval When Deploying Emily

### DIFF
--- a/.github/workflows/deploy-emily.yaml
+++ b/.github/workflows/deploy-emily.yaml
@@ -264,5 +264,5 @@ jobs:
           echo "Done bootstrapping CDK."
 
           echo "Deploying the stack..."
-          npx aws-cdk deploy
+          npx aws-cdk deploy --require-approval never
           echo "Deployed Emily Successfully!" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Added the `--require-approval never` flag to the `cdk deploy` step, as it was waiting for manual approval (`Y` key), which is impossible to do in GitHub Actions. This fix ensures that the step never requires interactive approval.