### PR TITLE
feat: send over the total vsize in the fees object

### DIFF
--- a/protobufs/stacks/signer/v1/common.proto
+++ b/protobufs/stacks/signer/v1/common.proto
@@ -19,10 +19,12 @@ message QualifiedRequestId {
   stacks.StacksBlockId block_hash = 3;
 }
 
-// Describes the fees for a transaction.
+// Describes the fees for a transaction package.
 message Fees {
-  // The total fee paid in sats for the transaction.
+  // The total fee paid in sats for the transaction package.
   uint64 total = 1;
   // The fee rate paid in sats per virtual byte.
   double rate = 2;
+  // The size of the transaction package in virtual bytes. 
+  uint64 vsize = 3;
 }

--- a/protobufs/stacks/signer/v1/common.proto
+++ b/protobufs/stacks/signer/v1/common.proto
@@ -25,6 +25,6 @@ message Fees {
   uint64 total = 1;
   // The fee rate paid in sats per virtual byte.
   double rate = 2;
-  // The size of the transaction package in virtual bytes. 
+  // The size of the transaction package in virtual bytes.
   uint64 vsize = 3;
 }

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -1511,11 +1511,11 @@ mod tests {
                 withdrawals: Vec::new(),
             }],
             fee_rate: 25.0,
-            last_fees: Some(Fees {
-                total: u64::MAX,
-                rate: 25.0,
-                vsize: NonZeroU64::new(u64::MAX),
-            }),
+            last_fees: Some(Fees::new_unchecked(
+                u64::MAX,
+                25.0,
+                NonZeroU64::new(u64::MAX),
+            )),
         };
         let large_overhead = measure_overhead(large_presign_request);
 
@@ -1658,11 +1658,11 @@ mod tests {
         // Now we add in the fee rate and some last fees to make the final
         // check more realistic.
         presign.fee_rate = 25.1234567;
-        presign.last_fees = Some(Fees {
-            total: u64::MAX,
-            rate: 25.1234567,
-            vsize: NonZeroU64::new(u64::MAX),
-        });
+        presign.last_fees = Some(Fees::new_unchecked(
+            u64::MAX,
+            25.1234567,
+            NonZeroU64::new(u64::MAX),
+        ));
 
         // Wrap the presign request in a Signed<SignerMessage>, since the
         // signed message is what gets encoded and broadcast.

--- a/signer/src/bitcoin/packaging.rs
+++ b/signer/src/bitcoin/packaging.rs
@@ -625,6 +625,7 @@ mod tests {
     use rand::Rng;
     use rand::prelude::SliceRandom as _;
     use signer::testing::get_rng;
+    use std::num::NonZeroU64;
     use std::sync::atomic::AtomicU64;
     use test_case::test_case;
 
@@ -1510,7 +1511,11 @@ mod tests {
                 withdrawals: Vec::new(),
             }],
             fee_rate: 25.0,
-            last_fees: Some(Fees { total: u64::MAX, rate: 25.0 }),
+            last_fees: Some(Fees {
+                total: u64::MAX,
+                rate: 25.0,
+                vsize: NonZeroU64::new(u64::MAX),
+            }),
         };
         let large_overhead = measure_overhead(large_presign_request);
 
