### PR TITLE
fix: validate for op successx opcodes in reclaim scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5806,6 +5806,7 @@ dependencies = [
  "more-asserts",
  "proptest",
  "rand 0.8.5",
+ "sbtc",
  "secp256k1 0.29.0",
  "serde",
  "serde_json",

--- a/sbtc/Cargo.toml
+++ b/sbtc/Cargo.toml
@@ -44,6 +44,11 @@ tokio = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 
 [dev-dependencies]
+# Add ourself as a dev-dependency with the "testing" feature enabled to
+# automatically include testing functionality for debug builds (i.e. dev/test).
+# This also ensures that your IDE will recognize feature-gated code as active.
+sbtc = { path = ".", features = ["testing"] }
+
 hex.workspace = true 
 assert_matches.workspace = true
 bitcoincore-rpc.workspace = true

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -9,7 +9,10 @@ use bitcoin::ScriptBuf;
 use bitcoin::Transaction;
 use bitcoin::XOnlyPublicKey;
 use bitcoin::locktime::relative::LockTime;
+use bitcoin::opcodes::Class;
+use bitcoin::opcodes::ClassifyContext;
 use bitcoin::opcodes::all as opcodes;
+use bitcoin::script::Instruction;
 use bitcoin::script::PushBytesBuf;
 use bitcoin::taproot::LeafVersion;
 use bitcoin::taproot::NodeInfo;
@@ -21,6 +24,7 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use secp256k1::SECP256K1;
 use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
 
+use crate::MAX_RECLAIM_SCRIPT_LENGTH;
 use crate::error::Error;
 
 /// This is the length of the fixed portion of the deposit script, which
@@ -400,8 +404,36 @@ pub struct ReclaimScriptInputs {
 }
 
 impl ReclaimScriptInputs {
-    /// Create a new one
+    /// Create a new one, validating that:
+    ///
+    /// * the lock time is a non-disabled block based time,
+    /// * the script is within the maximum length allowed for a reclaim
+    ///   script,
+    /// * the script does not contain any of the OP_SUCCESS opcodes.
     pub fn try_new(lock_time: u32, script: ScriptBuf) -> Result<Self, Error> {
+        // OP_CSV checks can be disabled if the locktime has the disabled
+        // locktime bit set to 1. So we disallow such locktimes to ensure
+        // that the OP_CSV check is always enabled.
+        //
+        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
+        let lock_time = LockTime::from_consensus(lock_time).map_err(Error::DisabledLockTime)?;
+
+        // For now, we only accept locktimes denominated in bitcoin block
+        // units.
+        if matches!(lock_time, LockTime::Time(_)) {
+            return Err(Error::UnsupportedLockTimeUnits(
+                lock_time.to_consensus_u32(),
+            ));
+        }
+
+        Self::validate_script(&script)?;
+
+        Ok(Self { lock_time, script })
+    }
+
+    /// Create a new one, but without validating the script.
+    #[cfg(any(test, feature = "testing"))]
+    pub fn try_new_unvalidated(lock_time: u32, script: ScriptBuf) -> Result<Self, Error> {
         // OP_CSV checks can be disabled if the locktime has the disabled
         // locktime bit set to 1. So we disallow such locktimes to ensure
         // that the OP_CSV check is always enabled.
@@ -503,6 +535,30 @@ impl ReclaimScriptInputs {
 
         let script = ScriptBuf::from_bytes(script.to_vec());
         ReclaimScriptInputs::try_new(lock_time, script)
+    }
+
+    /// Check if the script is a valid reclaim script.
+    ///
+    /// This function checks that the script does not contain any of the
+    /// OP_SUCCESS opcodes, and that the script length does not exceed
+    /// MAX_RECLAIM_SCRIPT_LENGTH.
+    pub fn validate_script(script: &ScriptBuf) -> Result<(), Error> {
+        if script.len() > MAX_RECLAIM_SCRIPT_LENGTH {
+            return Err(Error::InvalidReclaimScriptLength(script.len()));
+        }
+
+        let has_op_success_ops = script.instructions().any(|op| match op {
+            Ok(Instruction::Op(opcode)) => {
+                opcode.classify(ClassifyContext::TapScript) == Class::SuccessOp
+            }
+            _ => false,
+        });
+
+        if has_op_success_ops {
+            return Err(Error::ReclaimScriptWithSuccessOp);
+        }
+
+        Ok(())
     }
 }
 

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -966,16 +966,15 @@ mod tests {
     #[test]
     fn reclaim_script_op_success_byte_in_malformed_script() {
         let lock_time = 50;
-        let mut bytes: Vec<u8> = Vec::new();
-
-        // (1) OP_SUCCESS first — short-circuits the rest of the script
-        bytes.push(opcodes::OP_RETURN_187.to_u8());
-
-        // (2) Malformed push: OP_PUSHDATA1 followed by length 0xff, but
-        //     zero bytes of payload. bitcoin-core's GetOp on this should
-        //     return false and fail the script.
-        bytes.push(OP_PUSHDATA1);
-        bytes.push(0xff); // "the next 255 bytes are the push", except not really
+        let bytes: Vec<u8> = vec![
+            // (1) OP_SUCCESS first — short-circuits the rest of the script
+            opcodes::OP_RETURN_187.to_u8(),
+            // (2) Malformed push: OP_PUSHDATA1 followed by length 0xff, but
+            //     zero bytes of payload. bitcoin-core's GetOp on this should
+            //     return false and fail the script.
+            OP_PUSHDATA1,
+            0xff, // "the next 255 bytes are the push", except not really
+        ];
 
         let script = ScriptBuf::from_bytes(bytes);
 

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -482,7 +482,7 @@ impl ReclaimScriptInputs {
         });
 
         if has_op_success_ops {
-            return Err(Error::ReclaimScriptWithSuccessOp);
+            return Err(Error::ReclaimScriptWithSuccessOp(script.clone()));
         }
 
         Ok(())
@@ -919,7 +919,7 @@ mod tests {
             .into_script();
 
         let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
-        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp(_));
     }
 
     /// `OP_INVALIDOPCODE` (255) is not in the BIP-342 `OP_SUCCESSx`
@@ -958,7 +958,7 @@ mod tests {
             .into_script();
 
         let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
-        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp(_));
     }
 
     /// We check that we catch reclaim scripts with OP_SUCCESSx opcodes
@@ -984,7 +984,7 @@ mod tests {
         assert!(is_malformed);
 
         let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
-        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp(_));
     }
 
     #[test]

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -406,39 +406,44 @@ pub struct ReclaimScriptInputs {
 impl ReclaimScriptInputs {
     /// Create a new one, validating that:
     ///
-    /// * the lock time is a non-disabled block based time,
-    /// * the script is within the maximum length allowed for a reclaim
-    ///   script,
-    /// * the script does not contain any of the OP_SUCCESS opcodes.
+    /// * the lock time is a non-disabled block-based time,
+    /// * the user-supplied script is within the maximum length allowed
+    ///   for a reclaim script,
+    /// * the user-supplied script does not contain any OP_SUCCESSx
+    ///   opcodes, see [BIP-342].
+    ///
+    /// [BIP-342]: https://github.com/bitcoin/bips/blob/master/bip-0342.mediawiki
     pub fn try_new(lock_time: u32, script: ScriptBuf) -> Result<Self, Error> {
-        // OP_CSV checks can be disabled if the locktime has the disabled
-        // locktime bit set to 1. So we disallow such locktimes to ensure
-        // that the OP_CSV check is always enabled.
-        //
-        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
-        let lock_time = LockTime::from_consensus(lock_time).map_err(Error::DisabledLockTime)?;
-
-        // For now, we only accept locktimes denominated in bitcoin block
-        // units.
-        if matches!(lock_time, LockTime::Time(_)) {
-            return Err(Error::UnsupportedLockTimeUnits(
-                lock_time.to_consensus_u32(),
-            ));
-        }
-
+        let lock_time = Self::validate_lock_time(lock_time)?;
         Self::validate_script(&script)?;
 
         Ok(Self { lock_time, script })
     }
 
-    /// Create a new one, but without validating the script.
+    /// Create a new one, but without validating the user-supplied script.
+    ///
+    /// The lock time is still validated; only the script-content checks
+    /// performed by [`Self::validate_script`] are skipped. This is used
+    /// to construct otherwise-rejected reclaim scripts in tests that
+    /// exercise the validation logic itself.
     #[cfg(any(test, feature = "testing"))]
     pub fn try_new_unvalidated(lock_time: u32, script: ScriptBuf) -> Result<Self, Error> {
-        // OP_CSV checks can be disabled if the locktime has the disabled
-        // locktime bit set to 1. So we disallow such locktimes to ensure
-        // that the OP_CSV check is always enabled.
-        //
-        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
+        let lock_time = Self::validate_lock_time(lock_time)?;
+
+        Ok(Self { lock_time, script })
+    }
+
+    /// Validate the lock time used in the `<lock-time> OP_CSV` prefix of
+    /// the reclaim script.
+    ///
+    /// OP_CSV checks can be disabled if the lock time has the disabled
+    /// lock-time bit set, so we reject any such lock time to ensure that
+    /// the OP_CSV check is always enforced. We also reject time-based
+    /// (as opposed to block-height-based) lock times since we do not yet
+    /// support them.
+    ///
+    /// <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L560-L592>
+    fn validate_lock_time(lock_time: u32) -> Result<LockTime, Error> {
         let lock_time = LockTime::from_consensus(lock_time).map_err(Error::DisabledLockTime)?;
 
         // For now, we only accept locktimes denominated in bitcoin block
@@ -449,7 +454,46 @@ impl ReclaimScriptInputs {
             ));
         }
 
-        Ok(Self { lock_time, script })
+        Ok(lock_time)
+    }
+
+    /// Validate the user-supplied portion of a reclaim script.
+    ///
+    /// This is the script that follows the `<lock-time> OP_CSV` prefix. We
+    /// require:
+    ///
+    /// * its length is at most [`MAX_RECLAIM_SCRIPT_LENGTH`] bytes, and
+    /// * it does not contain any OP_SUCCESSx opcodes.
+    ///
+    /// We reject OP_SUCCESSx in order for the OP_CSV lock to be
+    /// meaningful: [BIP-342] states that any tapscript containing such an
+    /// opcode is unconditionally valid, which would let a depositor spend
+    /// the reclaim path without satisfying the lock-time.
+    ///
+    /// [BIP-342]: <https://github.com/bitcoin/bips/blob/554be702d7d28e3cd1cbf2e84c153f041fdde898/bip-0342.mediawiki>
+    fn validate_script(script: &ScriptBuf) -> Result<(), Error> {
+        if script.len() > MAX_RECLAIM_SCRIPT_LENGTH {
+            return Err(Error::InvalidReclaimScriptLength(script.len()));
+        }
+
+        // We mirror bitcoin-core's pre-execution scan for OP_SUCCESSx
+        // opcodes in tapscript.
+        //
+        // For the corresponding bitcoin-core logic, see the following:
+        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L1784-L1807>
+        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/script.cpp#L341-L347>
+        let has_op_success_ops = script.instructions().any(|op| match op {
+            Ok(Instruction::Op(opcode)) => {
+                opcode.classify(ClassifyContext::TapScript) == Class::SuccessOp
+            }
+            _ => false,
+        });
+
+        if has_op_success_ops {
+            return Err(Error::ReclaimScriptWithSuccessOp);
+        }
+
+        Ok(())
     }
 
     /// Get the lock time in the reclaim script.
