### PR TITLE
fix: install gettext for envsubst

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -51,5 +51,4 @@ RUN export LIBCLANG_PATH="$(find /usr/lib/llvm-* -name lib -type d | head -n 1)"
 FROM debian:trixie-slim AS blocklist-client
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/blocklist-client /usr/local/bin/blocklist-client
-
 ENTRYPOINT ["/usr/local/bin/blocklist-client"]

--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -51,4 +51,10 @@ RUN export LIBCLANG_PATH="$(find /usr/lib/llvm-* -name lib -type d | head -n 1)"
 FROM debian:trixie-slim AS blocklist-client
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/blocklist-client /usr/local/bin/blocklist-client
+
+# TODO: remove this once everybody removed envsubst
+# gettext provides envsubst
+RUN apt-get install -y gettext --no-install-recommends && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/usr/local/bin/blocklist-client"]

--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -52,9 +52,4 @@ FROM debian:trixie-slim AS blocklist-client
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/blocklist-client /usr/local/bin/blocklist-client
 
-# TODO: remove this once everybody removed envsubst
-# gettext provides envsubst
-RUN apt-get install -y gettext --no-install-recommends && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
 ENTRYPOINT ["/usr/local/bin/blocklist-client"]

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -53,4 +53,10 @@ RUN export LIBCLANG_PATH="$(find /usr/lib/llvm-* -name lib -type d | head -n 1)"
 FROM debian:trixie-slim AS signer
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/signer /usr/local/bin/signer
+
+# TODO: remove this once everybody removed envsubst
+# gettext provides envsubst
+RUN apt-get install -y gettext --no-install-recommends && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 ENTRYPOINT ["/usr/local/bin/signer", "--config", "/signer-config.toml", "--migrate-db"]

--- a/.github/actions/dockerfiles/Dockerfile.signer.debian
+++ b/.github/actions/dockerfiles/Dockerfile.signer.debian
@@ -19,6 +19,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc-x86-64-linux-gnu \
     g++-x86-64-linux-gnu \
     findutils \
+    # TODO: remove this once everybody removed envsubst
+    # gettext provides envsubst
+    gettext \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Add the Rust target for the target architecture.
@@ -53,10 +56,6 @@ RUN export LIBCLANG_PATH="$(find /usr/lib/llvm-* -name lib -type d | head -n 1)"
 FROM debian:trixie-slim AS signer
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/signer /usr/local/bin/signer
-
 # TODO: remove this once everybody removed envsubst
-# gettext provides envsubst
-RUN apt-get install -y gettext --no-install-recommends && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
-
+COPY --from=build /usr/bin/envsubst /usr/bin/envsubst
 ENTRYPOINT ["/usr/local/bin/signer", "--config", "/signer-config.toml", "--migrate-db"]


### PR DESCRIPTION
## Description

Closes: https://github.com/stacks-sbtc/sbtc/issues/2018

## Changes

Install missing `envsubst` to make the image backward compatible with old docker compose file.

## Testing Information

Tested locally:
 - Running devenv with built prod images works fine
 - We can envsubst in the signer container

## Checklist

- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
