### PR TITLE
feat: remove unused code in `get_transaction_fee`

### DIFF
--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -21,7 +21,6 @@ use bitcoincore_rpc_json::GetTxOutResult;
 use crate::{error::Error, util::ApiFallbackClient};
 
 use super::BitcoinInteract;
-use super::TransactionLookupHint;
 use super::rpc::BitcoinBlockHeader;
 use super::rpc::BitcoinBlockInfo;
 use super::rpc::BitcoinCoreClient;
@@ -110,9 +109,8 @@ impl BitcoinInteract for ApiFallbackClient<BitcoinCoreClient> {
     async fn get_transaction_fee(
         &self,
         txid: &bitcoin::Txid,
-        lookup_hint: Option<TransactionLookupHint>,
     ) -> Result<super::GetTransactionFeeResult, Error> {
-        self.exec(|client, _| client.get_transaction_fee(txid, lookup_hint))
+        self.exec(|client, _| client.get_transaction_fee(txid))
             .await
     }
 

--- a/signer/src/bitcoin/mod.rs
+++ b/signer/src/bitcoin/mod.rs
@@ -32,18 +32,6 @@ pub struct GetTransactionFeeResult {
     pub vsize: u64,
 }
 
-/// An enum representing the possible locations of a transaction, used to
-/// optimize certain lookups. It is assumed that an
-/// `Option<TransactionLookupHint>` is used to indicate that the caller is
-/// unsure of the location of the transaction.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TransactionLookupHint {
-    /// The transaction is in the mempool.
-    Mempool,
-    /// The transaction is in a (known) block.
-    Confirmed,
-}
-
 /// Represents the ability to interact with the bitcoin blockchain
 #[cfg_attr(any(test, feature = "testing"), mockall::automock())]
 pub trait BitcoinInteract: Sync + Send {
@@ -123,13 +111,12 @@ pub trait BitcoinInteract: Sync + Send {
         include_mempool: bool,
     ) -> impl Future<Output = Result<Option<GetTxOutResult>, Error>> + Send;
 
-    /// Gets the associated fees for the given transaction. It is expected that
-    /// the provided transaction is known to the Bitcoin core node, either
-    /// confirmed or in the mempool, otherwise an error will be returned.
+    /// Gets the associated fees for the given transaction. It is expected
+    /// that the provided transaction is known to the Bitcoin core node, in
+    /// the mempool, otherwise an error will be returned.
     fn get_transaction_fee(
         &self,
-        tx: &Txid,
-        lookup_hint: Option<TransactionLookupHint>,
+        txid: &Txid,
     ) -> impl Future<Output = Result<GetTransactionFeeResult, Error>> + Send;
 
     /// Attempts to get the mempool entry for the given transaction ID.

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -28,7 +28,6 @@ use crate::error::Error;
 use crate::storage::model::BitcoinBlockHeight;
 
 use super::GetTransactionFeeResult;
-use super::TransactionLookupHint;
 
 /// A slimmed down type representing a response from bitcoin-core's
 /// getrawtransaction RPC.
@@ -210,19 +209,6 @@ pub struct OutputScriptPubKey {
     /// The scriptPubKey locking the UTXO.
     #[serde(rename = "hex")]
     pub script: ScriptBuf,
-}
-
-/// A slimmed down version of the `BitcoinTxInfo` struct which only contains the
-/// `fee`, `vsize`, and `confirmations` fields; used in fee-retrieval contexts.
-#[derive(Debug, Clone, Deserialize)]
-pub struct BitcoinTxFeeInfo {
-    /// The transaction fee paid to the bitcoin miners. If the transaction is
-    /// not confirmed, a number of RPC endpoints will not return this field.
-    #[serde(default, with = "bitcoin::amount::serde::as_btc::opt")]
-    pub fee: Option<Amount>,
-    /// The virtual transaction size (differs from size for witness
-    /// transactions).
-    pub vsize: u64,
 }
 
 /// A detailed version of a bitcoin block. It is a slimmed down version of
@@ -500,34 +486,6 @@ impl BitcoinCoreClient {
         }
     }
 
