### PR TITLE
chore: skip non-sql migration files

### DIFF
--- a/signer/src/storage/postgres/store.rs
+++ b/signer/src/storage/postgres/store.rs
@@ -73,6 +73,7 @@ impl PgStore {
             // in the migrations directory.
             if !key.ends_with(".sql") {
                 tracing::debug!(migration = %key, "Skipping non-SQL migration file");
+                continue;
             }
 
             // Check if the migration has already been applied. If so, we should


### PR DESCRIPTION
## Description

Skip non-sql files when applying migrations.

## Changes

Add a missing `continue` that what missing when going over migration files.

## Testing Information

Tests apply migrations so if those are green we should be good.

## Checklist

- [X] I have performed a self-review of my code
- [X] I have had an AI agent review my code
