### PR TITLE
chore: remove deprecated testnet env

### DIFF
--- a/.github/workflows/deploy-emily.yaml
+++ b/.github/workflows/deploy-emily.yaml
@@ -10,10 +10,9 @@ on:
         type: choice
         options:
           - environment/sbtc-devnet
-          - environment/sbtc-testnet
-          - environment/sbtc-mainnet
           - environment/sbtc-staging
           - environment/sbtc-private-mainnet
+          - environment/sbtc-mainnet
   pull_request:
     branches:
       - main
@@ -46,7 +45,7 @@ jobs:
       - name: Resolve Environment
         id: set_env
         run: |
-          ALLOWED_ENVS=("environment/sbtc-devnet" "environment/sbtc-testnet" "environment/sbtc-mainnet" "environment/sbtc-staging" "environment/sbtc-private-mainnet")
+          ALLOWED_ENVS=("environment/sbtc-devnet" "environment/sbtc-mainnet" "environment/sbtc-staging" "environment/sbtc-private-mainnet")
           SHOULD_RUN=true
 
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then


### PR DESCRIPTION
## Description

Closes: #?

## Changes

Remove deprecated `environment/sbtc-testnet` from Emily deployment workflow. Also move mainnet down in the list.

## Testing Information

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