-    /// Fetch and decode raw transaction from bitcoin-core using the
-    /// `getrawtransaction` RPC with a verbosity of 2. This method returns a
-    /// highly slimmed-down version of the response, containing only the
-    /// `fee` and `vsize` fields for fees retrieval.
-    pub fn get_tx_fee_info(&self, txid: &Txid) -> Result<Option<BitcoinTxFeeInfo>, Error> {
-        let args = [
-            serde_json::to_value(txid).map_err(Error::JsonSerialize)?,
-            // This is the verbosity level. The acceptable values are 0, 1,
-            // and 2, and we want the 2 because it will include all the
-            // required fields of the type.
-            serde_json::Value::Number(serde_json::value::Number::from(2u32)),
-        ];
-
-        match self
-            .inner
-            .call::<BitcoinTxFeeInfo>("getrawtransaction", &args)
-        {
-            Ok(tx_info) => Ok(Some(tx_info)),
-            // If the `block_hash` is not found then the message is "Block
-            // hash not found", while if the transaction is not found in an
-            // actual block then the message is "No such transaction found
-            // in the provided block. Use `gettransaction` for wallet
-            // transactions." In both cases the code is the same.
-            Err(BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -5, .. }))) => Ok(None),
-            Err(err) => Err(Error::BitcoinCoreGetTransaction(err, *txid)),
-        }
-    }
-
     /// Scan the Bitcoin node's mempool to find transactions spending the
     /// provided output. This method uses the `gettxspendingprevout` RPC
     /// endpoint.
@@ -741,68 +699,12 @@ impl BitcoinInteract for BitcoinCoreClient {
         self.get_tx_out(outpoint, include_mempool)
     }
 