@@ -1656,6 +1661,7 @@ mod tests {
         presign.last_fees = Some(Fees {
             total: u64::MAX,
             rate: 25.1234567,
+            vsize: NonZeroU64::new(u64::MAX),
         });
 
         // Wrap the presign request in a Signed<SignerMessage>, since the

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -129,7 +129,7 @@ pub struct Fees {
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     pub rate: f64,
-    /// The size of the transaction package in virtual bytes. 
+    /// The size of the transaction package in virtual bytes.
     ///
     /// This is optional because we need to be backwards compatible until
     /// we know that all signers are sending this value.

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -128,11 +128,19 @@ pub struct Fees {
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     pub rate: f64,
+    /// The size of the transaction in virtual bytes.
+    pub vsize: Option<u64>,
 }
 
 impl Fees {
-    /// A zero-fee [`Fees`] instance.
-    pub const ZERO: Self = Self { total: 0, rate: 0.0 };
+    /// Get the fee rate for the fees.
+    pub fn rate(&self) -> f64 {
+        if let Some(vsize) = self.vsize {
+            self.total as f64 / vsize as f64
+        } else {
+            self.rate
+        }
+    }
 }
 
 /// A trait for getting the fees for a given instance.
@@ -397,12 +405,13 @@ impl SbtcRequests {
 /// BIP-125: https://github.com/bitcoin/bips/blob/master/bip-0125.mediawiki#implementation-details
 fn compute_transaction_fee(tx_vsize: f64, fee_rate: f64, last_fees: Option<Fees>) -> u64 {
     match last_fees {
-        Some(Fees { total, rate }) => {
+        Some(fees) => {
             // The requirement for an RBF transaction is that the new fee
             // amount be greater than the old fee amount.
+            let rate = fees.rate();
             let minimum_fee_rate = fee_rate.max(rate + rate * SATS_PER_VBYTE_INCREMENT);
             let fee_increment = tx_vsize * DEFAULT_INCREMENTAL_RELAY_FEE_RATE;
-            (total as f64 + fee_increment)
+            (fees.total as f64 + fee_increment)
                 .max(tx_vsize * minimum_fee_rate)
                 .ceil() as u64
         }
@@ -2626,6 +2635,7 @@ mod tests {
         requests.signer_state.last_fees = Some(Fees {
             total: old_fee_total,
             rate: old_fee_rate,
+            vsize: None,
         });
 
         let transactions = requests.construct_transactions().unwrap();

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1684,6 +1684,7 @@ impl TxDeconstructor for BitcoinTxInfo {
 
 #[cfg(test)]
 mod tests {
+    use core::f64;
     use std::collections::BTreeSet;
     use std::str::FromStr as _;
     use std::sync::atomic::AtomicU64;
@@ -3268,6 +3269,35 @@ mod tests {
             .sum::<u32>();
 
         assert_eq!(package_vsize, total_vsize);
+    }
+
+    #[test_case(0, true; "total is zero")]
+    #[test_case(100, true; "total is one hundred")]
+    #[test_case(f64::exp2(f64::MANTISSA_DIGITS as f64) as u64, false; "total is max f64 lossless integer")]
+    #[test_case(Amount::MAX_MONEY.to_sat() + 1, false; "total is over max money")]
+    #[test_case(Amount::MAX_MONEY.to_sat(), true; "total is max money")]
+    #[test_case(Amount::MAX_MONEY.to_sat() - 1, true; "total is just below max money")]
+    fn test_fees_creation(total: u64, is_ok: bool) {
+        let fees = Fees::new(total, 1.0, None);
+        assert_eq!(fees.is_ok(), is_ok);
+    }
+
+    #[test]
+    fn test_fees_rate() {
+        // Whenever the vsize is missing, the rate is whatever was set.
+        let fees = Fees::new(100, 1.0, None).unwrap();
+        assert_eq!(fees.rate(), 1.0);
+
+        let fees = Fees::new(100, 2.0, None).unwrap();
+        assert_eq!(fees.rate(), 2.0);
+
+        // Whenever the vsize is set, the rate() is whatever total / vsize
+        // is, and the rate field is ignored.
+        let fees = Fees::new(100, 2.0, NonZeroU64::new(100)).unwrap();
+        assert_eq!(fees.rate(), 1.0);
+
+        let fees = Fees::new(100, 25.0, NonZeroU64::new(200)).unwrap();
+        assert_eq!(fees.rate(), 0.5);
     }
 
     #[test_case(

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -128,7 +128,7 @@ pub struct Fees {
     /// The total fee paid in sats for the transaction package.
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
-    pub rate: f64,
+    rate: f64,
     /// The size of the transaction package in virtual bytes.
     ///
     /// This is optional because we need to be backwards compatible until
@@ -137,6 +137,23 @@ pub struct Fees {
 }
 
 impl Fees {
+    /// Create a new [`Fees`] instance.
+    ///
+    /// This function will return an error if the total fees are greater than
+    /// the maximum amount of bitcoin.
+    pub fn new(total: u64, rate: f64, vsize: Option<NonZeroU64>) -> Result<Self, Error> {
+        if total > Amount::MAX_MONEY.to_sat() {
+            return Err(Error::InvalidTotalFees(total));
+        }
+        Ok(Self { total, rate, vsize })
+    }
+
+    /// Create a new [`Fees`] instance.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new_unchecked(total: u64, rate: f64, vsize: Option<NonZeroU64>) -> Self {
+        Self { total, rate, vsize }
+    }
+
     /// Compute the fee rate, in sats per vbyte.
     ///
     /// This prefers to compute the fee rate when possible, and only falls

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -122,14 +122,14 @@ static DUMMY_SIGNATURE: LazyLock<Signature> = LazyLock::new(|| Signature {
     sighash_type: TapSighashType::All,
 });
 
-/// Describes the fees for a transaction.
+/// Describes the fees for a transaction package.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct Fees {
-    /// The total fee paid in sats for the transaction.
+    /// The total fee paid in sats for the transaction package.
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     pub rate: f64,
-    /// The size of the transaction in virtual bytes. 
+    /// The size of the transaction package in virtual bytes. 
     ///
     /// This is optional because we need to be backwards compatible until
     /// we know that all signers are sending this value.

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1,6 +1,7 @@
 //! Utxo management and transaction construction
 
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 use std::sync::LazyLock;
 
 use bitcoin::Amount;
@@ -128,15 +129,23 @@ pub struct Fees {
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     pub rate: f64,
-    /// The size of the transaction in virtual bytes.
-    pub vsize: Option<u64>,
+    /// The size of the transaction in virtual bytes. 
+    ///
+    /// This is optional because we need to be backwards compatible until
+    /// we know that all signers are sending this value.
+    pub vsize: Option<NonZeroU64>,
 }
 
 impl Fees {
-    /// Get the fee rate for the fees.
+    /// Compute the fee rate, in sats per vbyte.
+    ///
+    /// This prefers to compute the fee rate when possible, and only falls
+    /// back to the given fee rate when the vsize is not available. This
+    /// way is only temporary until signers have upgraded to always send
+    /// the vsize.
     pub fn rate(&self) -> f64 {
         if let Some(vsize) = self.vsize {
-            self.total as f64 / vsize as f64
+            self.total as f64 / vsize.get() as f64
         } else {
             self.rate
         }

--- a/signer/src/bitcoin/utxo.rs
+++ b/signer/src/bitcoin/utxo.rs
@@ -1684,7 +1684,6 @@ impl TxDeconstructor for BitcoinTxInfo {
 
 #[cfg(test)]
 mod tests {
-    use core::f64;
     use std::collections::BTreeSet;
     use std::str::FromStr as _;
     use std::sync::atomic::AtomicU64;

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -277,9 +277,10 @@ pub enum Error {
     #[error("the change amounts for the transaction is negative: {0}")]
     InvalidAmount(i64),
 
-    /// Old fee estimate
-    #[error("got an old fee estimate")]
-    OldFeeEstimate,
+    /// Getting this error means a programming error or an error in
+    /// bitcoin-core.
+    #[error("total fees paid for a transaction package was more than the max amount of sats: {0}")]
+    InvalidTotalFees(u64),
 
     /// No good fee estimate
     #[error("failed to get fee estimates from all fee estimate sources")]

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -1104,11 +1104,11 @@ mod tests {
         let presign = BitcoinPreSignRequest {
             request_package,
             fee_rate: 25.1234567,
-            last_fees: Some(Fees {
-                total: u64::MAX,
-                rate: 25.1234567,
-                vsize: NonZeroU64::new(u64::MAX),
-            }),
+            last_fees: Some(Fees::new_unchecked(
+                u64::MAX,
+                25.1234567,
+                NonZeroU64::new(u64::MAX),
+            )),
         };
 
         let signed = SignerMessage {

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -514,6 +514,8 @@ impl SignerSwarm {
 
 #[cfg(test)]
 mod tests {
+    use std::num::NonZeroU64;
+
     use fake::Fake as _;
     use futures::StreamExt as _;
     use libp2p::gossipsub::Message as GossipsubMessage;
@@ -1105,6 +1107,7 @@ mod tests {
             last_fees: Some(Fees {
                 total: u64::MAX,
                 rate: 25.1234567,
+                vsize: NonZeroU64::new(u64::MAX),
             }),
         };
 

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -9,6 +9,7 @@ use std::collections::BTreeMap;
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 
 use bitcoin::OutPoint;
 use clarity::codec::StacksMessageCodec as _;
@@ -1210,6 +1211,7 @@ impl From<Fees> for proto::Fees {
         proto::Fees {
             total: value.total,
             rate: value.rate,
+            vsize: value.vsize.map(NonZeroU64::get).unwrap_or(0),
         }
     }
 }
@@ -1219,6 +1221,7 @@ impl From<proto::Fees> for Fees {
         Fees {
             total: value.total,
             rate: value.rate,
+            vsize: NonZeroU64::new(value.vsize),
         }
     }
 }

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -1210,19 +1210,17 @@ impl From<Fees> for proto::Fees {
     fn from(value: Fees) -> Self {
         proto::Fees {
             total: value.total,
-            rate: value.rate,
+            rate: value.rate(),
             vsize: value.vsize.map(NonZeroU64::get).unwrap_or(0),
         }
     }
 }
 
-impl From<proto::Fees> for Fees {
-    fn from(value: proto::Fees) -> Self {
-        Fees {
-            total: value.total,
-            rate: value.rate,
-            vsize: NonZeroU64::new(value.vsize),
-        }
+impl TryFrom<proto::Fees> for Fees {
+    type Error = Error;
+    fn try_from(value: proto::Fees) -> Result<Self, Self::Error> {
+        let vsize = NonZeroU64::new(value.vsize);
+        Fees::new(value.total, value.rate, vsize)
     }
 }
 
@@ -1250,7 +1248,7 @@ impl TryFrom<proto::BitcoinPreSignRequest> for BitcoinPreSignRequest {
                 .map(|v| v.try_into())
                 .collect::<Result<Vec<_>, _>>()?,
             fee_rate: value.fee_rate,
-            last_fees: value.last_fees.map(|v| v.into()),
+            last_fees: value.last_fees.map(|v| v.try_into()).transpose()?,
         })
     }
 }

--- a/signer/src/proto/generated/stacks.signer.v1.rs
+++ b/signer/src/proto/generated/stacks.signer.v1.rs
@@ -17,15 +17,18 @@ pub struct QualifiedRequestId {
     #[prost(message, optional, tag = "3")]
     pub block_hash: ::core::option::Option<super::super::StacksBlockId>,
 }
-/// Describes the fees for a transaction.
+/// Describes the fees for a transaction package.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Fees {
-    /// The total fee paid in sats for the transaction.
+    /// The total fee paid in sats for the transaction package.
     #[prost(uint64, tag = "1")]
     pub total: u64,
     /// The fee rate paid in sats per virtual byte.
     #[prost(double, tag = "2")]
     pub rate: f64,
+    /// The size of the transaction package in virtual bytes.
+    #[prost(uint64, tag = "3")]
+    pub vsize: u64,
 }
 /// Represents a decision to accept or reject a deposit request.
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -753,8 +753,8 @@ impl fake::Dummy<fake::Faker> for TxRequestIds {
 }
 
 impl fake::Dummy<fake::Faker> for Fees {
-    fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
-        let total: u64 = config.fake_with_rng(rng);
+    fn dummy_with_rng<R: rand::RngCore + ?Sized>(_: &fake::Faker, rng: &mut R) -> Self {
+        let total: u64 = (0..=Amount::MAX_MONEY.to_sat()).fake_with_rng(rng);
         let vsize: u64 = (1..101000).fake_with_rng(rng);
         let rate: f64 = total as f64 / vsize as f64;
         Fees::new_unchecked(total, rate, NonZeroU64::new(vsize))

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -757,11 +757,7 @@ impl fake::Dummy<fake::Faker> for Fees {
         let total: u64 = config.fake_with_rng(rng);
         let vsize: u64 = (1..101000).fake_with_rng(rng);
         let rate: f64 = total as f64 / vsize as f64;
-        Fees {
-            total,
-            rate,
-            vsize: NonZeroU64::new(vsize),
-        }
+        Fees::new_unchecked(total, rate, NonZeroU64::new(vsize))
     }
 }
 

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -3,6 +3,7 @@
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 use std::ops::Range;
 
 use bitcoin::Amount;
@@ -753,9 +754,13 @@ impl fake::Dummy<fake::Faker> for TxRequestIds {
 
 impl fake::Dummy<fake::Faker> for Fees {
     fn dummy_with_rng<R: rand::RngCore + ?Sized>(config: &fake::Faker, rng: &mut R) -> Self {
+        let total: u64 = config.fake_with_rng(rng);
+        let vsize: u64 = (1..101000).fake_with_rng(rng);
+        let rate: f64 = total as f64 / vsize as f64;
         Fees {
-            total: config.fake_with_rng(rng),
-            rate: config.fake_with_rng(rng),
+            total,
+            rate,
+            vsize: NonZeroU64::new(vsize),
         }
     }
 }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -8,6 +8,7 @@
 use std::collections::BTreeSet;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 use std::time::Duration;
 
 use blockstack_lib::chainstate::stacks::StacksTransaction;
@@ -2520,7 +2521,11 @@ where
         // need to check for division by zero.
         let rate = total_fees as f64 / total_vsize as f64;
 
-        Ok(Some(Fees { total: total_fees, rate }))
+        Ok(Some(Fees {
+            total: total_fees,
+            rate,
+            vsize: NonZeroU64::new(total_vsize),
+        }))
     }
 
     /// Estimate transaction fees for a Stacks contract call. This function

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2509,11 +2509,15 @@ where
         // summing the vsize of the transactions for fee-rate calculation later.
         // If there were no descendants then this will just be the fee and size
         // from the best root sweep transaction.
-        let (total_fees, total_vsize) = descendant_fees
-            .into_iter()
-            .fold((fees.fee, fees.vsize), |acc, fees| {
-                (acc.0 + fees.fee, acc.1 + fees.vsize)
-            });
+        let (total_fees, total_vsize) =
+            descendant_fees
+                .into_iter()
+                .fold((fees.fee, fees.vsize), |(fee, vsize), fees| {
+                    (
+                        fee.saturating_add(fees.fee),
+                        vsize.saturating_add(fees.vsize),
+                    )
+                });
 
         // Calculate the fee rate based on the total fees and vsizes of the
         // transactions which we've found. Since this is returning transactions
@@ -2521,11 +2525,7 @@ where
         // need to check for division by zero.
         let rate = total_fees as f64 / total_vsize as f64;
 
-        Ok(Some(Fees {
-            total: total_fees,
-            rate,
-            vsize: NonZeroU64::new(total_vsize),
-        }))
+        Fees::new(total_fees, rate, NonZeroU64::new(total_vsize)).map(Some)
     }
 
     /// Estimate transaction fees for a Stacks contract call. This function

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -1,4 +1,6 @@
 mod serial {
+    use std::num::NonZeroU64;
+
     use bitcoin::AddressType;
     use bitcoin::Amount;
     use bitcoin::OutPoint;
@@ -281,6 +283,7 @@ mod serial {
             Fees {
                 total: last_fee,
                 rate: last_fee as f64 / last_size as f64,
+                vsize: NonZeroU64::new(last_size as u64),
             }
         };
 

--- a/signer/tests/integration/rbf.rs
+++ b/signer/tests/integration/rbf.rs
@@ -280,11 +280,8 @@ mod serial {
                 _ => panic!("Unexpected response when sending bad replacement transaction"),
             }
 
-            Fees {
-                total: last_fee,
-                rate: last_fee as f64 / last_size as f64,
-                vsize: NonZeroU64::new(last_size as u64),
-            }
+            let rate = last_fee as f64 / last_size as f64;
+            Fees::new_unchecked(last_fee, rate, NonZeroU64::new(last_size as u64))
         };
 
         // Step 3. Construct an RBF transaction

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -907,10 +907,10 @@ impl TestSweepSetup2 {
         let last_fees = txids
             .iter()
             .filter_map(|txid| self.client.get_mempool_entry(txid).unwrap())
-            .map(|entry| Fees {
-                total: entry.fees.base.to_sat(),
-                rate: entry.fees.base.to_sat() as f64 / entry.vsize as f64,
-                vsize: NonZeroU64::new(entry.vsize),
+            .map(|entry| {
+                let total = entry.fees.base.to_sat();
+                let rate = entry.fees.base.to_sat() as f64 / entry.vsize as f64;
+                Fees::new_unchecked(total, rate, NonZeroU64::new(entry.vsize))
             })
             .max_by_key(|fees| fees.total);
 

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::collections::HashSet;
+use std::num::NonZeroU64;
 use std::ops::Deref as _;
 use std::str::FromStr as _;
 use std::time::Duration;
@@ -909,6 +910,7 @@ impl TestSweepSetup2 {
             .map(|entry| Fees {
                 total: entry.fees.base.to_sat(),
                 rate: entry.fees.base.to_sat() as f64 / entry.vsize as f64,
+                vsize: NonZeroU64::new(entry.vsize),
             })
             .max_by_key(|fees| fees.total);
 

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4177,11 +4177,8 @@ mod serial {
             .await
             .unwrap();
 
-        let expected_fees = Fees {
-            total: 1_000,
-            rate: 1_000_f64 / tx1.vsize() as f64,
-            vsize: NonZeroU64::new(tx1.vsize() as u64),
-        };
+        let rate = 1_000_f64 / tx1.vsize() as f64;
+        let expected_fees = Fees::new_unchecked(1_000, rate, NonZeroU64::new(tx1.vsize() as u64));
 
         // Assert that everything's as expected.
         assert_eq!(btc_state.utxo.outpoint.txid, signer_utxo_txid);
@@ -4216,11 +4213,8 @@ mod serial {
             .await
             .unwrap();
 
-        let expected_fees = Fees {
-            total: 2_000,
-            rate: 2_000f64 / tx2.vsize() as f64,
-            vsize: NonZeroU64::new(tx2.vsize() as u64),
-        };
+        let rate = 2_000_f64 / tx2.vsize() as f64;
+        let expected_fees = Fees::new_unchecked(2_000, rate, NonZeroU64::new(tx2.vsize() as u64));
 
         // Assert that everything's as expected.
         assert_eq!(btc_state.utxo.outpoint.txid, signer_utxo_txid);

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -4043,6 +4043,8 @@ async fn test_get_btc_state_with_no_available_sweep_transactions() {
 }
 
 mod serial {
+    use std::num::NonZeroU64;
+
     use super::*;
 
     use test_log::test;
@@ -4178,6 +4180,7 @@ mod serial {
         let expected_fees = Fees {
             total: 1_000,
             rate: 1_000_f64 / tx1.vsize() as f64,
+            vsize: NonZeroU64::new(tx1.vsize() as u64),
         };
 
         // Assert that everything's as expected.
@@ -4216,6 +4219,7 @@ mod serial {
         let expected_fees = Fees {
             total: 2_000,
             rate: 2_000f64 / tx2.vsize() as f64,
+            vsize: NonZeroU64::new(tx2.vsize() as u64),
         };
 
         // Assert that everything's as expected.


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2020

## Changes

* Add a new `vsize` field to the `Fees` object.
* Add a `Fees::new` function for constructing a `Fees` object that rejects obviously invalid total fees.
* Update the protobufs in a backward-compatible way, and update the conversion functions to tolerate signers that haven't updated, but not tolerate signers that send bogus total fees data.

## Testing Information

Added some unit tests, which should cover what we want. We'll run proper network testing when we test this on devnet.

## Checklist

- [x] I have performed a self-review of my code