### PR TITLE
feat: emily to return deposits with any max fee

### DIFF
--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -178,28 +178,7 @@ pub async fn get_deposits(
         )
         .await?;
         // Convert data into resource types.
-        let deposits: Vec<DepositInfo> = entries
-            .into_iter()
-            .filter_map(|entry| {
-                // These deposits have all been validated, so we are okay
-                // with "bailing" here.
-                let info: DepositInfo = entry.into();
-                let deposit_script = ScriptBuf::from_hex(&info.deposit_script).ok()?;
-                let deposit_inputs =
-                    sbtc::deposits::DepositScriptInputs::parse(&deposit_script).ok()?;
-                if deposit_inputs.max_fee <= i64::MAX as u64 {
-                    Some(info)
-                } else {
-                    tracing::warn!(
-                        max_fee = %deposit_inputs.max_fee,
-                        txid = %info.bitcoin_txid,
-                        output_index = %info.bitcoin_tx_output_index,
-                        "ignoring deposit with max fee that is too high"
-                    );
-                    None
-                }
-            })
-            .collect();
+        let deposits: Vec<DepositInfo> = entries.into_iter().map(|entry| entry.into()).collect();
         // Create response.
         let response = GetDepositsResponse { deposits, next_token };
         // Respond.

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -449,15 +449,16 @@ async fn get_deposits() {
     clean_test_setup(tables).await;
 }
 
-/// Test that deposit requests where the max fee is greater than i64::MAX
-/// are not returned in get_deposits API calls.
+/// Test that deposit requests with a large max fee are returned in
+/// get_deposits API calls.
 #[tokio::test]
 async fn get_deposits_large_max_fee() {
     let (configuration, tables) = new_test_setup().await;
 
     // Arrange.
     // --------
-    let max_fees: [u64; 3] = [1000, i64::MAX as u64 + 1, i64::MAX as u64];
+    let max_fees = [1000, i64::MAX as u64 + 1, i64::MAX as u64, u64::MAX];
+
     // Setup test deposit transactions and the Emily request.
     let create_requests = max_fees
         .into_iter()
@@ -482,16 +483,20 @@ async fn get_deposits_large_max_fee() {
         .await
         .expect("Received an error after making a valid get deposits api call.");
 
+    let mut max_fees: std::collections::BTreeSet<u64> = max_fees.into_iter().collect();
     // Assert.
     // -------
-    // One of the deposits have a max fee that exceeds i64::MAX, so it
-    // should not be returned.
-    assert_eq!(response.deposits.len(), 2);
+    assert_eq!(response.deposits.len(), max_fees.len());
     for deposit_info in response.deposits.iter() {
         let deposit_script = ScriptBuf::from_hex(&deposit_info.deposit_script).unwrap();
         let deposit_script_inputs = DepositScriptInputs::parse(&deposit_script).unwrap();
-        assert!(deposit_script_inputs.max_fee <= i64::MAX as u64);
+        // Remove returns whether the element was actually present in the
+        // set.
+        assert!(max_fees.remove(&deposit_script_inputs.max_fee));
     }
+    // Not strictly necessary, since we have the length check and the
+    // assert! on remove above, but it's a good sanity check.
+    assert!(max_fees.is_empty());
 
     clean_test_setup(tables).await;
 }

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -492,8 +492,8 @@ async fn get_deposits_large_max_fee() {
     for deposit_info in response.deposits.iter() {
         let deposit_script = ScriptBuf::from_hex(&deposit_info.deposit_script).unwrap();
         let deposit_script_inputs = DepositScriptInputs::parse(&deposit_script).unwrap();
-        // Remove returns whether the element was actually present in the
-        // set.
+        // BTreeSet::remove returns whether the element was actually
+        // present in the set.
         assert!(expected_max_fees.remove(&deposit_script_inputs.max_fee));
     }
     // Not strictly necessary, since we have the length check and the

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -449,8 +449,8 @@ async fn get_deposits() {
     clean_test_setup(tables).await;
 }
 
-/// Test that deposit requests with a large max fee are returned in
-/// get_deposits API calls.
+/// Test that deposit requests with arbitrarily large max fees are returned
+/// in get_deposits API calls.
 #[tokio::test]
 async fn get_deposits_large_max_fee() {
     let (configuration, tables) = new_test_setup().await;
@@ -483,20 +483,22 @@ async fn get_deposits_large_max_fee() {
         .await
         .expect("Received an error after making a valid get deposits api call.");
 
-    let mut max_fees: std::collections::BTreeSet<u64> = max_fees.into_iter().collect();
+    // The fees are all unique so this should be fine.
+    let mut expected_max_fees: std::collections::BTreeSet<u64> = max_fees.into_iter().collect();
+    assert_eq!(expected_max_fees.len(), max_fees.len());
     // Assert.
     // -------
-    assert_eq!(response.deposits.len(), max_fees.len());
+    assert_eq!(response.deposits.len(), expected_max_fees.len());
     for deposit_info in response.deposits.iter() {
         let deposit_script = ScriptBuf::from_hex(&deposit_info.deposit_script).unwrap();
         let deposit_script_inputs = DepositScriptInputs::parse(&deposit_script).unwrap();
         // Remove returns whether the element was actually present in the
         // set.
-        assert!(max_fees.remove(&deposit_script_inputs.max_fee));
+        assert!(expected_max_fees.remove(&deposit_script_inputs.max_fee));
     }
     // Not strictly necessary, since we have the length check and the
     // assert! on remove above, but it's a good sanity check.
-    assert!(max_fees.is_empty());
+    assert!(expected_max_fees.is_empty());
 
     clean_test_setup(tables).await;
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2032

## Changes

* Emily now returns all deposit requests that have been stored in her database.

## Testing Information

Once approved, I think we should ship this to private-mainnet and test it there. Then we can merge it into main and ship to mainnet.

## Checklist

- [x] I have performed a self-review of my code
