### PR TITLE
fix: accommodate consensus valid payloads

### DIFF
--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -38,15 +38,6 @@ use super::SBTC_REGISTRY_CONTRACT_NAME;
 /// See https://github.com/stacks-network/sbtc/issues/501.
 static SBTC_REGISTRY_IDENTIFIER: OnceLock<QualifiedContractIdentifier> = OnceLock::new();
 
-/// Maximum request body size for the event observer endpoint.
-///
-/// Stacks blocks have a limit of 2 MB, which is enforced at the p2p level, but
-/// event observer events can be larger than that since they contain the
-/// subscribed sbtc events. Luckily, the size of the sbtc events themselves are
-/// bounded by the size of the transactions that create them, so a limit of 8 MB
-/// will be fine since it is twice as high as required.
-pub const EVENT_OBSERVER_BODY_LIMIT: usize = 8 * 1024 * 1024;
-
 /// A handler of `POST /new_block` webhook events.
 ///
 /// # Notes
@@ -310,6 +301,7 @@ mod tests {
     use test_case::test_case;
     use tower::ServiceExt as _;
 
+    use crate::EVENT_OBSERVER_BODY_LIMIT;
     use crate::api::get_router;
     use crate::storage::memory::Store;
     use crate::storage::model::DepositRequest;

--- a/signer/src/api/new_block.rs
+++ b/signer/src/api/new_block.rs
@@ -301,7 +301,6 @@ mod tests {
     use test_case::test_case;
     use tower::ServiceExt as _;
 
-    use crate::EVENT_OBSERVER_BODY_LIMIT;
     use crate::api::get_router;
     use crate::storage::memory::Store;
     use crate::storage::model::DepositRequest;
@@ -309,6 +308,9 @@ mod tests {
     use crate::testing::context::*;
     use crate::testing::get_rng;
     use crate::testing::storage::model::TestData;
+
+    /// The maximum request body size for the new block endpoint.
+    const TEST_NEW_BLOCK_LIMIT: usize = u16::MAX as usize;
 
     /// These were generated from a stacks node after running the
     /// "complete-deposit standard recipient", "accept-withdrawal",
@@ -669,8 +671,8 @@ mod tests {
         assert_eq!(stored_events, &vec![event]);
     }
 
-    #[test_case(EVENT_OBSERVER_BODY_LIMIT, true; "event within limit")]
-    #[test_case(EVENT_OBSERVER_BODY_LIMIT + 1, false; "event over limit")]
+    #[test_case(TEST_NEW_BLOCK_LIMIT, true; "event within limit")]
+    #[test_case(TEST_NEW_BLOCK_LIMIT + 1, false; "event over limit")]
     #[tokio::test]
     async fn test_big_event(event_size: usize, success: bool) {
         let ctx = TestContext::builder()
@@ -679,11 +681,14 @@ mod tests {
             .build();
 
         let state = ApiState { ctx: ctx.clone() };
-        let app = get_router().with_state(state);
+        let app = get_router(TEST_NEW_BLOCK_LIMIT).with_state(state);
 
         let db = ctx.inner_storage();
         // We don't have anything here yet
         assert!(db.lock().await.rotate_keys_transactions.is_empty());
+
+        // Sanity check that the limit is larger than the event.
+        more_asserts::assert_gt!(TEST_NEW_BLOCK_LIMIT, ROTATE_KEYS_WEBHOOK.len());
 
         let mut event: String = " ".repeat(event_size - ROTATE_KEYS_WEBHOOK.len());
         event.push_str(ROTATE_KEYS_WEBHOOK);

--- a/signer/src/api/router.rs
+++ b/signer/src/api/router.rs
@@ -24,8 +24,7 @@ pub fn get_router<C: Context + 'static>(new_block_limit: usize) -> Router<ApiSta
         .route("/info", get(info::info_handler))
         .route(
             "/new_block",
-            post(new_block::new_block_handler)
-                .layer(DefaultBodyLimit::max(new_block_limit)),
+            post(new_block::new_block_handler).layer(DefaultBodyLimit::max(new_block_limit)),
         )
         // TODO: remove this once https://github.com/stacks-network/stacks-core/issues/5558
         // is addressed
@@ -43,7 +42,7 @@ mod tests {
 
     use crate::{
         api::{ApiState, router::get_router},
-        testing::context::TestContext,  
+        testing::context::TestContext,
     };
 
     #[tokio::test]

--- a/signer/src/api/router.rs
+++ b/signer/src/api/router.rs
@@ -25,7 +25,7 @@ pub fn get_router<C: Context + 'static>() -> Router<ApiState<C>> {
         .route(
             "/new_block",
             post(new_block::new_block_handler)
-                .layer(DefaultBodyLimit::max(new_block::EVENT_OBSERVER_BODY_LIMIT)),
+                .layer(DefaultBodyLimit::max(crate::EVENT_OBSERVER_BODY_LIMIT)),
         )
         // TODO: remove this once https://github.com/stacks-network/stacks-core/issues/5558
         // is addressed

--- a/signer/src/api/router.rs
+++ b/signer/src/api/router.rs
@@ -18,14 +18,14 @@ async fn new_attachment_handler() -> StatusCode {
 }
 
 /// Return the default router
-pub fn get_router<C: Context + 'static>() -> Router<ApiState<C>> {
+pub fn get_router<C: Context + 'static>(new_block_limit: usize) -> Router<ApiState<C>> {
     Router::new()
         .route("/", get(status::status_handler))
         .route("/info", get(info::info_handler))
         .route(
             "/new_block",
             post(new_block::new_block_handler)
-                .layer(DefaultBodyLimit::max(crate::EVENT_OBSERVER_BODY_LIMIT)),
+                .layer(DefaultBodyLimit::max(new_block_limit)),
         )
         // TODO: remove this once https://github.com/stacks-network/stacks-core/issues/5558
         // is addressed
@@ -43,7 +43,7 @@ mod tests {
 
     use crate::{
         api::{ApiState, router::get_router},
-        testing::context::TestContext,
+        testing::context::TestContext,  
     };
 
     #[tokio::test]
@@ -51,7 +51,7 @@ mod tests {
         let context = TestContext::default_mocked();
 
         let state = ApiState { ctx: context.clone() };
-        let app: Router = get_router().with_state(state);
+        let app: Router = get_router(crate::NEW_BLOCK_BODY_LIMIT).with_state(state);
 
         let request = Request::builder()
             .uri("/attachments/new")

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -205,6 +205,26 @@ pub const MIN_BITCOIN_INPUT_VSIZE: u64 = 58;
 /// <https://github.com/libp2p/rust-libp2p/blob/84153a559bdbcb92a48413dd2a31035800cb882d/misc/quick-protobuf-codec/src/lib.rs#L74-L89>
 pub const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 65536;
 
+/// The maximum request body size for the event observer endpoint.
+///
+/// Stacks event observer events include the subscribed events and the
+/// transaction results for all transactions confirmed in the block. Stacks
+/// consensus bounds the size of a valid block by the size of the events
+/// and results produced by the confirmed transactions to 50 MB, and bounds
+/// the size of the confirmed transactions to 2 MB. Since events, results,
+/// and transactions are serialized in event webhooks as hex-encoded
+/// strings, we need to allow at least 104 MB of webhook payload space. To
+/// arrive at 256, we pad 104 to 128 and multiply by 2 to be safe.
+///
+/// In stacks-core, the variable that bounds event and result size is
+/// `MAX_RECEIPT_SIZES`, which is defined in [1] (without comment) and used
+/// in block production and processing in [2-3].
+///
+/// [1]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/stacks/db/blocks.rs#L160>
+/// [2]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/nakamoto/miner.rs#L924>
+/// [3]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/stacks/db/blocks.rs#L4512>
+pub const EVENT_OBSERVER_BODY_LIMIT: usize = 256 * 1024 * 1024;
+
 // These are all build info variables. Many of them are set in build.rs.
 
 /// The name of the binary that is being run,

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -224,7 +224,7 @@ pub const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 65536;
 /// [1]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/stacks/db/blocks.rs#L160>
 /// [2]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/nakamoto/miner.rs#L924>
 /// [3]: <https://github.com/stacks-network/stacks-core/blob/3.4.0.0.3/stackslib/src/chainstate/stacks/db/blocks.rs#L4512>
-pub const EVENT_OBSERVER_BODY_LIMIT: usize = 256 * 1024 * 1024;
+pub const NEW_BLOCK_BODY_LIMIT: usize = 256 * 1024 * 1024;
 
 // These are all build info variables. Many of them are set in build.rs.
 

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -210,11 +210,12 @@ pub const GOSSIPSUB_MAX_TRANSMIT_SIZE: usize = 65536;
 /// Stacks event observer events include the subscribed events and the
 /// transaction results for all transactions confirmed in the block. Stacks
 /// consensus bounds the size of a valid block by the size of the events
-/// and results produced by the confirmed transactions to 50 MB, and bounds
-/// the size of the confirmed transactions to 2 MB. Since events, results,
-/// and transactions are serialized in event webhooks as hex-encoded
-/// strings, we need to allow at least 104 MB of webhook payload space. To
-/// arrive at 256, we pad 104 to 128 and multiply by 2 to be safe.
+/// and results produced by the confirmed transactions to 50 MiB, and
+/// bounds the size of the confirmed transactions to 2 MiB. Since events,
+/// results, and transactions are serialized in event webhooks as
+/// hex-encoded strings, we need to allow at least 104 MiB of webhook
+/// payload space. To arrive at 256, we pad 104 to 128 and multiply by 2 to
+/// be safe.
 ///
 /// In stacks-core, the variable that bounds event and result size is
 /// `MAX_RECEIPT_SIZES`, which is defined in [1] (without comment) and used

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -357,7 +357,7 @@ async fn run_api(ctx: impl Context + 'static) -> Result<(), Error> {
     let request_id = Arc::new(AtomicU64::new(0));
 
     // Build the signer API application
-    let app = api::get_router()
+    let app = api::get_router(signer::NEW_BLOCK_BODY_LIMIT)
         .layer(
             TraceLayer::new_for_http()
                 .make_span_with(|request: &Request<_>| {


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2084

## Changes

* Raise the body limit for new block events to 256 MB. Also, move the constant to `lib.rs`

## Testing Information

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
