### PR TITLE
chore: normalize Emily deposits

### DIFF
--- a/emily/handler/src/api/handlers/deposit.rs
+++ b/emily/handler/src/api/handlers/deposit.rs
@@ -337,12 +337,15 @@ pub async fn create_deposit(
 
         let deposit_info = body.validate(context.settings.is_mainnet)?;
 
+        let bitcoin_txid = deposit_info.outpoint.txid.to_string();
+        let bitcoin_tx_output_index = deposit_info.outpoint.vout;
+
         // Check if deposit with such txid and outindex already exists.
         let entry = accessors::get_deposit_entry(
             &context,
             &DepositEntryKey {
-                bitcoin_txid: body.bitcoin_txid.clone(),
-                bitcoin_tx_output_index: body.bitcoin_tx_output_index,
+                bitcoin_txid: bitcoin_txid.clone(),
+                bitcoin_tx_output_index,
             },
         )
         .await;
@@ -359,16 +362,16 @@ pub async fn create_deposit(
         let reclaim_pubkeys_hash = extract_reclaim_pubkeys_hash(&deposit_info.reclaim_script);
         if reclaim_pubkeys_hash.is_none() {
             tracing::warn!(
-                bitcoin_txid = %body.bitcoin_txid,
-                bitcoin_tx_output_index = %body.bitcoin_tx_output_index,
+                %bitcoin_txid,
+                %bitcoin_tx_output_index,
                 "unknown reclaim script"
             );
         }
         // Make table entry.
         let deposit_entry: DepositEntry = DepositEntry {
             key: DepositEntryKey {
-                bitcoin_txid: body.bitcoin_txid,
-                bitcoin_tx_output_index: body.bitcoin_tx_output_index,
+                bitcoin_txid,
+                bitcoin_tx_output_index,
             },
             recipient: hex::encode(deposit_info.recipient.serialize_to_vec()),
             parameters: DepositParametersEntry {
@@ -385,8 +388,8 @@ pub async fn create_deposit(
             last_update_block_hash: stacks_block_hash,
             last_update_height: stacks_block_height,
             amount: deposit_info.amount,
-            reclaim_script: body.reclaim_script,
-            deposit_script: body.deposit_script,
+            reclaim_script: deposit_info.reclaim_script.to_hex_string(),
+            deposit_script: deposit_info.deposit_script.to_hex_string(),
             reclaim_pubkeys_hash,
             ..Default::default()
         };

--- a/emily/handler/tests/integration/deposit.rs
+++ b/emily/handler/tests/integration/deposit.rs
@@ -208,6 +208,94 @@ async fn create_and_get_deposit_happy_path() {
 }
 
 #[tokio::test]
+async fn create_deposit_normalization() {
+    let (configuration, tables) = new_test_setup().await;
+
+    // Arrange.
+    // --------
+    let bitcoin_tx_output_index = 0;
+
+    // Setup test deposit transaction.
+    let DepositTxnData {
+        recipients,
+        reclaim_scripts,
+        deposit_scripts,
+        bitcoin_txid,
+        transaction_hex,
+    } = DepositTxnData::new(DEPOSIT_LOCK_TIME, DEPOSIT_MAX_FEE, &[DEPOSIT_AMOUNT_SATS]);
+
+    let recipient = recipients.first().unwrap().clone();
+    let reclaim_script = reclaim_scripts.first().unwrap().clone();
+    let deposit_script = deposit_scripts.first().unwrap().clone();
+
+    let request = CreateDepositRequestBody {
+        bitcoin_tx_output_index,
+        bitcoin_txid: bitcoin_txid.clone(),
+        reclaim_script: reclaim_script.clone(),
+        deposit_script: deposit_script.clone(),
+        transaction_hex: transaction_hex.clone(),
+    };
+
+    // Try to create another one non-normalzied
+    let request_2 = CreateDepositRequestBody {
+        bitcoin_tx_output_index,
+        bitcoin_txid: bitcoin_txid.to_uppercase(),
+        reclaim_script: reclaim_script.to_uppercase(),
+        deposit_script: deposit_script.to_uppercase(),
+        transaction_hex: transaction_hex.to_uppercase(),
+    };
+
+    let expected_deposit = Deposit {
+        amount: DEPOSIT_AMOUNT_SATS,
+        bitcoin_tx_output_index,
+        bitcoin_txid: bitcoin_txid.clone(),
+        fulfillment: None,
+        last_update_block_hash: BLOCK_HASH.into(),
+        last_update_height: BLOCK_HEIGHT,
+        reclaim_script: reclaim_script.clone(),
+        deposit_script: deposit_script.clone(),
+        parameters: Box::new(DepositParameters {
+            lock_time: DEPOSIT_LOCK_TIME,
+            max_fee: DEPOSIT_MAX_FEE,
+        }),
+        recipient,
+        status: testing_emily_client::models::DepositStatus::Pending,
+        status_message: INITIAL_DEPOSIT_STATUS_MESSAGE.into(),
+        replaced_by_tx: None,
+    };
+
+    // Act.
+    // ----
+    let created_deposit = apis::deposit_api::create_deposit(&configuration, request)
+        .await
+        .expect("Received an error after making a valid create deposit request api call.");
+
+    let created_deposit_2 = apis::deposit_api::create_deposit(&configuration, request_2)
+        .await
+        .expect("Received an error after making a valid create deposit request api call.");
+
+    let deposits = apis::deposit_api::get_deposits(
+        &configuration,
+        testing_emily_client::models::DepositStatus::Pending,
+        None,
+        None,
+    )
+    .await
+    .expect("Received an error after making a valid get deposits api call.")
+    .deposits;
+
+    // Assert.
+    // -------
+    assert_eq!(expected_deposit, created_deposit);
+    assert_eq!(created_deposit, created_deposit_2);
+
+    assert_eq!(deposits.len(), 1);
+    assert_eq!(expected_deposit.bitcoin_txid, deposits[0].bitcoin_txid);
+
+    clean_test_setup(tables).await;
+}
+
+#[tokio::test]
 async fn wipe_databases_test() {
     let (configuration, tables) = new_test_setup().await;
 


### PR DESCRIPTION
## Description

Normalize Emily deposits on creation.

## Changes

When creating deposits on Emily, store them normalized.

## Testing Information

Existing tests are green.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have had an AI agent review my code
