### PR TITLE
fix: make sure devenv bitcoin mempool works

### DIFF
--- a/docker/bitcoin/bitcoin-mempool.conf
+++ b/docker/bitcoin/bitcoin-mempool.conf
@@ -12,17 +12,6 @@ disablewallet=0
 # call (default: 0)
 txindex=1
 
-# Connect only to the specified node; -noconnect disables automatic
-# connections (the rules for this peer are the same as for
-# -addnode). This option can be specified multiple times to connect
-# to multiple nodes.
-connect=bitcoin:18444
-
-# Maintain at most <n> automatic connections to peers (default: 125). This
-# limit does not apply to connections manually added via -addnode
-# or the addnode RPC, which have a separate limit of 8.
-maxconnections=8
-
 # Accept connections from outside (default: 1 if no -proxy, -connect or
 # -maxconnections=0)
 listen=1
@@ -47,6 +36,28 @@ dnsseed=0
 
 # Automatically create Tor onion service (default: 1)
 listenonion=0
+
+# Bind to the given address and add permission flags to the peers
+# connecting to it. Use [host]:port notation for IPv6. Allowed
+# permissions: bloomfilter (allow requesting BIP37 filtered blocks
+# and transactions), noban (do not ban for misbehavior; implies
+# download), forcerelay (relay transactions that are already in the
+# mempool; implies relay), relay (relay even in -blocksonly mode,
+# and unlimited transaction announcements), mempool (allow
+# requesting BIP35 mempool contents), download (allow getheaders
+# during IBD, no disconnect after maxuploadtarget limit), addr
+# (responses to GETADDR avoid hitting the cache and contain random
+# records with the most up-to-date info). Specify multiple
+# permissions separated by commas (default:
+# download,noban,mempool,relay). Can be specified multiple times.
+#whitebind=<[permissions@]addr>
+
+# Add permission flags to the peers connecting from the given IP address
+# (e.g. 1.2.3.4) or CIDR-notated network (e.g. 1.2.3.0/24). Uses
+# the same permissions as -whitebind. Can be specified multiple
+# times.
+#whitelist=<[permissions@]IP address or network>
+whitelist=0.0.0.0/0
 
 # [rpc]
 rpcserialversion=0

--- a/docker/bitcoin/bitcoin-pruned.conf
+++ b/docker/bitcoin/bitcoin-pruned.conf
@@ -15,6 +15,17 @@ disablewallet=0
 # call (default: 0)
 txindex=0
 
+# Connect only to the specified node; -noconnect disables automatic
+# connections (the rules for this peer are the same as for
+# -addnode). This option can be specified multiple times to connect
+# to multiple nodes.
+connect=bitcoin:18444
+
+# Maintain at most <n> automatic connections to peers (default: 125). This
+# limit does not apply to connections manually added via -addnode
+# or the addnode RPC, which have a separate limit of 8.
+maxconnections=8
+
 # Reduce storage requirements by enabling pruning (deleting) of old
 # blocks. This allows the pruneblockchain RPC to be called to
 # delete specific blocks and enables automatic pruning of old
@@ -44,7 +55,7 @@ prune=1
 discover=0
 
 # Allow DNS lookups for -addnode, -seednode and -connect (default: 1)
-dns=0
+dns=1
 
 # Query for peer addresses via DNS lookup, if low on addresses (default: 1
 # unless -connect used or -maxconnections=0)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -183,6 +183,7 @@ services:
     container_name: sbtc-signer-1
     depends_on:
       - postgres-1
+      - bitcoin-pruned
     environment:
       <<: *sbtc-signer-environment
       SIGNER_SIGNER__DB_ENDPOINT: postgresql://postgres:postgres@postgres-1:5432/signer
@@ -204,6 +205,7 @@ services:
     container_name: sbtc-signer-2
     depends_on:
       - postgres-2
+      - bitcoin-pruned
     environment:
       <<: *sbtc-signer-environment
       SIGNER_SIGNER__DB_ENDPOINT: postgresql://postgres:postgres@postgres-2:5432/signer
