### PR TITLE
chore: no `autoDeleteObjects`

### DIFF
--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -142,7 +142,7 @@ export class EmilyStack extends cdk.Stack {
             encryption: s3.BucketEncryption.S3_MANAGED,
             enforceSSL: true,
             removalPolicy,
-            autoDeleteObjects: removalPolicy === cdk.RemovalPolicy.DESTROY,
+            autoDeleteObjects: false,
         });
     }
 

--- a/emily/cdk/lib/emily-stack.ts
+++ b/emily/cdk/lib/emily-stack.ts
@@ -111,10 +111,7 @@ export class EmilyStack extends cdk.Stack {
             limitTable.grantReadWriteData(operationLambda);
             throttleTable.grantReadWriteData(operationLambda);
 
-            const sanctionsBucket: s3.Bucket = this.createSanctionsBucket(
-                persistentResourceRemovalPolicy,
-                props,
-            );
+            const sanctionsBucket: s3.Bucket = this.createSanctionsBucket(props);
 
             const emilyApis: apig.SpecRestApi[] = this.createOrUpdateApi(
                 alias,
@@ -127,21 +124,17 @@ export class EmilyStack extends cdk.Stack {
     /**
      * Creates the private S3 bucket that backs the sanctions list served at
      * `GET /sanctions` on the public API.
-     * @param {cdk.RemovalPolicy} removalPolicy The removal policy for the bucket.
      * @param {EmilyStackProps} props The stack properties.
      * @returns {s3.Bucket} The created or updated S3 bucket.
      */
-    createSanctionsBucket(
-        removalPolicy: cdk.RemovalPolicy,
-        props: EmilyStackProps,
-    ): s3.Bucket {
+    createSanctionsBucket(props: EmilyStackProps): s3.Bucket {
         const bucketId: string = 'SanctionsLists';
         return new s3.Bucket(this, bucketId, {
             bucketName: EmilyStackUtils.getResourceName(bucketId, props).toLowerCase(),
             blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
             encryption: s3.BucketEncryption.S3_MANAGED,
             enforceSSL: true,
-            removalPolicy,
+            removalPolicy: cdk.RemovalPolicy.RETAIN,
             autoDeleteObjects: false,
         });
     }


### PR DESCRIPTION
## Description

Setting `autoDeleteObjects` to true configures a lambda to automatically delete objects when the bucket is destroyed in our CDK stack. I don't think we want that lambda since we don't want our CDK managing the bucket.

## Changes

* Turn off `autoDeleteObject` on the bucket, and set the removal policy on the bucket to retain.

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
