### PR TITLE
feat: add network_chain_id config

### DIFF
--- a/signer/src/config/mod.rs
+++ b/signer/src/config/mod.rs
@@ -1,4 +1,6 @@
 //! Configuration management for the signer
+use blockstack_lib::core::CHAIN_ID_MAINNET;
+use blockstack_lib::core::CHAIN_ID_TESTNET;
 use config::Config;
 use config::ConfigError;
 use config::Environment;
@@ -110,6 +112,13 @@ impl NetworkKind {
     /// Returns whether the network variant is Mainnet.
     pub fn is_mainnet(&self) -> bool {
         self == &NetworkKind::Mainnet
+    }
+    /// Return the default Stacks network chain id
+    pub fn chain_id(&self) -> u32 {
+        match self {
+            NetworkKind::Mainnet => CHAIN_ID_MAINNET,
+            _ => CHAIN_ID_TESTNET,
+        }
     }
 }
 
@@ -377,8 +386,10 @@ pub struct SignerConfig {
     pub private_key: PrivateKey,
     /// P2P network configuration
     pub p2p: P2PNetworkConfig,
-    /// P2P network configuration
+    /// Bitcoin and Stacks network type
     pub network: NetworkKind,
+    /// Custom chain ID for the Stacks network. If unset defaults to the `network` default one
+    pub network_chain_id: Option<u32>,
     /// Event observer server configuration
     pub event_observer: EventObserverConfig,
     /// The address of the deployer of the sBTC smart contracts.
@@ -540,6 +551,11 @@ impl SignerConfig {
     /// Return the public key of the signer.
     pub fn public_key(&self) -> PublicKey {
         PublicKey::from_private_key(&self.private_key)
+    }
+    /// Return the Stacks network chain id
+    pub fn network_chain_id(&self) -> u32 {
+        self.network_chain_id
+            .unwrap_or_else(|| self.network.chain_id())
     }
 }
 
@@ -1676,7 +1692,7 @@ mod tests {
         clear_env();
 
         let is_mainnet = network == NetworkKind::Mainnet;
-        // The deployer address always has the opposite network kind.
+        // The deployer address matches the network kind.
         let address = StacksAddress::burn_address(is_mainnet);
         set_var("SIGNER_SIGNER__DEPLOYER", address.to_string());
         // Let's set the network. maybe use strum for this in the future
@@ -1765,5 +1781,31 @@ mod tests {
             settings.unwrap_err(),
             ConfigError::Message(msg) if msg == SignerConfigError::UnsupportedDatabaseDriver(driver.to_string()).to_string()
         ));
+    }
+
+    #[test_case::test_case(NetworkKind::Mainnet, "", CHAIN_ID_MAINNET; "mainnet network, no override")]
+    #[test_case::test_case(NetworkKind::Testnet, "", CHAIN_ID_TESTNET; "testnet network, no override")]
+    #[test_case::test_case(NetworkKind::Regtest, "", CHAIN_ID_TESTNET; "regtest network, no override")]
+    #[test_case::test_case(NetworkKind::Mainnet, "42", 42; "mainnet network, with override")]
+    #[test_case::test_case(NetworkKind::Testnet, "42", 42; "testnet network, with override")]
+    #[test_case::test_case(NetworkKind::Regtest, "42", 42; "regtest network, with override")]
+    fn network_chain_id(network: NetworkKind, network_chain_id: &str, expected_chain_id: u32) {
+        clear_env();
+
+        // We need these to pass the validation
+        let is_mainnet = network == NetworkKind::Mainnet;
+        // The deployer address matches the network kind.
+        let address = StacksAddress::burn_address(is_mainnet);
+        set_var("SIGNER_SIGNER__DEPLOYER", address.to_string());
+        // We need to set at least one seed when deploying to mainnet.
+        set_var("SIGNER_SIGNER__P2P__SEEDS", "tcp://localhost:4122");
+
+        set_var("SIGNER_SIGNER__NETWORK", network.to_string());
+        if !network_chain_id.is_empty() {
+            set_var("SIGNER_SIGNER__NETWORK_CHAIN_ID", network_chain_id);
+        }
+
+        let settings = Settings::new_from_default_config().unwrap();
+        assert_eq!(settings.signer.network_chain_id(), expected_chain_id);
     }
 }

