### PR TITLE
feat: bake sanctions file in release blocklist client

### DIFF
--- a/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
+++ b/.github/actions/dockerfiles/Dockerfile.blocklist-client.debian
@@ -52,7 +52,7 @@ FROM debian:trixie-slim AS blocklist-client
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /output/blocklist-client /usr/local/bin/blocklist-client
 
-# Optional: baked-in sanctions list. Glob pattern means missing file is a no-op.
-COPY sanctions.tx[t] /etc/blocklist-client/
+# The baked-in sanctions list file is required to build the release image
+COPY sanctions.txt /etc/blocklist-client/
 
 ENTRYPOINT ["/usr/local/bin/blocklist-client"]

--- a/.github/workflows/image-build-and-draft-release.yaml
+++ b/.github/workflows/image-build-and-draft-release.yaml
@@ -60,6 +60,26 @@ jobs:
         with:
           ref: refs/tags/${{ github.event.client_payload.tag_name }}
 
+      ## Fetch the sanctions list for the blocklist client
+      - name: Configure AWS Credentials via OIDC
+        if: matrix.docker_target == 'blocklist-client'
+        uses: stacks-sbtc/actions/aws/configure-aws-credentials@505c42b153ba2ac261c276e96bc5dc7b68d61039
+        with:
+          role-to-assume: ${{ secrets['SANCTIONS_AWS_ROLE_ARN'] }}
+          aws-region: ${{ vars['SANCTIONS_AWS_REGION'] }}
+
+      - name: Fetch sanctions list from S3 bucket
+        if: matrix.docker_target == 'blocklist-client'
+        env:
+          SANCTIONS_AWS_S3_BUCKET: ${{ vars['SANCTIONS_AWS_S3_BUCKET'] }}
+        run: |
+          aws s3 cp "s3://${SANCTIONS_AWS_S3_BUCKET}/ofac/sanctions.txt" ./sanctions.txt
+          if [ ! -f ./sanctions.txt ]; then
+            echo "sanctions file was not fetched"
+            exit 1
+          fi
+          wc -l ./sanctions.txt
+
       - name: Setup Buildx
         id: setup_buildx
         uses: stacks-sbtc/actions/docker/setup-buildx-action@505c42b153ba2ac261c276e96bc5dc7b68d61039


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2054

## Changes

Fetch the file from S3 in the docker context and copy it over in the image in the release job.
Also make the sanctions file required in the dockerfile.

With respect to the nightly one, the job doesn't fail for an empty sanctions file.

## Testing Information

We will test this with a release from main, see https://github.com/stacks-sbtc/sbtc/pull/2062 for the (working) nightly side.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have had an AI agent review my code