@@ -225,6 +227,7 @@ services:
     container_name: sbtc-signer-3
     depends_on:
       - postgres-3
+      - bitcoin-pruned
     environment:
       <<: *sbtc-signer-environment
       SIGNER_SIGNER__DB_ENDPOINT: postgresql://postgres:postgres@postgres-3:5432/signer
@@ -286,7 +289,7 @@ services:
     ports:
       - "127.0.0.1:18443:18443"
     volumes:
-      - ./bitcoin/bitcoin-pruned.conf:/root/.bitcoin/bitcoin.conf
+      - ./bitcoin/bitcoin-mempool.conf:/root/.bitcoin/bitcoin.conf
     entrypoint:
       - /bin/bash
       - -c
@@ -302,13 +305,13 @@ services:
       - default
       - bitcoin-mempool
 
-  bitcoin-mempool:
+  bitcoin-pruned:
     image: bitcoin/bitcoin:25.2
     depends_on:
       bitcoin:
         condition: service_healthy
     volumes:
-      - ./bitcoin/bitcoin-mempool.conf:/root/.bitcoin/bitcoin.conf
+      - ./bitcoin/bitcoin-pruned.conf:/root/.bitcoin/bitcoin.conf
     entrypoint:
       - /bin/bash
       - -c
@@ -321,6 +324,7 @@ services:
       timeout: 1s
       retries: 3
     profiles:
+      - default
       - bitcoin-mempool
 
   bitcoin-miner:
@@ -549,7 +553,7 @@ services:
       - "127.0.0.1:60401:60401"
       - "127.0.0.1:3002:3002"
     depends_on:
-      bitcoin-mempool:
+      bitcoin:
         condition: service_healthy
       bitcoin-miner:
         condition: service_started
@@ -622,7 +626,7 @@ services:
       ELECTRUM_PORT: "60401"
       ELECTRUM_TLS_ENABLED: "false"
       # Connect to bitcoin rpc
-      CORE_RPC_HOST: "bitcoin-mempool"
+      CORE_RPC_HOST: "bitcoin"
       CORE_RPC_PORT: "18443"
       CORE_RPC_USERNAME: "devnet"
       CORE_RPC_PASSWORD: "devnet"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -286,8 +286,6 @@ services:
   # --------------------
   bitcoin:
     image: bitcoin/bitcoin:25.2
-    ports:
-      - "127.0.0.1:18443:18443"
     volumes:
       - ./bitcoin/bitcoin-mempool.conf:/root/.bitcoin/bitcoin.conf
     entrypoint:
@@ -307,6 +305,8 @@ services:
 
   bitcoin-pruned:
     image: bitcoin/bitcoin:25.2
+    ports:
+      - "127.0.0.1:18443:18443"
     depends_on:
       bitcoin:
         condition: service_healthy

--- a/docker/sbtc/signer/signer-config.toml
+++ b/docker/sbtc/signer/signer-config.toml
@@ -55,7 +55,7 @@ endpoints = [
 # Environment: SIGNER_BITCOIN__RPC_ENDPOINTS
 # Environment Example: http://user:pass@seed-1:4122,http://foo:bar@seed-2:4122
 rpc_endpoints = [
-    "http://devnet:devnet@bitcoin:18443",
+    "http://devnet:devnet@bitcoin-pruned:18443",
 ]
 
 # An optional fallback fee rate in sats/vbyte to use when the initial fee rate


### PR DESCRIPTION
## Description

Fixes an issue that arose after https://github.com/stacks-sbtc/sbtc/pull/1976 was merged.

The local mempool.space containers needs access to a bitcoin core node with the `txindex` enabled. We added another bitcoin core node that had the `txindex` enabled, but that doesn't appear to work reliably, and this PR fixes it.

## Changes

* Make the main node a non-pruned node on devenv. Point electrs at the main bitcoin node.
* Point the sBTC signers use the pruned node.
* Allow the pruned node to fetch more data from the non-pruned node on devenv. This is to allow the pruned node to have the same mempool data as the main node. 

## Testing Information

## Checklist

- [x] I have performed a self-review of my code