### PR TITLE
feat: dockerignore git stuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ docker
 .git
 .gitmodules
 .gitworktrees
+node_modules


### PR DESCRIPTION
## Description

Closes nothing.

I ran into an issue building a docker image from a `git worktree` and this was the fix. Well the fix was the git stuff, I added `node_modules` since it makes sense. I'm mainly unsure if this affects our production builds in some weird way but it really shouldn't.

## Changes

* Add more folders to `.dockerignore`

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