-    async fn get_transaction_fee(
-        &self,
-        txid: &bitcoin::Txid,
-        lookup_hint: Option<TransactionLookupHint>,
-    ) -> Result<GetTransactionFeeResult, Error> {
-        let vsize: u64;
-        let fee: u64;
-
-        match lookup_hint {
-            None => {
-                // Since we don't know if the transaction is confirmed or in
-                // the mempool, we first try to get the fee info from the
-                // confirmed transactions. This will also return a value if
-                // the transaction exists in the mempool, but the fee will be
-                // empty.
-                let tx_fee_info = self
-                    .get_tx_fee_info(txid)?
-                    .ok_or(Error::BitcoinTxMissing(*txid, None))?;
-
-                vsize = tx_fee_info.vsize;
-
-                // If the fee is present, then the transaction was confirmed and
-                // we can can simply use that value.
-                if let Some(tx_fee) = tx_fee_info.fee {
-                    fee = tx_fee.to_sat();
-                } else {
-                    // Otherwise, we need to get the mempool entry which does
-                    // include the fee information.
-                    let mempool_entry = self
-                        .get_mempool_entry(txid)?
-                        .ok_or(Error::BitcoinTxMissing(*txid, None))?;
-
-                    fee = mempool_entry.fees.base.to_sat();
-                }
-            }
-            Some(TransactionLookupHint::Confirmed) => {
-                let tx_fee_info = self
-                    .get_tx_fee_info(txid)?
-                    .ok_or(Error::BitcoinTxMissing(*txid, None))?;
-
-                vsize = tx_fee_info.vsize;
-
-                // If the transaction is confirmed, the fee will be present.
-                // But if not, we will return an error since the hint explicitly
-                // indicates that the transaction is confirmed.
-                fee = tx_fee_info
-                    .fee
-                    .ok_or(Error::BitcoinTxMissing(*txid, None))?
-                    .to_sat();
-            }
-            Some(TransactionLookupHint::Mempool) => {
-                // If the hint indicates that the transaction is in the mempool
-                // then we can skip the confirmed transaction lookup and go
-                // straight to the mempool entry.
-                let mempool_entry = self
-                    .get_mempool_entry(txid)?
-                    .ok_or(Error::BitcoinTxMissing(*txid, None))?;
-
-                vsize = mempool_entry.vsize;
-                fee = mempool_entry.fees.base.to_sat();
-            }
-        }
+    async fn get_transaction_fee(&self, txid: &Txid) -> Result<GetTransactionFeeResult, Error> {
+        let mempool_entry = self
+            .get_mempool_entry(txid)?
+            .ok_or(Error::BitcoinTxMissing(*txid, None))?;
+        let vsize = mempool_entry.vsize;
+        let fee = mempool_entry.fees.base.to_sat();
 
         // This should never happen since we're pulling the vsize from an actual
         // bitcoin transaction, but we'll check just in case.

--- a/signer/src/testing/block_observer.rs
+++ b/signer/src/testing/block_observer.rs
@@ -24,7 +24,6 @@ use sbtc::deposits::CreateDepositRequest;
 use crate::bitcoin::BitcoinBlockHashStreamProvider;
 use crate::bitcoin::BitcoinInteract;
 use crate::bitcoin::GetTransactionFeeResult;
-use crate::bitcoin::TransactionLookupHint;
 use crate::bitcoin::rpc::BitcoinBlockHeader;
 use crate::bitcoin::rpc::BitcoinBlockInfo;
 use crate::bitcoin::rpc::BitcoinTxInfo;
@@ -287,7 +286,6 @@ impl BitcoinInteract for TestHarness {
     async fn get_transaction_fee(
         &self,
         _txid: &bitcoin::Txid,
-        _lookup_hint: Option<TransactionLookupHint>,
     ) -> Result<GetTransactionFeeResult, Error> {
         unimplemented!()
     }

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -401,7 +401,6 @@ impl BitcoinInteract for WrappedMockBitcoinInteract {
     async fn get_transaction_fee(
         &self,
         _txid: &bitcoin::Txid,
-        _lookup_hint: Option<crate::bitcoin::TransactionLookupHint>,
     ) -> Result<GetTransactionFeeResult, Error> {
         unimplemented!()
     }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -20,7 +20,6 @@ use crate::WITHDRAWAL_BLOCKS_EXPIRY;
 use crate::WITHDRAWAL_DUST_LIMIT;
 use crate::WITHDRAWAL_EXPIRY_BUFFER;
 use crate::bitcoin::BitcoinInteract as _;
-use crate::bitcoin::TransactionLookupHint;
 use crate::bitcoin::utxo;
 use crate::bitcoin::utxo::Fees;
 use crate::bitcoin::utxo::UnsignedMockTransaction;
@@ -2416,7 +2415,7 @@ where
             let bitcoin_client = bitcoin_client.clone();
             async move {
                 bitcoin_client
-                    .get_transaction_fee(txid, Some(TransactionLookupHint::Mempool))
+                    .get_transaction_fee(txid)
                     .await
                     .map(|fee| (txid, fee))
             }
@@ -2446,11 +2445,7 @@ where
         // descendants then this will just result in an empty list.
         let descendant_fees = try_join_all(descendant_txids.iter().map(|txid| {
             let bitcoin_client = bitcoin_client.clone();
-            async move {
-                bitcoin_client
-                    .get_transaction_fee(txid, Some(TransactionLookupHint::Mempool))
-                    .await
-            }
+            async move { bitcoin_client.get_transaction_fee(txid).await }
         }))
         .await?;
 

--- a/signer/tests/integration/bitcoin_client.rs
+++ b/signer/tests/integration/bitcoin_client.rs
@@ -10,8 +10,8 @@ mod serial {
         self, AsUtxo as _, BITCOIN_CORE_RPC_ENDPOINT, BITCOIN_CORE_RPC_PASSWORD,
         BITCOIN_CORE_RPC_USERNAME, Recipient, p2wpkh_sign_transaction,
     };
+    use signer::bitcoin::BitcoinInteract as _;
     use signer::bitcoin::rpc::{BitcoinCoreClient, BitcoinCoreClientParams};
-    use signer::bitcoin::{BitcoinInteract as _, TransactionLookupHint};
     use signer::util::ApiFallbackClient;
     use url::Url;
 
@@ -80,76 +80,6 @@ mod serial {
     }
 
     #[tokio::test]
-    async fn calculate_transaction_fee_works_confirmed() {
-        let client = BitcoinCoreClient::new(
-            regtest::BITCOIN_CORE_RPC_ENDPOINT,
-            regtest::BITCOIN_CORE_RPC_USERNAME.to_string(),
-            regtest::BITCOIN_CORE_RPC_PASSWORD.to_string(),
-            Duration::from_secs(10),
-        )
-        .unwrap();
-
-        let (rpc, faucet) = regtest::initialize_blockchain();
-        let addr1 = Recipient::new(AddressType::P2wpkh);
-
-        // Get some coins to spend (and our "utxo" outpoint).
-        let outpoint = faucet.send_to(500_000, &addr1.address);
-        // A coinbase transaction is not spendable until it has 100 confirmations.
-        faucet.generate_blocks(1);
-
-        // Get a utxo to spend (this method gives us an `AsUtxo` type which is
-        // needed for signing below).
-        let utxo = addr1.get_utxos(rpc, Some(1_000)).pop().unwrap();
-        assert_eq!(utxo.outpoint(), outpoint);
-
-        // Create a transaction that spends the utxo.
-        let mut tx = bitcoin::Transaction {
-            version: Version::ONE,
-            lock_time: LockTime::ZERO,
-            input: vec![bitcoin::TxIn {
-                previous_output: utxo.outpoint(),
-                script_sig: ScriptBuf::new(),
-                sequence: Sequence::ZERO,
-                witness: Witness::new(),
-            }],
-            output: vec![
-                bitcoin::TxOut {
-                    value: Amount::from_sat(1_000),
-                    script_pubkey: addr1.address.script_pubkey(),
-                },
-                bitcoin::TxOut {
-                    value: utxo.amount - Amount::from_sat(1_000) * 2,
-                    script_pubkey: addr1.address.script_pubkey(),
-                },
-            ],
-        };
-
-        // Sign and broadcast the transaction
-        p2wpkh_sign_transaction(&mut tx, 0, &utxo, &addr1.keypair);
-        let txid = tx.compute_txid();
-        client.broadcast_transaction(&tx).await.unwrap();
-        // Confirm the transaction
-        let block_hash = faucet.generate_blocks(1).pop().unwrap();
-
-        let _ = client
-            .get_tx_info(&txid, &block_hash)
-            .unwrap()
-            .expect("expected to be able to retrieve txinfo verbosity 2 for confirmed tx");
-
-        let result = client
-            .get_transaction_fee(&txid, Some(TransactionLookupHint::Confirmed))
-            .await
-            .expect("failed to calculate transaction fee");
-
-        let expected_fee_total =
-            utxo.amount.to_sat() - tx.output.iter().map(|o| o.value.to_sat()).sum::<u64>();
-        let expected_fee_rate = expected_fee_total as f64 / tx.vsize() as f64;
-
-        assert_eq!(result.fee, expected_fee_total);
-        assert_eq!(result.fee_rate, expected_fee_rate);
-    }
-
-    #[tokio::test]
     async fn calculate_transaction_fee_works_mempool() {
         let client = BitcoinCoreClient::new(
             regtest::BITCOIN_CORE_RPC_ENDPOINT,
@@ -199,7 +129,7 @@ mod serial {
         client.broadcast_transaction(&tx).await.unwrap();
 
         let result = client
-            .get_transaction_fee(&tx.compute_txid(), Some(TransactionLookupHint::Mempool))
+            .get_transaction_fee(&tx.compute_txid())
             .await
             .expect("failed to calculate transaction fee");
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/1974.

## Changes

* Remove the unused branches in the `get_transaction_fee`.
* Remove an unnecessary struct, enum, and test.

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
