### PR TITLE
chore: fix slow test

### DIFF
--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -2769,7 +2769,7 @@ mod tests {
             private_key: ctx.config().signer.private_key,
             signing_round_max_duration: Duration::from_secs(10),
             bitcoin_presign_request_max_duration: Duration::from_secs(10),
-            dkg_max_duration: Duration::from_secs(10),
+            dkg_max_duration: Duration::from_secs(1),
             is_epoch3: true,
         };
 
@@ -2792,7 +2792,8 @@ mod tests {
 
         // Now the chain tip in the state matches the chain tip passed in,
         // so we should process the blocks. However, we do not have any
-        // signer set info in the state, so we'll bail with an error.
+        // signer set info in the state, so we'll bail with an error after
+        // attempting (and failing) to DKG.
         let error = ev.process_new_blocks(chain_tip1).await.unwrap_err();
         assert_matches::assert_matches!(error, Error::MissingAggregateKey(_));
     }


### PR DESCRIPTION
## Description

Fix slow `should_skip_processing_bitcoin_blocks_if_chain_tip_has_changed` test.

## Changes

This test was taking the full 10s in the last `process_new_blocks` call:
```
24.713Z ERROR process_new_blocks{public_key=.. bitcoin_tip_hash=4a..2e bitcoin_tip_height=7..}: signer::transaction_coordinator: no bitcoin chain tip in state, skipping processing
24.714Z  INFO process_new_blocks{public_key=.. bitcoin_tip_hash=4a..2e bitcoin_tip_height=7..}: signer::transaction_coordinator: bitcoin chain tip has changed, skipping processing state_bitcoin_tip_hash=98..d4 state_bitcoin_tip_height=2..
24.714Z DEBUG process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}: signer::transaction_coordinator: we are the coordinator
24.714Z DEBUG process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}: signer::transaction_coordinator: determining if we need to coordinate DKG
24.714Z  INFO process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}: signer::transaction_coordinator: no non-failed DKG shares exist; proceeding with DKG
24.714Z  INFO process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}:coordinate_dkg: signer::transaction_coordinator: Coordinating DKG
24.714Z DEBUG process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}:coordinate_dkg: wsts::state_machine::coordinator::fire: state change from Idle to DkgPublicDistribute
24.714Z  INFO process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}:coordinate_dkg: wsts::state_machine::coordinator::fire: Starting Public Share Distribution dkg_id=2826160002783239898
24.714Z DEBUG process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}:coordinate_dkg: wsts::state_machine::coordinator::fire: state change from DkgPublicDistribute to DkgPublicGather
34.717Z ERROR process_new_blocks{public_key=.. bitcoin_tip_hash=98..d4 bitcoin_tip_height=2..}: signer::transaction_coordinator: failed to coordinate DKG; using existing aggregate key error=coordinator timed out after 10 seconds
```

## Testing Information

Test is green.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have had an AI agent review my code
