### PR TITLE
feat: skip database lookup when transaction-signer receives a message

### DIFF
--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -381,19 +381,11 @@ where
         msg_sender: PublicKey,
         msg_bitcoin_chain_tip: &model::BitcoinBlockHash,
     ) -> Result<MsgChainTipReport, Error> {
-        let storage = self.context.get_storage();
-
         let chain_tip = self
             .context
             .state()
             .bitcoin_chain_tip()
             .ok_or(Error::NoChainTip)?;
-
-        let is_known = storage
-            .get_bitcoin_block(msg_bitcoin_chain_tip)
-            .await?
-            .is_some();
-        let is_canonical = msg_bitcoin_chain_tip == &chain_tip.block_hash;
 
         let signer_set = self.context.coordinator_signer_set();
         let sender_is_coordinator = crate::transaction_coordinator::given_key_is_coordinator(
@@ -402,10 +394,10 @@ where
             &signer_set,
         );
 
-        let chain_tip_status = match (is_known, is_canonical) {
-            (true, true) => ChainTipStatus::Canonical,
-            (true, false) => ChainTipStatus::Known,
-            (false, _) => ChainTipStatus::Unknown,
+        let chain_tip_status = if msg_bitcoin_chain_tip == &chain_tip.block_hash {
+            ChainTipStatus::Canonical
+        } else {
+            ChainTipStatus::NonCanonical
         };
 
         Ok(MsgChainTipReport {
@@ -1609,16 +1601,14 @@ impl MsgChainTipReport {
     }
 }
 
-/// The status of a chain tip relative to the known blocks in the signer database.
+/// The status of a peer's chain tip relative to our canonical chain tip.
 #[derive(Debug, Clone, Copy, PartialEq, strum::Display)]
 #[strum(serialize_all = "SCREAMING_SNAKE_CASE")]
 pub enum ChainTipStatus {
     /// The chain tip is the tip of the canonical fork.
     Canonical,
-    /// The chain tip is for a known block, but is not the canonical chain tip.
-    Known,
-    /// The chain tip belongs to a block that hasn't been seen yet.
-    Unknown,
+    /// The chain tip of the sender does not match our canonical chain tip.
+    NonCanonical,
 }
 
 #[cfg(test)]
@@ -1912,7 +1902,7 @@ mod tests {
         // non canonical chain tip
         let chain_tip_report = MsgChainTipReport {
             sender_is_coordinator: true,
-            chain_tip_status: ChainTipStatus::Known,
+            chain_tip_status: ChainTipStatus::NonCanonical,
             chain_tip: Faker.fake(),
         };
 
@@ -1999,7 +1989,7 @@ mod tests {
         // non canonical chain tip
         let chain_tip_report = MsgChainTipReport {
             sender_is_coordinator: true,
-            chain_tip_status: ChainTipStatus::Known,
+            chain_tip_status: ChainTipStatus::NonCanonical,
             chain_tip: Faker.fake(),
         };
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1969

## Changes

* Remove the database look-up from `inspect_msg_chain_tip`

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