@@ -535,30 +579,6 @@ impl ReclaimScriptInputs {
 
         let script = ScriptBuf::from_bytes(script.to_vec());
         ReclaimScriptInputs::try_new(lock_time, script)
-    }
-
-    /// Check if the script is a valid reclaim script.
-    ///
-    /// This function checks that the script does not contain any of the
-    /// OP_SUCCESS opcodes, and that the script length does not exceed
-    /// MAX_RECLAIM_SCRIPT_LENGTH.
-    pub fn validate_script(script: &ScriptBuf) -> Result<(), Error> {
-        if script.len() > MAX_RECLAIM_SCRIPT_LENGTH {
-            return Err(Error::InvalidReclaimScriptLength(script.len()));
-        }
-
-        let has_op_success_ops = script.instructions().any(|op| match op {
-            Ok(Instruction::Op(opcode)) => {
-                opcode.classify(ClassifyContext::TapScript) == Class::SuccessOp
-            }
-            _ => false,
-        });
-
-        if has_op_success_ops {
-            return Err(Error::ReclaimScriptWithSuccessOp);
-        }
-
-        Ok(())
     }
 }
 
@@ -884,6 +904,87 @@ mod tests {
         let reclaim = ReclaimScriptInputs::try_new(lock_time, ScriptBuf::new()).unwrap_err();
 
         assert!(matches!(reclaim, Error::UnsupportedLockTimeUnits(_)));
+    }
+
+    /// A user script of exactly `MAX_RECLAIM_SCRIPT_LENGTH` bytes is
+    /// accepted; one byte more is rejected.
+    #[test]
+    fn reclaim_script_length_boundary() {
+        let lock_time = 50;
+
+        // Build a script of length exactly MAX_RECLAIM_SCRIPT_LENGTH out
+        // of `OP_DROP` opcodes. `OP_DROP` is a single byte and is not an
+        // `OP_SUCCESSx` opcode, so it isolates the length check.
+        let max_script = ScriptBuf::from_bytes(vec![OP_CSV; MAX_RECLAIM_SCRIPT_LENGTH]);
+        assert_eq!(max_script.len(), MAX_RECLAIM_SCRIPT_LENGTH);
+        ReclaimScriptInputs::try_new(lock_time, max_script).unwrap();
+
+        let too_long = ScriptBuf::from_bytes(vec![OP_CSV; MAX_RECLAIM_SCRIPT_LENGTH + 1]);
+        let err = ReclaimScriptInputs::try_new(lock_time, too_long).unwrap_err();
+        assert!(
+            matches!(err, Error::InvalidReclaimScriptLength(n) if n == MAX_RECLAIM_SCRIPT_LENGTH + 1)
+        );
+    }
+
+    /// Each opcode in the BIP-342 `OP_SUCCESSx` range causes the
+    /// user-supplied reclaim script to be rejected.
+    #[test_case(opcodes::OP_RESERVED   ; "OP_RESERVED (80)")]
+    #[test_case(opcodes::OP_VER        ; "OP_VER (98)")]
+    #[test_case(opcodes::OP_CAT        ; "OP_CAT (126)")]
+    #[test_case(opcodes::OP_SUBSTR     ; "OP_SUBSTR (127)")]
+    #[test_case(opcodes::OP_INVERT     ; "OP_INVERT (131)")]
+    #[test_case(opcodes::OP_RESERVED1  ; "OP_RESERVED1 (137)")]
+    #[test_case(opcodes::OP_2MUL       ; "OP_2MUL (141)")]
+    #[test_case(opcodes::OP_MUL        ; "OP_MUL (149)")]
+    #[test_case(opcodes::OP_RETURN_187 ; "OP_RETURN_187 (187)")]
+    #[test_case(opcodes::OP_RETURN_254 ; "OP_RETURN_254 (254)")]
+    fn reclaim_script_op_success_rejected(op: bitcoin::opcodes::Opcode) {
+        let lock_time = 50;
+
+        let script = ScriptBuf::builder()
+            .push_opcode(opcodes::OP_RETURN)
+            .push_opcode(op)
+            .into_script();
+
+        let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
+        assert!(matches!(err, Error::ReclaimScriptWithSuccessOp));
+    }
+
+    /// `OP_INVALIDOPCODE` (255) is not in the BIP-342 `OP_SUCCESSx`
+    /// range, so a script containing it as an opcode is not flagged by
+    /// the `OP_SUCCESSx` check. The script is still bytewise within the
+    /// length limit, so `try_new` accepts it.
+    #[test]
+    fn reclaim_script_op_invalidopcode_not_op_success() {
+        let lock_time = 50;
+        let script = ScriptBuf::from_bytes(vec![opcodes::OP_INVALIDOPCODE.to_u8()]);
+        ReclaimScriptInputs::try_new(lock_time, script).unwrap();
+    }
+
+    /// Bytes that *equal* an `OP_SUCCESSx` value but appear inside a
+    /// pushed data payload must not trigger the `OP_SUCCESSx` check.
+    /// Bitcoin-core's scan walks opcodes (skipping over push payloads),
+    /// and ours must do the same.
+    #[test]
+    fn reclaim_script_op_success_byte_in_pushdata_allowed() {
+        let lock_time = 50;
+        // A 32-byte payload of `OP_RETURN_187` bytes pushed via
+        // `push_slice` — the leading length byte is the opcode and the
+        // payload bytes are skipped by the instruction iterator.
+        let script = ScriptBuf::builder()
+            .push_slice([opcodes::OP_RETURN_187.to_u8(); 32])
+            .push_opcode(opcodes::OP_DROP)
+            .into_script();
+
+        ReclaimScriptInputs::try_new(lock_time, script).unwrap();
+
+        // This is different, this is just the invalid opcode.
+        let script = ScriptBuf::builder()
+            .push_opcode(opcodes::OP_RETURN_187)
+            .push_opcode(opcodes::OP_DROP)
+            .into_script();
+
+        ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
     }
 
     #[test]

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -928,14 +928,14 @@ mod tests {
 
     /// Each opcode in the BIP-342 `OP_SUCCESSx` range causes the
     /// user-supplied reclaim script to be rejected.
-    #[test_case(opcodes::OP_RESERVED   ; "OP_RESERVED (80)")]
-    #[test_case(opcodes::OP_VER        ; "OP_VER (98)")]
-    #[test_case(opcodes::OP_CAT        ; "OP_CAT (126)")]
-    #[test_case(opcodes::OP_SUBSTR     ; "OP_SUBSTR (127)")]
-    #[test_case(opcodes::OP_INVERT     ; "OP_INVERT (131)")]
-    #[test_case(opcodes::OP_RESERVED1  ; "OP_RESERVED1 (137)")]
-    #[test_case(opcodes::OP_2MUL       ; "OP_2MUL (141)")]
-    #[test_case(opcodes::OP_MUL        ; "OP_MUL (149)")]
+    #[test_case(opcodes::OP_RESERVED ; "OP_RESERVED (80)")]
+    #[test_case(opcodes::OP_VER ; "OP_VER (98)")]
+    #[test_case(opcodes::OP_CAT ; "OP_CAT (126)")]
+    #[test_case(opcodes::OP_SUBSTR ; "OP_SUBSTR (127)")]
+    #[test_case(opcodes::OP_INVERT ; "OP_INVERT (131)")]
+    #[test_case(opcodes::OP_RESERVED1 ; "OP_RESERVED1 (137)")]
+    #[test_case(opcodes::OP_2MUL ; "OP_2MUL (141)")]
+    #[test_case(opcodes::OP_MUL ; "OP_MUL (149)")]
     #[test_case(opcodes::OP_RETURN_187 ; "OP_RETURN_187 (187)")]
     #[test_case(opcodes::OP_RETURN_254 ; "OP_RETURN_254 (254)")]
     fn reclaim_script_op_success_rejected(op: bitcoin::opcodes::Opcode) {

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -961,6 +961,32 @@ mod tests {
         assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
     }
 
+    /// We check that we catch reclaim scripts with OP_SUCCESSx opcodes
+    /// that are also unparsable on bitcoin-core.
+    #[test]
+    fn reclaim_script_op_success_byte_in_malformed_script() {
+        let lock_time = 50;
+        let mut bytes: Vec<u8> = Vec::new();
+
+        // (1) OP_SUCCESS first — short-circuits the rest of the script
+        bytes.push(opcodes::OP_RETURN_187.to_u8());
+
+        // (2) Malformed push: OP_PUSHDATA1 followed by length 0xff, but
+        //     zero bytes of payload. bitcoin-core's GetOp on this should
+        //     return false and fail the script.
+        bytes.push(OP_PUSHDATA1);
+        bytes.push(0xff); // "the next 255 bytes are the push", except not really
+
+        let script = ScriptBuf::from_bytes(bytes);
+
+        // check that the script is malformed
+        let is_malformed = script.instructions().any(|op| op.is_err());
+        assert!(is_malformed);
+
+        let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
+    }
+
     #[test]
     fn happy_path_tx_validation() {
         let max_fee: u64 = 15000;

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -24,7 +24,6 @@ use clarity::vm::types::QualifiedContractIdentifier;
 use secp256k1::SECP256K1;
 use stacks_common::types::chainstate::STACKS_ADDRESS_ENCODED_SIZE;
 
-use crate::MAX_RECLAIM_SCRIPT_LENGTH;
 use crate::error::Error;
 
 /// This is the length of the fixed portion of the deposit script, which
@@ -460,10 +459,7 @@ impl ReclaimScriptInputs {
     /// Validate the user-supplied portion of a reclaim script.
     ///
     /// This is the script that follows the `<lock-time> OP_CSV` prefix. We
-    /// require:
-    ///
-    /// * its length is at most [`MAX_RECLAIM_SCRIPT_LENGTH`] bytes, and
-    /// * it does not contain any OP_SUCCESSx opcodes.
+    /// require that it does not contain any OP_SUCCESSx opcodes.
     ///
     /// We reject OP_SUCCESSx in order for the OP_CSV lock to be
     /// meaningful. BIP-342[1] states that any tapscript containing such an
@@ -472,10 +468,6 @@ impl ReclaimScriptInputs {
     ///
     /// [1]: <https://github.com/bitcoin/bips/blob/554be702d7d28e3cd1cbf2e84c153f041fdde898/bip-0342.mediawiki>
     fn validate_script(script: &ScriptBuf) -> Result<(), Error> {
-        if script.len() > MAX_RECLAIM_SCRIPT_LENGTH {
-            return Err(Error::InvalidReclaimScriptLength(script.len()));
-        }
-
         // We mirror bitcoin-core's pre-execution scan for OP_SUCCESSx
         // opcodes in tapscript.
         //
@@ -904,26 +896,6 @@ mod tests {
         let reclaim = ReclaimScriptInputs::try_new(lock_time, ScriptBuf::new()).unwrap_err();
 
         assert!(matches!(reclaim, Error::UnsupportedLockTimeUnits(_)));
-    }
-
-    /// A user script of exactly `MAX_RECLAIM_SCRIPT_LENGTH` bytes is
-    /// accepted; one byte more is rejected.
-    #[test]
-    fn reclaim_script_length_boundary() {
-        let lock_time = 50;
-
-        // Build a script of length exactly MAX_RECLAIM_SCRIPT_LENGTH out
-        // of `OP_DROP` opcodes. `OP_DROP` is a single byte and is not an
-        // `OP_SUCCESSx` opcode, so it isolates the length check.
-        let max_script = ScriptBuf::from_bytes(vec![OP_CSV; MAX_RECLAIM_SCRIPT_LENGTH]);
-        assert_eq!(max_script.len(), MAX_RECLAIM_SCRIPT_LENGTH);
-        ReclaimScriptInputs::try_new(lock_time, max_script).unwrap();
-
-        let too_long = ScriptBuf::from_bytes(vec![OP_CSV; MAX_RECLAIM_SCRIPT_LENGTH + 1]);
-        let err = ReclaimScriptInputs::try_new(lock_time, too_long).unwrap_err();
-        assert!(
-            matches!(err, Error::InvalidReclaimScriptLength(n) if n == MAX_RECLAIM_SCRIPT_LENGTH + 1)
-        );
     }
 
     /// Each opcode in the BIP-342 `OP_SUCCESSx` range causes the

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -466,11 +466,11 @@ impl ReclaimScriptInputs {
     /// * it does not contain any OP_SUCCESSx opcodes.
     ///
     /// We reject OP_SUCCESSx in order for the OP_CSV lock to be
-    /// meaningful: [BIP-342] states that any tapscript containing such an
+    /// meaningful. BIP-342[1] states that any tapscript containing such an
     /// opcode is unconditionally valid, which would let a depositor spend
     /// the reclaim path without satisfying the lock-time.
     ///
-    /// [BIP-342]: <https://github.com/bitcoin/bips/blob/554be702d7d28e3cd1cbf2e84c153f041fdde898/bip-0342.mediawiki>
+    /// [1]: <https://github.com/bitcoin/bips/blob/554be702d7d28e3cd1cbf2e84c153f041fdde898/bip-0342.mediawiki>
     fn validate_script(script: &ScriptBuf) -> Result<(), Error> {
         if script.len() > MAX_RECLAIM_SCRIPT_LENGTH {
             return Err(Error::InvalidReclaimScriptLength(script.len()));
@@ -978,7 +978,8 @@ mod tests {
 
         ReclaimScriptInputs::try_new(lock_time, script).unwrap();
 
-        // This is different, this is just the invalid opcode.
+        // For comparison: the same byte used as a bare opcode (rather
+        // than inside a push payload) is rejected.
         let script = ScriptBuf::builder()
             .push_opcode(opcodes::OP_RETURN_187)
             .push_opcode(opcodes::OP_DROP)

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -406,8 +406,6 @@ impl ReclaimScriptInputs {
     /// Create a new one, validating that:
     ///
     /// * the lock time is a non-disabled block-based time,
-    /// * the user-supplied script is within the maximum length allowed
-    ///   for a reclaim script,
     /// * the user-supplied script does not contain any OP_SUCCESSx
     ///   opcodes, see [BIP-342].
     ///

--- a/sbtc/src/deposits.rs
+++ b/sbtc/src/deposits.rs
@@ -919,7 +919,7 @@ mod tests {
             .into_script();
 
         let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
-        assert!(matches!(err, Error::ReclaimScriptWithSuccessOp));
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
     }
 
     /// `OP_INVALIDOPCODE` (255) is not in the BIP-342 `OP_SUCCESSx`
@@ -957,7 +957,8 @@ mod tests {
             .push_opcode(opcodes::OP_DROP)
             .into_script();
 
-        ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
+        let err = ReclaimScriptInputs::try_new(lock_time, script).unwrap_err();
+        assert_matches::assert_matches!(err, Error::ReclaimScriptWithSuccessOp);
     }
 
     #[test]

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -73,9 +73,9 @@ pub enum Error {
     #[error("the reclaim script was too long: {0} bytes")]
     InvalidReclaimScriptLength(usize),
 
-    /// The reclaim script contained an OP_SUCCESS opcode.
-    #[error("the reclaim script contained an OP_SUCCESS opcode")]
-    ReclaimScriptWithSuccessOp,
+    /// The reclaim script contained an OP_SUCCESSx opcode.
+    #[error("the reclaim script contained an OP_SUCCESSx opcode: {0}")]
+    ReclaimScriptWithSuccessOp(bitcoin::ScriptBuf),
 
     /// This is thrown when failing to parse a hex string into bytes.
     #[cfg(any(test, feature = "webhooks"))]

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -69,10 +69,6 @@ pub enum Error {
         from_request: Txid,
     },
 
-    /// The reclaim script was invalid because it was too long.
-    #[error("the reclaim script was too long: {0} bytes")]
-    InvalidReclaimScriptLength(usize),
-
     /// The reclaim script contained an OP_SUCCESSx opcode.
     #[error("the reclaim script contained an OP_SUCCESSx opcode: {0}")]
     ReclaimScriptWithSuccessOp(bitcoin::ScriptBuf),

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -70,7 +70,7 @@ pub enum Error {
     },
 
     /// The reclaim script was invalid because it was too long.
-    #[error("the reclaim script was too long: was {0} bytes")]
+    #[error("the reclaim script was too long: {0} bytes")]
     InvalidReclaimScriptLength(usize),
 
     /// The reclaim script contained an OP_SUCCESS opcode.

--- a/sbtc/src/error.rs
+++ b/sbtc/src/error.rs
@@ -69,6 +69,14 @@ pub enum Error {
         from_request: Txid,
     },
 
+    /// The reclaim script was invalid because it was too long.
+    #[error("the reclaim script was too long: was {0} bytes")]
+    InvalidReclaimScriptLength(usize),
+
+    /// The reclaim script contained an OP_SUCCESS opcode.
+    #[error("the reclaim script contained an OP_SUCCESS opcode")]
+    ReclaimScriptWithSuccessOp,
+
     /// This is thrown when failing to parse a hex string into bytes.
     #[cfg(any(test, feature = "webhooks"))]
     #[error("could not decode the hex string into bytes: {0}")]

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -56,10 +56,3 @@ pub static UNSPENDABLE_TAPROOT_KEY: LazyLock<XOnlyPublicKey> =
 /// of https://github.com/stacks-network/sbtc/discussions/12 and in the
 /// comments of https://github.com/stacks-network/sbtc/issues/16.
 pub const WITHDRAWAL_MIN_CONFIRMATIONS: u64 = 6;
-
-/// The maximum length, in bytes, of the portion of a reclaim script that
-/// follows the `<lock-time> OP_CSV`.
-///
-/// This value was chosen to allow for most known reclaim scripts, while
-/// keeping potential storage costs low for depositors.
-pub const MAX_RECLAIM_SCRIPT_LENGTH: usize = 2048;

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -57,8 +57,9 @@ pub static UNSPENDABLE_TAPROOT_KEY: LazyLock<XOnlyPublicKey> =
 /// comments of https://github.com/stacks-network/sbtc/issues/16.
 pub const WITHDRAWAL_MIN_CONFIRMATIONS: u64 = 6;
 
-/// This is the maximum length of a reclaim script.
+/// The maximum length, in bytes, of the portion of a reclaim script that
+/// follows the `<lock-time> OP_CSV`.
 ///
-/// This is the maximum length of the user supplied part of the script in
-/// the reclaim spending path.
+/// This value was chosen to allow for most known reclaim scripts, while
+/// keeping potential storage costs low for depositors.
 pub const MAX_RECLAIM_SCRIPT_LENGTH: usize = 2048;

--- a/sbtc/src/lib.rs
+++ b/sbtc/src/lib.rs
@@ -56,3 +56,9 @@ pub static UNSPENDABLE_TAPROOT_KEY: LazyLock<XOnlyPublicKey> =
 /// of https://github.com/stacks-network/sbtc/discussions/12 and in the
 /// comments of https://github.com/stacks-network/sbtc/issues/16.
 pub const WITHDRAWAL_MIN_CONFIRMATIONS: u64 = 6;
+
+/// This is the maximum length of a reclaim script.
+///
+/// This is the maximum length of the user supplied part of the script in
+/// the reclaim spending path.
+pub const MAX_RECLAIM_SCRIPT_LENGTH: usize = 2048;

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -585,19 +585,29 @@ mod serial {
         );
     }
 
-    /// This validates that a user can reclaim their funds after the locktime.
+    /// This validates the motivation for rejecting reclaim scripts that
+    /// contain OP_SUCCESSx opcodes. Per BIP-342, any tapscript that
+    /// contains such an opcode is unconditionally valid, which means such
+    /// a script bypasses the <lock-time> OP_CSV lock entirely at the
+    /// consensus level.
     ///
     /// The test proceeds as follows:
-    /// 1. Spend all the user's funds for a sBTC deposit. Check that the
-    ///    balance is zero.
-    /// 2. Wait locktime blocks after the first confirmation.
-    /// 3. Create and submit another transaction reclaiming the funds.
-    /// 4. Confirm the transaction and check that the balance is what it is
-    ///    supposed to be, less the bitcoin transaction fees.
+    /// 1. Confirm a deposit whose reclaim path's user script contains an
+    ///    OP_SUCCESSx opcode, gated by an u16::MAX-block OP_CSV lock.
+    /// 2. Verify that CreateDepositRequest::validate_tx rejects this
+    ///    deposit, so that we know that the signers will reject it.
+    /// 3. Build a reclaim transaction with Sequence::ZERO so the OP_CSV
+    ///    lock is not satisfied, and confirm that the bitcoin-core mempool
+    ///    rejects it as non-standard with OP_SUCCESSx reserved for
+    ///    soft-fork upgrades.
+    /// 4. Force-mine the reclaim transaction with generateblock, which
+    ///    bypasses standardness, and confirm that consensus accepts.
     #[test]
     fn reclaiming_rejected_deposits_op_success() {
         let max_fee: u64 = 15000;
         let amount_sats = 49_900_000;
+        // Set far higher than any block we'll mine in the test, so the
+        // OP_CSV lock cannot possibly be satisfied via timing alone.
         let lock_time = u16::MAX as u32;
 
         let (rpc, faucet) = regtest::initialize_blockchain();
@@ -621,10 +631,12 @@ mod serial {
             max_fee,
         };
 
-        // const OP_RETURN_187: u8 = opcodes::all::OP_RETURN_187.to_u8();
-        // Now the depositor's reclaim script is locked with a P2PK script that
-        // is locked with an x-only public key. This means we need to use a
-        // BIP-341 Schnorr signature to spend the funds.
+        // The depositor's reclaim path has a leading OP_RETURN with an
+        // OP_SUCCESSx opcode. Bitcoin-core's OP_SUCCESSx scan in tapscript
+        // happens before execution, so even an OP_RETURN ahead of the
+        // OP_SUCCESSx opcode does not prevent unconditional success. See
+        // the tapscript branch of xecuteWitnessScript:
+        // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L1792-L1808>
         let x_only_key = depositor.keypair.public_key().x_only_public_key().0;
         let reclaim_script = ScriptBuf::builder()
             .push_opcode(opcodes::all::OP_RETURN)
@@ -633,8 +645,9 @@ mod serial {
             .push_slice(x_only_key.serialize())
             .push_opcode(opcodes::all::OP_CHECKSIG)
             .into_script();
-        // The full reclaim path script includes an OP_CSV lock, so let's
-        // create one.
+        // We use try_new_unvalidated because the whole point of the
+        // test is to construct an OP_SUCCESSx-bearing reclaim script
+        // that the production try_new is supposed to reject.
         let reclaim = ReclaimScriptInputs::try_new_unvalidated(lock_time, reclaim_script).unwrap();
 
         // Now we have both scripts in the taproot scriptPubKey.
@@ -738,12 +751,10 @@ mod serial {
         ];
         reclaim_tx.input[0].witness = Witness::from_slice(&witness_data);
 
-        // Let's generate one block, which is not enough to spend the funds
-        // because they are locked for u16::MAX blocks. We can spend the
-        // funds at the consensus level but bitcoin-core evaluates the
-        // script when it doesn't need to.
-        faucet.generate_blocks(1);
 
+        // We haven't generated enough blocks to satisfy the OP_CSV lock,
+        // so this should fail regardless. In this case, it fails because
+        // of the OP_SUCCESSx opcode.
         match rpc.send_raw_transaction(&reclaim_tx).unwrap_err() {
             BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. }))
                 if message
@@ -754,8 +765,12 @@ mod serial {
 
         assert_eq!(depositor.get_balance(rpc).to_sat(), 0);
 
-        // Let's confirm the reclaim transaction to reclaim the funds. In
-        // this test scenario the signers have not swept the funds.
+        // Bypass mempool standardness using the generateblock RPC, which
+        // mines a block including the given raw transactions even if they
+        // would not pass the mempool's policy checks. At the consensus
+        // level tapscript treats OP_SUCCESSx as unconditional success, so
+        // the reclaim transaction is accepted despite the unsatisfied
+        // OP_CSV lock.
         #[derive(serde::Deserialize)]
         struct GeneratedBlockHash {
             hash: bitcoin::BlockHash,

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -22,6 +22,7 @@ mod serial {
     use bitcoin::taproot::TaprootSpendInfo;
     use bitcoin::transaction::Version;
     use bitcoincore_rpc::Error as BtcRpcError;
+    use bitcoincore_rpc::RawTx as _;
     use bitcoincore_rpc::RpcApi as _;
     use bitcoincore_rpc::jsonrpc::error::Error as JsonRpcError;
     use bitcoincore_rpc::jsonrpc::error::RpcError;
@@ -582,5 +583,203 @@ mod serial {
             depositor.get_balance(rpc).to_sat(),
             amount_sats - reclaim_tx_fee
         );
+    }
+
+    /// This validates that a user can reclaim their funds after the locktime.
+    ///
+    /// The test proceeds as follows:
+    /// 1. Spend all the user's funds for a sBTC deposit. Check that the
+    ///    balance is zero.
+    /// 2. Wait locktime blocks after the first confirmation.
+    /// 3. Create and submit another transaction reclaiming the funds.
+    /// 4. Confirm the transaction and check that the balance is what it is
+    ///    supposed to be, less the bitcoin transaction fees.
+    #[test]
+    fn reclaiming_rejected_deposits_op_success() {
+        let max_fee: u64 = 15000;
+        let amount_sats = 49_900_000;
+        let lock_time = u16::MAX as u32;
+
+        let (rpc, faucet) = regtest::initialize_blockchain();
+        let depositor = Recipient::new(AddressType::P2tr);
+        assert_eq!(depositor.get_balance(rpc).to_sat(), 0);
+
+        // Start off with some initial UTXOs to work with.
+        let outpoint = faucet.send_to(50_000_000, &depositor.address);
+        faucet.generate_blocks(1);
+
+        // There is only one UTXO under the depositor's name, so let's get it
+        let utxos = depositor.get_utxos(rpc, None);
+
+        assert_eq!(depositor.get_balance(rpc).to_sat(), 50_000_000);
+        // This is the "signers' secret". It doesn't matter for this test, so we
+        // generate one randomly.
+        let secret_key = SecretKey::new(&mut OsRng);
+        let deposit = DepositScriptInputs {
+            signers_public_key: secret_key.x_only_public_key(SECP256K1).0,
+            recipient: PrincipalData::from(StacksAddress::burn_address(false)),
+            max_fee,
+        };
+
+        // const OP_RETURN_187: u8 = opcodes::all::OP_RETURN_187.to_u8();
+        // Now the depositor's reclaim script is locked with a P2PK script that
+        // is locked with an x-only public key. This means we need to use a
+        // BIP-341 Schnorr signature to spend the funds.
+        let x_only_key = depositor.keypair.public_key().x_only_public_key().0;
+        let reclaim_script = ScriptBuf::builder()
+            .push_opcode(opcodes::all::OP_RETURN)
+            .push_opcode(opcodes::all::OP_RETURN_187)
+            .push_opcode(opcodes::all::OP_DROP)
+            .push_slice(x_only_key.serialize())
+            .push_opcode(opcodes::all::OP_CHECKSIG)
+            .into_script();
+        // The full reclaim path script includes an OP_CSV lock, so let's
+        // create one.
+        let reclaim = ReclaimScriptInputs::try_new_unvalidated(lock_time, reclaim_script).unwrap();
+
+        // Now we have both scripts in the taproot scriptPubKey.
+        let deposit_script = deposit.deposit_script();
+        let reclaim_script = reclaim.reclaim_script();
+
+        // This is a valid deposit UTXO for sBTC.
+        let deposit_utxo = TxOut {
+            value: Amount::from_sat(amount_sats),
+            script_pubkey: sbtc::deposits::to_script_pubkey(
+                deposit_script.clone(),
+                reclaim_script.clone(),
+            ),
+        };
+
+        // This is a full transaction including our deposit UTXO. Let's sign
+        // and submit it.
+        let mut deposit_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: outpoint,
+                sequence: Sequence::ZERO,
+                script_sig: ScriptBuf::new(),
+                witness: Witness::new(),
+            }],
+            output: vec![deposit_utxo.clone()],
+        };
+
+        regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &utxos, &depositor.keypair);
+        rpc.send_raw_transaction(&deposit_tx).unwrap();
+        // Let's confirm it.
+        faucet.generate_blocks(1);
+        // Nice, the depositor spent all of their funds on the deposit.
+        assert_eq!(depositor.get_balance(rpc).to_sat(), 0);
+
+        // Let's check that this is an invalid sBTC deposit.
+        let request = CreateDepositRequest {
+            outpoint: OutPoint::new(deposit_tx.compute_txid(), 0),
+            reclaim_script: reclaim_script.clone(),
+            deposit_script: deposit_script.clone(),
+        };
+
+        request.validate_tx(&deposit_tx, false).unwrap_err();
+
+        // Alright now we know the signers haven't moved our funds, so we
+        // reclaim it. We construct a transaction spending the funds back to
+        // ourselves.
+        let reclaim_tx_fee = 30000;
+        let mut reclaim_tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(deposit_tx.compute_txid(), 0),
+                sequence: Sequence::ZERO,
+                script_sig: ScriptBuf::new(),
+                witness: Witness::new(),
+            }],
+            output: vec![TxOut {
+                value: Amount::from_sat(amount_sats - reclaim_tx_fee),
+                script_pubkey: depositor.script_pubkey.clone(),
+            }],
+        };
+
+        // Now we need to sign our input. We construct the sighash and create a
+        // BIP-341 Schnorr signature. This part is not obvious.
+        let input_utxos: Vec<TxOut> = vec![deposit_utxo];
+
+        let prevouts = Prevouts::All(input_utxos.as_slice());
+        let sighash_type = TapSighashType::Default;
+        let mut sighasher = SighashCache::new(&reclaim_tx);
+
+        let leaf_hash = TapLeafHash::from_script(&reclaim_script, LeafVersion::TapScript);
+        let reclaim_sighash = sighasher
+            .taproot_script_spend_signature_hash(0, &prevouts, leaf_hash, sighash_type)
+            .unwrap();
+        let msg = secp256k1::Message::from(reclaim_sighash);
+
+        // Now we sign the sighash
+        let signature = SECP256K1.sign_schnorr(&msg, &depositor.keypair);
+
+        // Now we need to construct the merkle path proving that the merkle
+        // tree is what we say it is.
+        let ver = LeafVersion::TapScript;
+        // For such a simple tree, we construct it by hand.
+        let leaf1 = NodeInfo::new_leaf_with_ver(deposit_script.clone(), ver);
+        let leaf2 = NodeInfo::new_leaf_with_ver(reclaim_script.clone(), ver);
+
+        let node = NodeInfo::combine(leaf1, leaf2).unwrap();
+        let internal_key = *sbtc::UNSPENDABLE_TAPROOT_KEY;
+
+        let taproot = TaprootSpendInfo::from_node_info(SECP256K1, internal_key, node);
+        let control_block = taproot
+            .control_block(&(reclaim_script.clone(), ver))
+            .unwrap();
+        // Now we can set the witness data.
+        let witness_data = [
+            signature.serialize().to_vec(),
+            reclaim_script.to_bytes(),
+            control_block.serialize(),
+        ];
+        reclaim_tx.input[0].witness = Witness::from_slice(&witness_data);
+
+        // Let's generate one block, which is not enough to spend the funds
+        // because they are locked for u16::MAX blocks. We can spend the
+        // funds at the consensus level but bitcoin-core evaluates the
+        // script when it doesn't need to.
+        faucet.generate_blocks(1);
+
+        match rpc.send_raw_transaction(&reclaim_tx).unwrap_err() {
+            BtcRpcError::JsonRpc(JsonRpcError::Rpc(RpcError { code: -26, message, .. }))
+                if message
+                    == "non-mandatory-script-verify-flag (OP_SUCCESSx reserved for soft-fork upgrades)" =>
+                {}
+            err => panic!("{err}"),
+        };
+
+        assert_eq!(depositor.get_balance(rpc).to_sat(), 0);
+
+        // Let's confirm the reclaim transaction to reclaim the funds. In
+        // this test scenario the signers have not swept the funds.
+        #[derive(serde::Deserialize)]
+        struct GeneratedBlockHash {
+            hash: bitcoin::BlockHash,
+        }
+        let args = [
+            faucet.address.to_string().into(),
+            [reclaim_tx.raw_hex()].into(),
+        ];
+        let block_hash = rpc
+            .call::<GeneratedBlockHash>("generateblock", &args)
+            .unwrap()
+            .hash;
+
+        // Okay, the reclaim transaction is confirmed. Let's get the
+        // transaction, and check that looks like the one that we are
+        // expecting.
+        let reclaim_txid = reclaim_tx.compute_txid();
+        let tx_info = rpc
+            .get_raw_transaction_info(&reclaim_txid, Some(&block_hash))
+            .unwrap();
+
+        let expected_balance = amount_sats - reclaim_tx_fee;
+        assert_eq!(tx_info.blockhash, Some(block_hash));
+        assert_eq!(tx_info.confirmations, Some(1));
+        assert_eq!(depositor.get_balance(rpc).to_sat(), expected_balance);
     }
 }

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -593,7 +593,7 @@ mod serial {
     ///
     /// The test proceeds as follows:
     /// 1. Confirm a deposit whose reclaim path's user script contains an
-    ///    OP_SUCCESSx opcode, gated by an u16::MAX-block OP_CSV lock.
+    ///    OP_SUCCESSx opcode, gated by an u16::MAX block OP_CSV lock.
     /// 2. Verify that CreateDepositRequest::validate_tx rejects this
     ///    deposit, so that we know that the signers will reject it.
     /// 3. Build a reclaim transaction with Sequence::ZERO so the OP_CSV
@@ -635,7 +635,7 @@ mod serial {
         // OP_SUCCESSx opcode. Bitcoin-core's OP_SUCCESSx scan in tapscript
         // happens before execution, so even an OP_RETURN ahead of the
         // OP_SUCCESSx opcode does not prevent unconditional success. See
-        // the tapscript branch of xecuteWitnessScript:
+        // the tapscript branch of ExecuteWitnessScript:
         // <https://github.com/bitcoin/bitcoin/blob/v27.1/src/script/interpreter.cpp#L1792-L1808>
         let x_only_key = depositor.keypair.public_key().x_only_public_key().0;
         let reclaim_script = ScriptBuf::builder()
@@ -750,7 +750,6 @@ mod serial {
             control_block.serialize(),
         ];
         reclaim_tx.input[0].witness = Witness::from_slice(&witness_data);
-
 
         // We haven't generated enough blocks to satisfy the OP_CSV lock,
         // so this should fail regardless. In this case, it fails because

--- a/sbtc/tests/integration/validation.rs
+++ b/sbtc/tests/integration/validation.rs
@@ -616,7 +616,7 @@ mod serial {
 
         // Start off with some initial UTXOs to work with.
         let outpoint = faucet.send_to(50_000_000, &depositor.address);
-        faucet.generate_blocks(1);
+        faucet.generate_block();
 
         // There is only one UTXO under the depositor's name, so let's get it
         let utxos = depositor.get_utxos(rpc, None);
@@ -680,7 +680,7 @@ mod serial {
         regtest::p2tr_sign_transaction(&mut deposit_tx, 0, &utxos, &depositor.keypair);
         rpc.send_raw_transaction(&deposit_tx).unwrap();
         // Let's confirm it.
-        faucet.generate_blocks(1);
+        faucet.generate_block();
         // Nice, the depositor spent all of their funds on the deposit.
         assert_eq!(depositor.get_balance(rpc).to_sat(), 0);
 


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2027

## Changes

* Check that there are no `OP_SUCCESSx` opcodes in the user-supplied part of the reclaim script.
* Added a test that checks that `OP_SUCCESSx` works the way that they claimed in the BIP.

## Testing Information

Tested on devenv, and Emily successfully rejected a deposit using the `OP_SUCCESSx` opcode in the reclaim script.

## Checklist:

- [x] I have performed a self-review of my code