--- a/signer/src/stacks/api.rs
+++ b/signer/src/stacks/api.rs
@@ -1835,7 +1835,14 @@ mod tests {
             .take(num_keys as usize)
             .collect::<Vec<_>>();
 
-        SignerWallet::new(&public_keys, signatures_required, network_kind, 0).unwrap()
+        SignerWallet::new(
+            &public_keys,
+            signatures_required,
+            network_kind,
+            network_kind.chain_id(),
+            0,
+        )
+        .unwrap()
     }
 
     #[ignore = "This is an integration test that hasn't been setup for CI yet"]

--- a/signer/src/stacks/contracts.rs
+++ b/signer/src/stacks/contracts.rs
@@ -1677,7 +1677,14 @@ mod tests {
             SecretKey::new(&mut rng),
         ];
         let public_keys = secret_keys.map(|sk| sk.public_key(SECP256K1).into());
-        let wallet = SignerWallet::new(&public_keys, 2, NetworkKind::Testnet, 0).unwrap();
+        let wallet = SignerWallet::new(
+            &public_keys,
+            2,
+            NetworkKind::Testnet,
+            NetworkKind::Testnet.chain_id(),
+            0,
+        )
+        .unwrap();
         let deployer = StacksAddress::burn_address(false);
         let aggregate_key: PublicKey = fake::Faker.fake_with_rng(&mut rng);
 

--- a/signer/src/stacks/wallet.rs
+++ b/signer/src/stacks/wallet.rs
@@ -17,8 +17,6 @@ use blockstack_lib::chainstate::stacks::TransactionAuth;
 use blockstack_lib::chainstate::stacks::TransactionPublicKeyEncoding;
 use blockstack_lib::chainstate::stacks::TransactionSpendingCondition;
 use blockstack_lib::chainstate::stacks::TransactionVersion;
-use blockstack_lib::core::CHAIN_ID_MAINNET;
-use blockstack_lib::core::CHAIN_ID_TESTNET;
 use blockstack_lib::types::chainstate::StacksAddress;
 use blockstack_lib::util::secp256k1::Secp256k1PublicKey;
 use rand::SeedableRng as _;
