### PR TITLE
fix: gate peers early in libp2p behavior

### DIFF
--- a/signer/src/context/mod.rs
+++ b/signer/src/context/mod.rs
@@ -6,6 +6,7 @@ mod signer_state;
 mod termination;
 
 use std::collections::BTreeSet;
+use std::sync::Arc;
 
 use tokio::sync::broadcast::error::RecvError;
 use tokio_stream::wrappers::ReceiverStream;
@@ -31,7 +32,7 @@ pub trait Context: Clone + Sync + Send {
     /// Get the current configuration for the signer.
     fn config(&self) -> &Settings;
     /// Get the current state for the signer.
-    fn state(&self) -> &SignerState;
+    fn state(&self) -> &Arc<SignerState>;
     /// Subscribe to the application signalling channel, returning a receiver
     /// which can be used to listen for events.
     fn get_signal_receiver(&self) -> tokio::sync::broadcast::Receiver<SignerSignal>;

--- a/signer/src/context/signer_context.rs
+++ b/signer/src/context/signer_context.rs
@@ -122,7 +122,7 @@ where
         &self.config
     }
 
-    fn state(&self) -> &SignerState {
+    fn state(&self) -> &Arc<SignerState> {
         &self.state
     }
 

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -334,6 +334,7 @@ async fn run_libp2p_swarm(ctx: impl Context) -> Result<(), Error> {
         .enable_quic_transport(enable_quic)
         .with_initial_bootstrap_delay(Duration::from_secs(INITIAL_BOOTSTRAP_DELAY_SECS))
         .with_num_signers(num_signers)
+        .with_signer_state(ctx.state().clone())
         .build()?;
 
     // Start the libp2p swarm. This will run until either the shutdown signal is

--- a/signer/src/main.rs
+++ b/signer/src/main.rs
@@ -38,12 +38,6 @@ use tower_http::trace::TraceLayer;
 use tracing::Instrument as _;
 use tracing::Span;
 
-/// This is how many seconds the P2P swarm will wait before attempting to
-/// bootstrap (i.e. connect to other peers). Three seconds is a sane default
-/// value, giving the swarm a few seconds to start up and bind listener(s)
-/// before proceeding.
-const INITIAL_BOOTSTRAP_DELAY_SECS: u64 = 3;
-
 // Timeout after which signer info logger will print new log.
 // Currently chosen to be 1 hour.
 // TODO: make this interval a config parameter.
@@ -261,18 +255,6 @@ async fn run_libp2p_swarm(ctx: impl Context) -> Result<(), Error> {
     tracing::debug!("building the libp2p swarm");
     let config = ctx.config();
 
-    let enable_quic = config.signer.p2p.is_quic_used();
-
-    // Limit the number of signers to the maximum number of signer pubkeys we
-    // can support. Note that this value is used as a base value for swarm
-    // connection limit calculations.
-    let num_signers = ctx
-        .state()
-        .current_signer_set()
-        .num_signers()
-        .try_into()
-        .unwrap_or(signer::MAX_KEYS);
-
     // Look for known peers in the database which will be included as part of
     // the bootstrapping process. We will only include peers that have been
     // dialed within the KNOWN_PEER_WINDOW, and we will limit the number of
@@ -325,16 +307,8 @@ async fn run_libp2p_swarm(ctx: impl Context) -> Result<(), Error> {
     };
 
     // Build the swarm.
-    let mut swarm = SignerSwarmBuilder::new(&config.signer.private_key)
-        .add_listen_endpoints(&ctx.config().signer.p2p.listen_on)
-        .add_seed_addrs(&ctx.config().signer.p2p.seeds)
+    let mut swarm = SignerSwarmBuilder::from(&ctx)
         .add_known_peers(&known_peers)
-        .add_external_addresses(&ctx.config().signer.p2p.public_endpoints)
-        .enable_mdns(config.signer.p2p.enable_mdns)
-        .enable_quic_transport(enable_quic)
-        .with_initial_bootstrap_delay(Duration::from_secs(INITIAL_BOOTSTRAP_DELAY_SECS))
-        .with_num_signers(num_signers)
-        .with_signer_state(ctx.state().clone())
         .build()?;
 
     // Start the libp2p swarm. This will run until either the shutdown signal is

--- a/signer/src/network/libp2p/bootstrap.rs
+++ b/signer/src/network/libp2p/bootstrap.rs
@@ -280,36 +280,25 @@ impl NetworkBehaviour for Behavior {
 
     fn handle_established_inbound_connection(
         &mut self,
-        connection_id: ConnectionId,
-        peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _peer_id: PeerId,
         _local_addr: &Multiaddr,
-        remote_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        self.peer_connected(peer_id, connection_id, remote_addr);
-
+        // Accounting is deferred to `FromSwarm::ConnectionEstablished` so it
+        // only runs for connections that actually establish.
         Ok(dummy::ConnectionHandler)
     }
 
     fn handle_established_outbound_connection(
         &mut self,
-        connection_id: ConnectionId,
-        peer_id: PeerId,
-        address: &Multiaddr,
+        _connection_id: ConnectionId,
+        _peer_id: PeerId,
+        _address: &Multiaddr,
         _role_override: Endpoint,
         _port_use: PortUse,
     ) -> Result<THandler<Self>, ConnectionDenied> {
-        self.peer_connected(peer_id, connection_id, address);
-
-        if self.pending_connections.remove(&connection_id) {
-            tracing::debug!(%connection_id, %peer_id, %address, "successfully dialed bootstrap peer");
-            self.pending_events
-                .push_back(ToSwarm::GenerateEvent(BootstrapEvent::Connected {
-                    connection_id,
-                    peer_id,
-                    address: address.clone(),
-                }));
-        }
-
+        // Same reasoning here as in `handle_established_inbound_connection`.
         Ok(dummy::ConnectionHandler)
     }
 
@@ -341,6 +330,28 @@ impl NetworkBehaviour for Behavior {
 
     fn on_swarm_event(&mut self, event: libp2p::swarm::FromSwarm) {
         match event {
+            FromSwarm::ConnectionEstablished(e) => {
+                // This fires only after every behavior's
+                // `handle_established_*` returned `Ok` and the connection
+                // was added to the pool.
+                let address = e.endpoint.get_remote_address();
+                self.peer_connected(e.peer_id, e.connection_id, address);
+
+                if self.pending_connections.remove(&e.connection_id) {
+                    tracing::debug!(
+                        connection_id = %e.connection_id,
+                        peer_id = %e.peer_id,
+                        %address,
+                        "successfully dialed bootstrap peer"
+                    );
+                    let event = BootstrapEvent::Connected {
+                        connection_id: e.connection_id,
+                        peer_id: e.peer_id,
+                        address: address.clone(),
+                    };
+                    self.pending_events.push_back(ToSwarm::GenerateEvent(event));
+                }
+            }
             FromSwarm::ConnectionClosed(e) => {
                 let (peer_id, connection_id, address) =
                     (e.peer_id, e.connection_id, e.endpoint.get_remote_address());

--- a/signer/src/network/libp2p/bootstrap.rs
+++ b/signer/src/network/libp2p/bootstrap.rs
@@ -337,6 +337,9 @@ impl NetworkBehaviour for Behavior {
                 let address = e.endpoint.get_remote_address();
                 self.peer_connected(e.peer_id, e.connection_id, address);
 
+                // We only add entries into the pending connections set if
+                // we initiated the dial, so we can remove it here and log
+                // accordingly.
                 if self.pending_connections.remove(&e.connection_id) {
                     tracing::debug!(
                         connection_id = %e.connection_id,

--- a/signer/src/network/libp2p/event_loop.rs
+++ b/signer/src/network/libp2p/event_loop.rs
@@ -108,6 +108,9 @@ pub async fn run(ctx: &impl Context, swarm: Arc<Mutex<Swarm<SignerBehavior>>>) {
                         peer_id,
                         ..
                     } => {
+                        // TODO: This should be unnecessary since we have
+                        // the gatekeeper behavior, so it should be okay to
+                        // remove.
                         if !ctx.state().current_signer_set().is_allowed_peer(&peer_id) {
                             tracing::warn!(%connection_id, %peer_id, ?endpoint, "connected to peer, however it is not a known signer; disconnecting");
                             let _ = swarm.disconnect_peer_id(peer_id);

--- a/signer/src/network/libp2p/gatekeeper.rs
+++ b/signer/src/network/libp2p/gatekeeper.rs
@@ -106,9 +106,9 @@ impl NetworkBehaviour for Behavior {
 mod tests {
     use libp2p::core::transport::PortUse;
 
-    use crate::testing::get_rng;
     use crate::keys::PrivateKey;
     use crate::keys::PublicKey;
+    use crate::testing::get_rng;
 
     use super::*;
 
@@ -118,7 +118,7 @@ mod tests {
         (public_key, public_key.into())
     }
 
-    /// Create a behavior with allowing the given public key
+    /// Create a behavior with the given public key
     fn behaviour_allowing(public_key: PublicKey) -> Behavior {
         let state = Arc::new(SignerState::default());
         state.current_signer_set().add_signer(public_key);

--- a/signer/src/network/libp2p/gatekeeper.rs
+++ b/signer/src/network/libp2p/gatekeeper.rs
@@ -38,7 +38,7 @@ pub struct PeerNotInSignerSet(pub PeerId);
 /// Behavior for allowing only signers to connect to the signer.
 pub struct Behavior {
     /// The signer state to check against.
-    pub state: Arc<SignerState>,
+    state: Arc<SignerState>,
 }
 
 impl Behavior {

--- a/signer/src/network/libp2p/gatekeeper.rs
+++ b/signer/src/network/libp2p/gatekeeper.rs
@@ -1,0 +1,207 @@
+//! LibP2P behaviour that gates connections to peers in the current signer
+//! set. Placed first in [`super::swarm::SignerBehavior`] so its denial
+//! fires during the connection-upgrade phase, before any other behaviour
+//! records per-connection state.
+//!
+//! Rejecting non-signers here means the connection never enters the swarm
+//! pool, never consumes a slot against `connection_limits`, and never
+//! causes any other behaviour's state machinery to run for it.
+//!
+//! The behaviour holds an [`Arc<SignerState>`] — the same handle the rest
+//! of the signer shares — and reads the live signer set on each
+//! connection. The set is `RwLock`-guarded internally, so updates made
+//! anywhere else are observed here without any extra wiring.
+
+use std::sync::Arc;
+
+use libp2p::Multiaddr;
+use libp2p::PeerId;
+use libp2p::core::Endpoint;
+use libp2p::core::transport::PortUse;
+use libp2p::swarm::ConnectionDenied;
+use libp2p::swarm::ConnectionId;
+use libp2p::swarm::FromSwarm;
+use libp2p::swarm::NetworkBehaviour;
+use libp2p::swarm::THandler;
+use libp2p::swarm::THandlerInEvent;
+use libp2p::swarm::ToSwarm;
+use libp2p::swarm::dummy;
+
+use crate::context::SignerState;
+
+/// Reason returned to libp2p when a peer is rejected. Surfaces in the
+/// `ConnectionDenied` cause chain.
+#[derive(Debug, thiserror::Error)]
+#[error("peer {0} is not in the current signer set")]
+pub struct PeerNotInSignerSet(pub PeerId);
+
+/// Behavior for allowing only signers to connect to the signer.
+pub struct Behavior {
+    /// The signer state to check against.
+    pub state: Arc<SignerState>,
+}
+
+impl Behavior {
+    /// Creates a new [`Behavior`] that admits only peers in the current signer
+    /// set of the given shared state.
+    pub fn new(state: Arc<SignerState>) -> Self {
+        Self { state }
+    }
+
+    fn check(&self, peer_id: PeerId) -> Result<(), ConnectionDenied> {
+        if self.state.current_signer_set().is_allowed_peer(&peer_id) {
+            Ok(())
+        } else {
+            Err(ConnectionDenied::new(PeerNotInSignerSet(peer_id)))
+        }
+    }
+}
+
+impl NetworkBehaviour for Behavior {
+    type ConnectionHandler = dummy::ConnectionHandler;
+    type ToSwarm = std::convert::Infallible;
+
+    fn handle_established_inbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer_id: PeerId,
+        _local_addr: &Multiaddr,
+        _remote_addr: &Multiaddr,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.check(peer_id)?;
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn handle_established_outbound_connection(
+        &mut self,
+        _connection_id: ConnectionId,
+        peer_id: PeerId,
+        _address: &Multiaddr,
+        _role_override: Endpoint,
+        _port_use: PortUse,
+    ) -> Result<THandler<Self>, ConnectionDenied> {
+        self.check(peer_id)?;
+        Ok(dummy::ConnectionHandler)
+    }
+
+    fn on_swarm_event(&mut self, _event: FromSwarm) {}
+
+    fn on_connection_handler_event(
+        &mut self,
+        _peer_id: PeerId,
+        _connection_id: ConnectionId,
+        _event: libp2p::swarm::THandlerOutEvent<Self>,
+    ) {
+    }
+
+    fn poll(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<ToSwarm<Self::ToSwarm, THandlerInEvent<Self>>> {
+        std::task::Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::core::transport::PortUse;
+    use rand::rngs::OsRng;
+
+    use crate::keys::PrivateKey;
+    use crate::keys::PublicKey;
+
+    use super::*;
+
+    fn peer_id() -> (PublicKey, PeerId) {
+        let public_key = PublicKey::from_private_key(&PrivateKey::new(&mut OsRng));
+        (public_key, public_key.into())
+    }
+
+    fn behaviour_allowing(public_key: PublicKey) -> Behavior {
+        let state = Arc::new(SignerState::default());
+        state.current_signer_set().add_signer(public_key);
+        Behavior::new(state)
+    }
+
+    #[test]
+    fn admits_inbound_signer_and_rejects_others() {
+        let (allowed_key, allowed_peer) = peer_id();
+        let (_, other_peer) = peer_id();
+        let mut behaviour = behaviour_allowing(allowed_key);
+
+        let conn = ConnectionId::new_unchecked(0);
+        let addr = Multiaddr::empty();
+
+        assert!(
+            behaviour
+                .handle_established_inbound_connection(conn, allowed_peer, &addr, &addr)
+                .is_ok()
+        );
+
+        let denied = behaviour
+            .handle_established_inbound_connection(conn, other_peer, &addr, &addr)
+            .err()
+            .expect("a non-signer must be rejected");
+        assert!(denied.downcast::<PeerNotInSignerSet>().is_ok());
+    }
+
+    #[test]
+    fn admits_outbound_signer_and_rejects_others() {
+        let (allowed_key, allowed_peer) = peer_id();
+        let (_, other_peer) = peer_id();
+        let mut behaviour = behaviour_allowing(allowed_key);
+
+        let conn = ConnectionId::new_unchecked(0);
+        let addr = Multiaddr::empty();
+
+        assert!(
+            behaviour
+                .handle_established_outbound_connection(
+                    conn,
+                    allowed_peer,
+                    &addr,
+                    Endpoint::Dialer,
+                    PortUse::New,
+                )
+                .is_ok()
+        );
+
+        assert!(
+            behaviour
+                .handle_established_outbound_connection(
+                    conn,
+                    other_peer,
+                    &addr,
+                    Endpoint::Dialer,
+                    PortUse::New,
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn tracks_live_signer_set_updates() {
+        let (allowed_key, allowed_peer) = peer_id();
+        let state = Arc::new(SignerState::default());
+        let mut behaviour = Behavior::new(Arc::clone(&state));
+
+        let conn = ConnectionId::new_unchecked(0);
+        let addr = Multiaddr::empty();
+
+        // Initially the set is empty, so the peer is rejected.
+        assert!(
+            behaviour
+                .handle_established_inbound_connection(conn, allowed_peer, &addr, &addr)
+                .is_err()
+        );
+
+        // Adding the signer to the shared state is observed without rebuilding
+        // the behaviour.
+        state.current_signer_set().add_signer(allowed_key);
+        assert!(
+            behaviour
+                .handle_established_inbound_connection(conn, allowed_peer, &addr, &addr)
+                .is_ok()
+        );
+    }
+}

--- a/signer/src/network/libp2p/gatekeeper.rs
+++ b/signer/src/network/libp2p/gatekeeper.rs
@@ -105,28 +105,34 @@ impl NetworkBehaviour for Behavior {
 #[cfg(test)]
 mod tests {
     use libp2p::core::transport::PortUse;
-    use rand::rngs::OsRng;
 
+    use crate::testing::get_rng;
     use crate::keys::PrivateKey;
     use crate::keys::PublicKey;
 
     use super::*;
 
-    fn peer_id() -> (PublicKey, PeerId) {
-        let public_key = PublicKey::from_private_key(&PrivateKey::new(&mut OsRng));
+    /// Generate a random public key / peer id pair using the given RNG.
+    fn peer_id<R: rand::RngCore + ?Sized>(rng: &mut R) -> (PublicKey, PeerId) {
+        let public_key = PublicKey::from_private_key(&PrivateKey::new(rng));
         (public_key, public_key.into())
     }
 
+    /// Create a behavior with allowing the given public key
     fn behaviour_allowing(public_key: PublicKey) -> Behavior {
         let state = Arc::new(SignerState::default());
         state.current_signer_set().add_signer(public_key);
         Behavior::new(state)
     }
 
+    /// Test that the behavior allows an inbound connection from a peer in
+    /// the signer set and rejects with the expected error peers who are
+    /// not part of the signer set.
     #[test]
     fn admits_inbound_signer_and_rejects_others() {
-        let (allowed_key, allowed_peer) = peer_id();
-        let (_, other_peer) = peer_id();
+        let mut rng = get_rng();
+        let (allowed_key, allowed_peer) = peer_id(&mut rng);
+        let (_, other_peer) = peer_id(&mut rng);
         let mut behaviour = behaviour_allowing(allowed_key);
 
         let conn = ConnectionId::new_unchecked(0);
@@ -145,10 +151,13 @@ mod tests {
         assert!(denied.downcast::<PeerNotInSignerSet>().is_ok());
     }
 
+    /// Test that the behavior allows an outbound connection from a peer in
+    /// the signer set and rejects peers who are not.
     #[test]
     fn admits_outbound_signer_and_rejects_others() {
-        let (allowed_key, allowed_peer) = peer_id();
-        let (_, other_peer) = peer_id();
+        let mut rng = get_rng();
+        let (allowed_key, allowed_peer) = peer_id(&mut rng);
+        let (_, other_peer) = peer_id(&mut rng);
         let mut behaviour = behaviour_allowing(allowed_key);
 
         let conn = ConnectionId::new_unchecked(0);
@@ -179,9 +188,12 @@ mod tests {
         );
     }
 
+    /// Test that updates to the signer set in the state are reflected in
+    /// the behavior.
     #[test]
     fn tracks_live_signer_set_updates() {
-        let (allowed_key, allowed_peer) = peer_id();
+        let mut rng = get_rng();
+        let (allowed_key, allowed_peer) = peer_id(&mut rng);
         let state = Arc::new(SignerState::default());
         let mut behaviour = Behavior::new(Arc::clone(&state));
 

--- a/signer/src/network/libp2p/mod.rs
+++ b/signer/src/network/libp2p/mod.rs
@@ -7,6 +7,7 @@ use libp2p::gossipsub::IdentTopic;
 mod bootstrap;
 mod errors;
 mod event_loop;
+mod gatekeeper;
 mod multiaddr;
 mod network;
 mod swarm;

--- a/signer/src/network/libp2p/network.rs
+++ b/signer/src/network/libp2p/network.rs
@@ -175,6 +175,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm1_addr.clone())
             .add_seed_addr(swarm2_addr.clone())
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
 
@@ -182,6 +183,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm2_addr)
             .add_seed_addr(swarm1_addr)
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
 
@@ -275,6 +277,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm1_addr.clone())
             .add_seed_addr(swarm2_addr.clone())
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
 
@@ -283,6 +286,7 @@ mod tests {
             .add_listen_endpoint(swarm2_addr.clone())
             .add_seed_addr(swarm1_addr.clone())
             .add_seed_addr(swarm3_addr.clone())
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
 
@@ -290,6 +294,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm3_addr.clone())
             .add_seed_addr(swarm2_addr.clone())
+            .with_signer_state(context3.state().clone())
             .build()
             .expect("Failed to build swarm 3");
 
@@ -430,6 +435,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm1_addr.clone())
             .add_seed_addr(swarm2_addr.clone())
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
 
@@ -438,6 +444,7 @@ mod tests {
             .add_listen_endpoint(swarm2_addr.clone())
             .add_seed_addr(swarm1_addr.clone())
             .add_seed_addr(swarm3_addr.clone())
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
 
@@ -445,6 +452,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm3_addr.clone())
             .add_seed_addr(swarm2_addr.clone())
+            .with_signer_state(context3.state().clone())
             .build()
             .expect("Failed to build swarm 3");
 
@@ -623,12 +631,14 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm1_addr.clone())
             .add_seed_addrs(&[swarm2_addr.clone(), swarm3_addr.clone()])
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
         let mut swarm2 = SignerSwarmBuilder::new(&key2)
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm2_addr.clone())
             .add_seed_addrs(&[swarm1_addr.clone(), swarm3_addr.clone()])
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
         // Create the adversarial swarm.
@@ -636,6 +646,7 @@ mod tests {
             .enable_memory_transport(true)
             .add_listen_endpoint(swarm3_addr.clone())
             .add_seed_addrs(&[swarm1_addr, swarm2_addr])
+            .with_signer_state(context3.state().clone())
             .build()
             .expect("Failed to build swarm 3");
 

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -77,6 +77,8 @@ pub struct SignerSwarmConfig {
     pub known_peers: Vec<(PeerId, Multiaddr)>,
     pub num_signers: u16,
     pub max_transmit_size: usize,
+    /// This should be the same signer state from the context, so that
+    /// updates that happen to the signer set are observed here.
     pub signer_state: Arc<SignerState>,
 }
 

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -19,9 +19,12 @@ use rand::rngs::StdRng;
 use tokio::sync::Mutex;
 
 use super::errors::SignerSwarmError;
+
+use super::gatekeeper;
 use super::{bootstrap, event_loop};
 use crate::GOSSIPSUB_MAX_TRANSMIT_SIZE;
 use crate::context::Context;
+use crate::context::SignerState;
 use crate::keys::PrivateKey;
 
 /// The maximum number of substreams _per connection_. This is used to limit
@@ -44,9 +47,17 @@ const MAX_SUBSTREAMS_PER_CONNECTION: usize = 20;
 const NEGOTIATION_TIMEOUT_SECS: u64 = 10;
 
 /// Define the behaviors of the [`SignerSwarm`] libp2p network.
+///
+/// The derive macro composes each behavior's `handle_established_*` call
+/// in declaration order and bailing on a returned `Err`, so gatekeepers
+/// should appear before any behavior that records per-connection state.
 #[derive(NetworkBehaviour)]
 pub struct SignerBehavior {
-    pub bootstrap: bootstrap::Behavior,
+    /// The gatekeeper behavior that rejects non-signer peers during the
+    /// connection upgrade phase.
+    pub gatekeeper: gatekeeper::Behavior,
+    /// The connection limits behavior that enforces numeric slot limits.
+    pub connection_limits: connection_limits::Behaviour,
     pub gossipsub: gossipsub::Behaviour,
     mdns: Toggle<mdns::tokio::Behaviour>,
     pub kademlia: Toggle<kad::Behaviour<MemoryStore>>,
@@ -54,7 +65,7 @@ pub struct SignerBehavior {
     pub identify: identify::Behaviour,
     pub autonat_client: Toggle<autonat::v2::client::Behaviour<StdRng>>,
     pub autonat_server: Toggle<autonat::v2::server::Behaviour<StdRng>>,
-    pub connection_limits: connection_limits::Behaviour,
+    pub bootstrap: bootstrap::Behavior,
 }
 
 pub struct SignerSwarmConfig {
@@ -66,6 +77,7 @@ pub struct SignerSwarmConfig {
     pub known_peers: Vec<(PeerId, Multiaddr)>,
     pub num_signers: u16,
     pub max_transmit_size: usize,
+    pub signer_state: Arc<SignerState>,
 }
 
 impl SignerBehavior {
@@ -111,6 +123,7 @@ impl SignerBehavior {
         let bootstrap = bootstrap::Behavior::new(bootstrap_config);
 
         Ok(Self {
+            gatekeeper: gatekeeper::Behavior::new(config.signer_state),
             gossipsub: Self::gossipsub(&keypair, config.max_transmit_size)?,
             mdns,
             kademlia,
@@ -220,10 +233,14 @@ pub struct SignerSwarmBuilder<'a> {
     initial_bootstrap_delay: Duration,
     num_signers: u16,
     max_transmit_size: usize,
+    signer_state: Arc<SignerState>,
 }
 
 impl<'a> SignerSwarmBuilder<'a> {
     /// Create a new [`SignerSwarmBuilder`] with the given private key.
+    ///
+    /// By default the swarm is wired to a fresh, empty [`SignerState`], whose
+    /// signer set is empty and so rejects every peer.
     pub fn new(private_key: &'a PrivateKey) -> Self {
         Self {
             private_key,
@@ -239,7 +256,15 @@ impl<'a> SignerSwarmBuilder<'a> {
             initial_bootstrap_delay: Duration::ZERO,
             num_signers: crate::MAX_KEYS,
             max_transmit_size: GOSSIPSUB_MAX_TRANSMIT_SIZE,
+            signer_state: Arc::new(SignerState::default()),
         }
+    }
+
+    /// Wires the swarm to the shared [`SignerState`]. Any peer not in the
+    /// set is rejected during the connection-upgrade phase.
+    pub fn with_signer_state(mut self, signer_state: Arc<SignerState>) -> Self {
+        self.signer_state = signer_state;
+        self
     }
 
     /// Sets whether or not this swarm should use mdns.
@@ -370,6 +395,7 @@ impl<'a> SignerSwarmBuilder<'a> {
             known_peers: self.known_peers,
             num_signers: self.num_signers,
             max_transmit_size: self.max_transmit_size,
+            signer_state: self.signer_state,
         };
         let behavior = SignerBehavior::new(keypair.clone(), behavior_config)?;
 
@@ -764,6 +790,7 @@ mod tests {
             .enable_memory_transport(true)
             .with_initial_bootstrap_delay(Duration::MAX) // We manually dial below
             .add_listen_endpoint(swarm1_addr.clone())
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
 
@@ -774,6 +801,7 @@ mod tests {
             .enable_memory_transport(true)
             .with_initial_bootstrap_delay(Duration::MAX) // We manually dial below
             .add_listen_endpoint(swarm2_addr.clone())
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
 
@@ -874,6 +902,7 @@ mod tests {
             .with_initial_bootstrap_delay(Duration::ZERO) // Connect immediately
             .add_known_peers(&[(key2_pub.into(), swarm2_addr.clone())])
             .add_listen_endpoint(swarm1_addr.clone())
+            .with_signer_state(context1.state().clone())
             .build()
             .expect("Failed to build swarm 1");
         let swarm2 = SignerSwarmBuilder::new(&key2)
@@ -883,6 +912,7 @@ mod tests {
             .enable_memory_transport(true)
             .with_initial_bootstrap_delay(Duration::MAX) // Let swarm1 bootstrap
             .add_listen_endpoint(swarm2_addr.clone())
+            .with_signer_state(context2.state().clone())
             .build()
             .expect("Failed to build swarm 2");
 
@@ -941,6 +971,15 @@ mod tests {
             // all discovery protocols disabled so the test is self-contained.
             let key1 = PrivateKey::new(rng);
             let key2 = PrivateKey::new(rng);
+            let pub_key = PublicKey::from_private_key(&key1);
+            let sub_key = PublicKey::from_private_key(&key2);
+
+            // Each side's shared state allows only the other peer. The swarm's
+            // allow-list gate reads the signer set from this handle.
+            let pub_state = Arc::new(SignerState::default());
+            pub_state.current_signer_set().add_signer(sub_key);
+            let sub_state = Arc::new(SignerState::default());
+            sub_state.current_signer_set().add_signer(pub_key);
 
             // Use random memory addresses to avoid conflicts when other
             // tests are running in parallel.
@@ -957,6 +996,7 @@ mod tests {
                 .with_initial_bootstrap_delay(Duration::MAX)
                 .with_max_transmit_size(publisher_max_transmit_size)
                 .add_listen_endpoint(pub_addr.clone())
+                .with_signer_state(pub_state)
                 .build()
                 .unwrap();
 
@@ -969,6 +1009,7 @@ mod tests {
                 .with_initial_bootstrap_delay(Duration::MAX)
                 .with_max_transmit_size(subscriber_max_transmit_size)
                 .add_listen_endpoint(sub_addr.clone())
+                .with_signer_state(sub_state)
                 .build()
                 .unwrap();
 

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -27,6 +27,12 @@ use crate::context::Context;
 use crate::context::SignerState;
 use crate::keys::PrivateKey;
 
+/// This is how many seconds the P2P swarm will wait before attempting to
+/// bootstrap (i.e. connect to other peers). Three seconds is a sane default
+/// value, giving the swarm a few seconds to start up and bind listener(s)
+/// before proceeding.
+const INITIAL_BOOTSTRAP_DELAY_SECS: u64 = 3;
+
 /// The maximum number of substreams _per connection_. This is used to limit
 /// the number of concurrent substreams that can be opened on a single
 /// connection. The general assumption at the time of writing is:
@@ -221,8 +227,8 @@ impl SignerBehavior {
 }
 
 /// Builder for the [`SignerSwarm`] libp2p network.
-pub struct SignerSwarmBuilder<'a> {
-    private_key: &'a PrivateKey,
+pub struct SignerSwarmBuilder {
+    private_key: PrivateKey,
     listen_on: Vec<Multiaddr>,
     seed_addrs: Vec<Multiaddr>,
     known_peers: Vec<(PeerId, Multiaddr)>,
@@ -238,14 +244,51 @@ pub struct SignerSwarmBuilder<'a> {
     signer_state: Arc<SignerState>,
 }
 
-impl<'a> SignerSwarmBuilder<'a> {
+impl<C: Context> From<&C> for SignerSwarmBuilder {
+    fn from(ctx: &C) -> Self {
+        let config = ctx.config();
+        let state = ctx.state();
+        // Limit the number of signers to the maximum number of signer
+        // pubkeys we can support. Note that this value is used as a base
+        // value for swarm connection limit calculations.
+        let num_signers = state
+            .current_signer_set()
+            .num_signers()
+            .try_into()
+            .unwrap_or(crate::MAX_KEYS);
+
+        let me = Self {
+            private_key: config.signer.private_key,
+            listen_on: Vec::new(),
+            seed_addrs: Vec::new(),
+            known_peers: Vec::new(),
+            external_addresses: Vec::new(),
+            enable_mdns: config.signer.p2p.enable_mdns,
+            enable_kademlia: true,
+            enable_autonat: true,
+            enable_quic_transport: config.signer.p2p.is_quic_used(),
+            enable_memory_transport: false,
+            initial_bootstrap_delay: Duration::from_secs(INITIAL_BOOTSTRAP_DELAY_SECS),
+            num_signers,
+            max_transmit_size: GOSSIPSUB_MAX_TRANSMIT_SIZE,
+            signer_state: state.clone(),
+        };
+
+        me.add_listen_endpoints(&config.signer.p2p.listen_on)
+            .add_seed_addrs(&config.signer.p2p.seeds)
+            .add_external_addresses(&config.signer.p2p.public_endpoints)
+    }
+}
+
+impl SignerSwarmBuilder {
     /// Create a new [`SignerSwarmBuilder`] with the given private key.
     ///
     /// By default the swarm is wired to a fresh, empty [`SignerState`], whose
     /// signer set is empty and so rejects every peer.
-    pub fn new(private_key: &'a PrivateKey) -> Self {
+    #[cfg(any(test, feature = "testing"))]
+    pub fn new(private_key: &PrivateKey) -> Self {
         Self {
-            private_key,
+            private_key: private_key.clone(),
             listen_on: Vec::new(),
             seed_addrs: Vec::new(),
             known_peers: Vec::new(),
@@ -387,7 +430,7 @@ impl<'a> SignerSwarmBuilder<'a> {
 
     /// Build the [`SignerSwarm`], consuming the builder.
     pub fn build(self) -> Result<SignerSwarm, SignerSwarmError> {
-        let keypair: Keypair = (*self.private_key).into();
+        let keypair: Keypair = self.private_key.into();
         let behavior_config = SignerSwarmConfig {
             enable_mdns: self.enable_mdns,
             enable_kademlia: self.enable_kademlia,

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -46,6 +46,7 @@ const NEGOTIATION_TIMEOUT_SECS: u64 = 10;
 /// Define the behaviors of the [`SignerSwarm`] libp2p network.
 #[derive(NetworkBehaviour)]
 pub struct SignerBehavior {
+    pub bootstrap: bootstrap::Behavior,
     pub gossipsub: gossipsub::Behaviour,
     mdns: Toggle<mdns::tokio::Behaviour>,
     pub kademlia: Toggle<kad::Behaviour<MemoryStore>>,
@@ -53,7 +54,6 @@ pub struct SignerBehavior {
     pub identify: identify::Behaviour,
     pub autonat_client: Toggle<autonat::v2::client::Behaviour<StdRng>>,
     pub autonat_server: Toggle<autonat::v2::server::Behaviour<StdRng>>,
-    pub bootstrap: bootstrap::Behavior,
     pub connection_limits: connection_limits::Behaviour,
 }
 

--- a/signer/src/network/libp2p/swarm.rs
+++ b/signer/src/network/libp2p/swarm.rs
@@ -288,7 +288,7 @@ impl SignerSwarmBuilder {
     #[cfg(any(test, feature = "testing"))]
     pub fn new(private_key: &PrivateKey) -> Self {
         Self {
-            private_key: private_key.clone(),
+            private_key: *private_key,
             listen_on: Vec::new(),
             seed_addrs: Vec::new(),
             known_peers: Vec::new(),

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -264,7 +264,7 @@ where
         self.inner.config()
     }
 
-    fn state(&self) -> &SignerState {
+    fn state(&self) -> &Arc<SignerState> {
         self.inner.state()
     }
 

--- a/signer/tests/integration/communication.rs
+++ b/signer/tests/integration/communication.rs
@@ -4,10 +4,13 @@ use std::collections::BTreeSet;
 use std::time::Duration;
 
 use libp2p::Multiaddr;
+use std::sync::Arc;
+
 use signer::context::Context as _;
 use signer::context::P2PEvent;
 use signer::context::SignerEvent;
 use signer::context::SignerSignal;
+use signer::context::SignerState;
 use signer::keys::PrivateKey;
 use signer::keys::PublicKey;
 use signer::network::P2PNetwork;
@@ -73,6 +76,7 @@ async fn libp2p_clients_can_exchange_messages_given_real_network(addr1: &str, ad
         .enable_autonat(false)
         .enable_quic_transport(true)
         .add_listen_endpoint(swarm1_addr.clone())
+        .with_signer_state(context1.state().clone())
         .build()
         .expect("Failed to build swarm 1");
 
@@ -82,6 +86,7 @@ async fn libp2p_clients_can_exchange_messages_given_real_network(addr1: &str, ad
         .enable_autonat(false)
         .enable_quic_transport(true)
         .add_listen_endpoint(swarm2_addr)
+        .with_signer_state(context2.state().clone())
         .build()
         .expect("Failed to build swarm 2");
 
@@ -144,6 +149,12 @@ async fn libp2p_limits_max_established_connections() -> Result<(), Box<dyn std::
         .map(PublicKey::from_private_key)
         .collect::<BTreeSet<_>>();
 
+    // Shared signer state used to wire every swarm's allow-list gate. All
+    // ten keys are signers, so the gate admits every peer and this test
+    // can exercise `connection_limits`.
+    let signer_state = Arc::new(SignerState::default());
+    signer_state.update_current_signer_set(public_keys.clone());
+
     let mut handles = Vec::new();
     let mut contexts = Vec::new();
     let mut swarms = Vec::new();
@@ -156,6 +167,7 @@ async fn libp2p_limits_max_established_connections() -> Result<(), Box<dyn std::
         .with_initial_bootstrap_delay(Duration::MAX)
         .add_listen_endpoint("/ip4/127.0.0.1/tcp/0".parse().unwrap())
         .with_num_signers(2) // Sets max_established = 3*2 = 6
+        .with_signer_state(signer_state.clone())
         .build()?;
 
     let context1 = TestContext::builder()
@@ -209,6 +221,7 @@ async fn libp2p_limits_max_established_connections() -> Result<(), Box<dyn std::
             .enable_kademlia(false)
             .enable_autonat(false)
             .with_initial_bootstrap_delay(Duration::MAX)
+            .with_signer_state(signer_state.clone())
             .build()?;
 
         let peer_context = TestContext::builder()
@@ -274,6 +287,7 @@ async fn libp2p_limits_max_established_connections() -> Result<(), Box<dyn std::
             .enable_kademlia(false)
             .enable_autonat(false)
             .with_initial_bootstrap_delay(Duration::MAX)
+            .with_signer_state(signer_state.clone())
             .build()?;
 
         // Just dial without starting the swarm


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2087, probably closes https://github.com/stacks-sbtc/sbtc/issues/2086, closes https://github.com/stacks-sbtc/sbtc/issues/2083, and closes https://github.com/stacks-sbtc/sbtc/issues/1668.

## Changes

* Handle accounting of the pending connections and connected peers after the connection has been established.
* Add a new gatekeeper behavior that rejects connection upgrades if the peer is not part of the signer set.

I also considered making it so that you need a context to create a `SignerBehavior` in production code, which would make it impossible to forget to add the signer set when constructing it. However, I decided against it since it isn't strictly necessary. I actually want it though, so I'll probably add that in later.

## Testing Information

I tested this in devenv and everything worked.

I also tested this against an adversary using the code at https://github.com/djordon-stacks/sbtc/tree/immunefi/connection-to-oom-libp2p. In my tests, this patch kept memory usage under 24 MB, whereas on main it grew uncontrollably very quickly. I tried the same "attacker" setup without the new gatekeeper behavior, and memory usage still grows, just less quickly, suggesting that either we or libp2p keeps some things around for each connection.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