@@ -66,6 +64,8 @@ pub struct SignerWallet {
     signatures_required: u16,
     /// The kind of network we are operating under.
     network_kind: NetworkKind,
+    /// The network chain id
+    network_chain_id: u32,
     /// The multi-sig address associated with the public keys.
     address: StacksAddress,
     /// The next nonce for the StacksAddress associated with the address of
@@ -110,6 +110,7 @@ impl SignerWallet {
         public_keys: I,
         signatures_required: u16,
         network_kind: NetworkKind,
+        network_chain_id: u32,
         nonce: u64,
     ) -> Result<Self, Error>
     where
@@ -152,6 +153,7 @@ impl SignerWallet {
             public_keys,
             signatures_required,
             network_kind,
+            network_chain_id,
             address: StacksAddress::from_public_keys(version, &hash_mode, num_sigs, &pubkeys)
                 .ok_or(Error::StacksMultiSig(signatures_required, num_keys))?,
             nonce: AtomicU64::new(nonce),
@@ -176,7 +178,13 @@ impl SignerWallet {
             Some(info) => {
                 let public_keys = info.signer_set;
                 let signatures_required = info.signatures_required;
-                SignerWallet::new(&public_keys, signatures_required, config.network, 0)
+                SignerWallet::new(
+                    &public_keys,
+                    signatures_required,
+                    config.network,
+                    config.network_chain_id(),
+                    0,
+                )
             }
             None => Self::load_boostrap_wallet(&ctx.config().signer),
         }
@@ -188,7 +196,13 @@ impl SignerWallet {
         let public_keys = config.bootstrap_signing_set.clone();
         let signatures_required = config.bootstrap_signatures_required;
 
-        SignerWallet::new(&public_keys, signatures_required, network_kind, 0)
+        SignerWallet::new(
+            &public_keys,
+            signatures_required,
+            network_kind,
+            config.network_chain_id(),
+            0,
+        )
     }
 
     fn hash_mode() -> OrderIndependentMultisigHashMode {
@@ -298,9 +312,9 @@ impl MultisigTx {
         // https://github.com/hirosystems/stacks.js/blob/2c57ea4e5abed76da903f5138c79c1d2eceb008b/packages/transactions/src/constants.ts#L1-L8,
         // and in the clarity docs at
         // https://docs.stacks.co/clarity/keywords#chain-id-clarity2:
-        let (version, chain_id) = match wallet.network_kind {
-            NetworkKind::Mainnet => (TransactionVersion::Mainnet, CHAIN_ID_MAINNET),
-            _ => (TransactionVersion::Testnet, CHAIN_ID_TESTNET),
+        let version = match wallet.network_kind {
+            NetworkKind::Mainnet => TransactionVersion::Mainnet,
+            _ => TransactionVersion::Testnet,
         };
 
         let conditions = payload.post_conditions();
@@ -309,7 +323,7 @@ impl MultisigTx {
 
         let tx = StacksTransaction {
             version,
-            chain_id,
+            chain_id: wallet.network_chain_id,
             auth: TransactionAuth::Standard(spending_condition),
             anchor_mode: TransactionAnchorMode::Any,
             post_condition_mode: conditions.post_condition_mode,
@@ -414,6 +428,7 @@ where
         &public_keys,
         wallet.signatures_required,
         wallet.network_kind,
+        wallet.network_chain_id,
         0,
     )?;
 
@@ -537,7 +552,14 @@ mod tests {
             .collect();
 
         let public_keys: Vec<_> = key_pairs.iter().map(|kp| kp.public_key().into()).collect();
-        let wallet = SignerWallet::new(&public_keys, signatures_required, network, 1).unwrap();
+        let wallet = SignerWallet::new(
+            &public_keys,
+            signatures_required,
+            network,
+            network.chain_id(),
+            1,
+        )
+        .unwrap();
 
         let mut tx_signer =
             MultisigTx::new_contract_call(TestContractCall::default(), &wallet, TX_FEE);
@@ -589,7 +611,14 @@ mod tests {
             .collect();
 
         let public_keys: Vec<_> = key_pairs.iter().map(|kp| kp.public_key().into()).collect();
-        let wallet = SignerWallet::new(&public_keys, signatures_required, network, 1).unwrap();
+        let wallet = SignerWallet::new(
+            &public_keys,
+            signatures_required,
+            network,
+            network.chain_id(),
+            1,
+        )
+        .unwrap();
 
         let mut tx_signer =
             MultisigTx::new_contract_call(TestContractCall::default(), &wallet, TX_FEE);
@@ -647,7 +676,7 @@ mod tests {
                 .collect();
 
         let pks1 = public_keys.clone();
-        let wallet1 = SignerWallet::new(&pks1, 5, network, 0).unwrap();
+        let wallet1 = SignerWallet::new(&pks1, 5, network, network.chain_id(), 0).unwrap();
 
         // Although it's unlikely, it's possible for the shuffle to not
         // shuffle anything, so we need to keep trying.
@@ -655,7 +684,7 @@ mod tests {
             public_keys.shuffle(&mut OsRng);
         }
 
-        let wallet2 = SignerWallet::new(&public_keys, 5, network, 0).unwrap();
+        let wallet2 = SignerWallet::new(&public_keys, 5, network, network.chain_id(), 0).unwrap();
 
         assert_eq!(wallet1.address(), wallet2.address())
     }
@@ -701,7 +730,14 @@ mod tests {
                 .collect();
         let signatures_required = 5;
         let network = NetworkKind::Regtest;
-        let wallet1 = SignerWallet::new(&signer_keys, signatures_required, network, 0).unwrap();
+        let wallet1 = SignerWallet::new(
+            &signer_keys,
+            signatures_required,
+            network,
+            network.chain_id(),
+            0,
+        )
+        .unwrap();
 
         let (_, stacks_chain_tip) = db.get_chain_tips().await;
 
@@ -765,7 +801,14 @@ mod tests {
             .take(num_keys as usize)
             .collect::<Vec<_>>();
 
-        let wallet = SignerWallet::new(&public_keys, signatures_required, network_kind, 0).unwrap();
+        let wallet = SignerWallet::new(
+            &public_keys,
+            signatures_required,
+            network_kind,
+            network_kind.chain_id(),
+            0,
+        )
+        .unwrap();
 
         let payload =
             TransactionPayload::ContractCall(TestContractCall::default().as_contract_call());

--- a/signer/src/testing/wallet.rs
+++ b/signer/src/testing/wallet.rs
@@ -39,8 +39,14 @@ pub fn regtest_bootstrap_wallet() -> (SignerWallet, [Keypair; 3]) {
     .map(|sk| Keypair::from_seckey_str(SECP256K1, sk).unwrap());
 
     let public_keys = key_pairs.map(|kp| kp.public_key().into());
-    let wallet =
-        SignerWallet::new(&public_keys, signatures_required, NetworkKind::Testnet, 0).unwrap();
+    let wallet = SignerWallet::new(
+        &public_keys,
+        signatures_required,
+        NetworkKind::Testnet,
+        NetworkKind::Testnet.chain_id(),
+        0,
+    )
+    .unwrap();
 
     (wallet, key_pairs)
 }

--- a/signer/tests/integration/e2e.rs
+++ b/signer/tests/integration/e2e.rs
@@ -78,8 +78,14 @@ async fn start_signers(
         .collect::<Vec<_>>();
 
     let public_keys: Vec<PublicKey> = keypairs.iter().map(|kp| kp.public_key().into()).collect();
-    let wallet =
-        SignerWallet::new(&public_keys, signatures_required, NetworkKind::Testnet, 0).unwrap();
+    let wallet = SignerWallet::new(
+        &public_keys,
+        signatures_required,
+        NetworkKind::Testnet,
+        NetworkKind::Testnet.chain_id(),
+        0,
+    )
+    .unwrap();
 
     let tx = fund_stx(
         stacks_client,

--- a/signer/tests/integration/rotate_keys.rs
+++ b/signer/tests/integration/rotate_keys.rs
@@ -67,6 +67,7 @@ impl TestRotateKeySetup {
             &signer_keys,
             signatures_required,
             signer::config::NetworkKind::Regtest,
+            signer::config::NetworkKind::Regtest.chain_id(),
             0,
         )
         .unwrap();
@@ -432,6 +433,7 @@ async fn rotate_key_validation_wrong_signatures_required() {
         setup.wallet.public_keys(),
         setup.wallet.signatures_required() + 1,
         signer::config::NetworkKind::Regtest,
+        signer::config::NetworkKind::Regtest.chain_id(),
         0,
     )
     .unwrap();

--- a/signer/tests/integration/setup.rs
+++ b/signer/tests/integration/setup.rs
@@ -410,6 +410,7 @@ impl TestSweepSetup {
             &signer_set,
             self.signatures_required,
             NetworkKind::Regtest,
+            NetworkKind::Regtest.chain_id(),
             0,
         )
         .unwrap();
@@ -583,8 +584,14 @@ impl TestSignerSet {
     }
 
     pub fn address(&self, signatures_required: u16) -> StacksAddress {
-        let wallet =
-            SignerWallet::new(&self.keys, signatures_required, NetworkKind::Regtest, 0).unwrap();
+        let wallet = SignerWallet::new(
+            &self.keys,
+            signatures_required,
+            NetworkKind::Regtest,
+            NetworkKind::Regtest.chain_id(),
+            0,
+        )
+        .unwrap();
         wallet.address().clone()
     }
 }

--- a/signer/tests/integration/transaction_coordinator.rs
+++ b/signer/tests/integration/transaction_coordinator.rs
@@ -6141,6 +6141,7 @@ where
         &signer_keys,
         signatures_required,
         signer::config::NetworkKind::Regtest,
+        signer::config::NetworkKind::Regtest.chain_id(),
         0,
     )
     .unwrap();


### PR DESCRIPTION
## Description

Closes #?

## Changes

Add an optional `network_chain_id` config to override the default chain id (derived from `network`).

## Testing Information

Add a unit test, and the override is being used in private testnet.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
