### PR TITLE
fix: use stacks core provided chain tip

### DIFF
--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -42,6 +42,7 @@ use crate::storage::DbWrite;
 use crate::storage::Transactable as _;
 use crate::storage::TransactionHandle as _;
 use crate::storage::model;
+use crate::storage::model::BitcoinBlockHash;
 use crate::storage::model::BitcoinBlockRef;
 use crate::storage::model::EncryptedDkgShares;
 use crate::storage::model::StacksBlockRef;
@@ -180,23 +181,27 @@ where
                         tracing::error!(%error, "could not process bitcoin blocks");
                     }
 
-                    if let Err(error) = self.process_stacks_blocks().await {
-                        tracing::error!(%error, "could not process stacks blocks");
-                    }
+                    let Ok(chain_tip) = self.get_bitcoin_chain_tip(block_hash).await else {
+                        tracing::error!("could not get bitcoin chain tip");
+                        continue;
+                    };
 
-                    if let Err(error) = self.check_pending_dkg_shares(block_hash).await {
+                    if let Err(error) = self.check_pending_dkg_shares(&chain_tip).await {
                         tracing::error!(%error, "could not check pending dkg shares");
                         continue;
                     }
 
+                    // This updates the signer state with the stacks chain tip.
+                    if let Err(error) = self.process_stacks_blocks().await {
+                        tracing::error!(%error, "could not process stacks blocks");
+                        continue;
+                    }
+
                     tracing::debug!("updating the signer state");
-                    let chain_tip = match self.update_signer_state(block_hash).await {
-                        Ok(chain_tip) => chain_tip,
-                        Err(error) => {
-                            tracing::error!(%error, "could not update the signer state");
-                            continue;
-                        }
-                    };
+                    if let Err(error) = self.update_signer_state(chain_tip).await {
+                        tracing::error!(%error, "could not update the signer state");
+                        continue;
+                    }
 
                     tracing::info!("loading latest deposit requests from Emily");
                     if let Err(error) = self.load_latest_deposit_requests().await {
@@ -452,6 +457,18 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(())
     }
 
+    /// Get a bitcoin block ref from a block hash.
+    async fn get_bitcoin_chain_tip(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
+        self.context
+            .get_storage()
+            .get_bitcoin_block(&chain_tip.into())
+            .await
+            .inspect_err(|error| tracing::error!(%error, "could not get bitcoin chain tip"))?
+            .map(model::BitcoinBlockRef::from)
+            .ok_or_else(|| Error::UnknownBitcoinBlock(chain_tip))
+            .inspect_err(|error| tracing::error!(%error, "could not get bitcoin chain tip"))
+    }
+
     /// Process all recent stacks blocks.
     ///
     /// # Note
@@ -483,7 +500,7 @@ impl<C: Context, B> BlockObserver<C, B> {
     }
 
     /// Update the sBTC peg limits from Emily
-    async fn update_sbtc_limits(&self, chain_tip: BlockHash) -> Result<(), Error> {
+    async fn update_sbtc_limits(&self, chain_tip: BitcoinBlockHash) -> Result<(), Error> {
         let limits = self.context.get_emily_client().get_limits().await?;
         let sbtc_deployed = self.context.state().sbtc_contracts_deployed();
 
@@ -507,7 +524,7 @@ impl<C: Context, B> BlockObserver<C, B> {
         let withdrawn_total = self
             .context
             .get_storage()
-            .compute_withdrawn_total(&chain_tip.into(), rolling_limits.blocks)
+            .compute_withdrawn_total(&chain_tip, rolling_limits.blocks)
             .await?;
 
         let limits = SbtcLimits::new(
@@ -552,19 +569,6 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(())
     }
 
-    /// Set the `SignerState` object with current bitcoin chain tip.
-    async fn set_bitcoin_chain_tip(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
-        let db = self.context.get_storage();
-        let chain_tip = db
-            .get_bitcoin_block(&chain_tip.into())
-            .await?
-            .map(model::BitcoinBlockRef::from)
-            .ok_or_else(|| Error::UnknownBitcoinBlock(chain_tip))?;
-
-        self.context.state().set_bitcoin_chain_tip(chain_tip);
-        Ok(chain_tip)
-    }
-
     /// Update the `SignerState` object with data that is unlikely to
     /// change until the arrival of the next bitcoin block.
     ///
@@ -575,19 +579,20 @@ impl<C: Context, B> BlockObserver<C, B> {
     /// * The current signer set.
     /// * The current aggregate key.
     /// * The current bitcoin chain tip.
-    async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
+    async fn update_signer_state(&self, chain_tip: BitcoinBlockRef) -> Result<(), Error> {
         tracing::info!("loading sbtc limits from Emily");
-        self.update_sbtc_limits(chain_tip).await?;
+        self.update_sbtc_limits(chain_tip.block_hash).await?;
 
         tracing::info!("updating the signer state with the current signer set");
         self.set_signer_set_info().await?;
 
         tracing::info!("updating the signer state with the current bitcoin chain tip");
-        self.set_bitcoin_chain_tip(chain_tip).await
+        self.context.state().set_bitcoin_chain_tip(chain_tip);
+        Ok(())
     }
 
     /// Checks if the latest dkg share is pending and is no longer valid
-    async fn check_pending_dkg_shares(&self, chain_tip: BlockHash) -> Result<(), Error> {
+    async fn check_pending_dkg_shares(&self, chain_tip: &BitcoinBlockRef) -> Result<(), Error> {
         let db = self.context.get_storage_mut();
 
         let last_dkg = db.get_latest_encrypted_dkg_shares().await?;
@@ -610,10 +615,6 @@ impl<C: Context, B> BlockObserver<C, B> {
             return Ok(());
         };
 
-        let chain_tip = db
-            .get_bitcoin_block(&chain_tip.into())
-            .await?
-            .ok_or(Error::NoChainTip)?;
         let verification_window = self.context.config().signer.dkg_verification_window;
 
         let max_verification_height = last_dkg

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -44,6 +44,7 @@ use crate::storage::TransactionHandle as _;
 use crate::storage::model;
 use crate::storage::model::BitcoinBlockRef;
 use crate::storage::model::EncryptedDkgShares;
+use crate::storage::model::StacksBlockRef;
 use crate::util::FutureExt as _;
 use bitcoin::Amount;
 use bitcoin::BlockHash;
@@ -179,9 +180,13 @@ where
                         tracing::error!(%error, "could not process bitcoin blocks");
                     }
 
-                    if let Err(error) = self.process_stacks_blocks().await {
-                        tracing::error!(%error, "could not process stacks blocks");
-                    }
+                    let stacks_chain_tip = match self.process_stacks_blocks().await {
+                        Ok(chain_tip) => chain_tip,
+                        Err(error) => {
+                            tracing::error!(%error, "could not process stacks blocks");
+                            continue;
+                        }
+                    };
 
                     if let Err(error) = self.check_pending_dkg_shares(block_hash).await {
                         tracing::error!(%error, "could not check pending dkg shares");
@@ -189,7 +194,8 @@ where
                     }
 
                     tracing::debug!("updating the signer state");
-                    let chain_tip = match self.update_signer_state(block_hash).await {
+                    let chain_tip_fut = self.update_signer_state(block_hash, stacks_chain_tip);
+                    let chain_tip = match chain_tip_fut.await {
                         Ok(chain_tip) => chain_tip,
                         Err(error) => {
                             tracing::error!(%error, "could not update the signer state");
@@ -453,7 +459,7 @@ impl<C: Context, B> BlockObserver<C, B> {
 
     /// Process all recent stacks blocks.
     #[tracing::instrument(skip_all)]
-    async fn process_stacks_blocks(&self) -> Result<(), Error> {
+    async fn process_stacks_blocks(&self) -> Result<StacksBlockRef, Error> {
         tracing::info!("processing stacks block");
         let stacks_client = self.context.get_stacks_client();
         let db = self.context.get_storage_mut();
@@ -466,7 +472,10 @@ impl<C: Context, B> BlockObserver<C, B> {
             .await?;
 
         tracing::debug!("finished processing stacks block");
-        Ok(())
+        Ok(StacksBlockRef {
+            block_hash: tenure_info.tip_block_id,
+            block_height: tenure_info.tip_height,
+        })
     }
 
     /// Update the sBTC peg limits from Emily
@@ -552,19 +561,6 @@ impl<C: Context, B> BlockObserver<C, B> {
         Ok(chain_tip)
     }
 
-    /// Set the `SignerState` object with current stacks chain tip.
-    async fn set_stacks_chain_tip(&self, chain_tip: BlockHash) -> Result<(), Error> {
-        let db = self.context.get_storage();
-        let chain_tip = db
-            .get_stacks_chain_tip(&chain_tip.into())
-            .await?
-            .map(model::StacksBlockRef::from)
-            .ok_or_else(|| Error::NoStacksChainTip)?;
-
-        self.context.state().set_stacks_chain_tip(chain_tip);
-        Ok(())
-    }
-
     /// Update the `SignerState` object with data that is unlikely to
     /// change until the arrival of the next bitcoin block.
     ///
@@ -576,7 +572,11 @@ impl<C: Context, B> BlockObserver<C, B> {
     /// * The current aggregate key.
     /// * The current stacks chain tip.
     /// * The current bitcoin chain tip.
-    async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
+    async fn update_signer_state(
+        &self,
+        chain_tip: BlockHash,
+        stacks_chain_tip: StacksBlockRef,
+    ) -> Result<BitcoinBlockRef, Error> {
         tracing::info!("loading sbtc limits from Emily");
         self.update_sbtc_limits(chain_tip).await?;
 
@@ -584,7 +584,7 @@ impl<C: Context, B> BlockObserver<C, B> {
         self.set_signer_set_info().await?;
 
         tracing::info!("updating the signer state with the current stacks chain tip");
-        self.set_stacks_chain_tip(chain_tip).await?;
+        self.context.state().set_stacks_chain_tip(stacks_chain_tip);
 
         tracing::info!("updating the signer state with the current bitcoin chain tip");
         self.set_bitcoin_chain_tip(chain_tip).await

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -477,7 +477,7 @@ impl<C: Context, B> BlockObserver<C, B> {
             block_hash: tenure_info.tip_block_id,
             block_height: tenure_info.tip_height,
         };
-        tracing::debug!("updating the signer state with the current stacks chain tip");
+        tracing::info!("updating the signer state with the current stacks chain tip");
         self.context.state().set_stacks_chain_tip(stacks_chain_tip);
         Ok(())
     }

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -180,13 +180,9 @@ where
                         tracing::error!(%error, "could not process bitcoin blocks");
                     }
 
-                    let stacks_chain_tip = match self.process_stacks_blocks().await {
-                        Ok(chain_tip) => chain_tip,
-                        Err(error) => {
-                            tracing::error!(%error, "could not process stacks blocks");
-                            continue;
-                        }
-                    };
+                    if let Err(error) = self.process_stacks_blocks().await {
+                        tracing::error!(%error, "could not process stacks blocks");
+                    }
 
                     if let Err(error) = self.check_pending_dkg_shares(block_hash).await {
                         tracing::error!(%error, "could not check pending dkg shares");
@@ -194,8 +190,7 @@ where
                     }
 
                     tracing::debug!("updating the signer state");
-                    let chain_tip_fut = self.update_signer_state(block_hash, stacks_chain_tip);
-                    let chain_tip = match chain_tip_fut.await {
+                    let chain_tip = match self.update_signer_state(block_hash).await {
                         Ok(chain_tip) => chain_tip,
                         Err(error) => {
                             tracing::error!(%error, "could not update the signer state");
@@ -458,8 +453,13 @@ impl<C: Context, B> BlockObserver<C, B> {
     }
 
     /// Process all recent stacks blocks.
+    ///
+    /// # Note
+    ///
+    /// This function updates the current stacks chain tip in the signer
+    /// state.
     #[tracing::instrument(skip_all)]
-    async fn process_stacks_blocks(&self) -> Result<StacksBlockRef, Error> {
+    async fn process_stacks_blocks(&self) -> Result<(), Error> {
         tracing::info!("processing stacks block");
         let stacks_client = self.context.get_stacks_client();
         let db = self.context.get_storage_mut();
@@ -472,10 +472,14 @@ impl<C: Context, B> BlockObserver<C, B> {
             .await?;
 
         tracing::debug!("finished processing stacks block");
-        Ok(StacksBlockRef {
+
+        let stacks_chain_tip = StacksBlockRef {
             block_hash: tenure_info.tip_block_id,
             block_height: tenure_info.tip_height,
-        })
+        };
+        tracing::debug!("updating the signer state with the current stacks chain tip");
+        self.context.state().set_stacks_chain_tip(stacks_chain_tip);
+        Ok(())
     }
 
     /// Update the sBTC peg limits from Emily
@@ -570,21 +574,13 @@ impl<C: Context, B> BlockObserver<C, B> {
     /// * sBTC limits from Emily.
     /// * The current signer set.
     /// * The current aggregate key.
-    /// * The current stacks chain tip.
     /// * The current bitcoin chain tip.
-    async fn update_signer_state(
-        &self,
-        chain_tip: BlockHash,
-        stacks_chain_tip: StacksBlockRef,
-    ) -> Result<BitcoinBlockRef, Error> {
+    async fn update_signer_state(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
         tracing::info!("loading sbtc limits from Emily");
         self.update_sbtc_limits(chain_tip).await?;
 
         tracing::info!("updating the signer state with the current signer set");
         self.set_signer_set_info().await?;
-
-        tracing::info!("updating the signer state with the current stacks chain tip");
-        self.context.state().set_stacks_chain_tip(stacks_chain_tip);
 
         tracing::info!("updating the signer state with the current bitcoin chain tip");
         self.set_bitcoin_chain_tip(chain_tip).await

--- a/signer/src/block_observer.rs
+++ b/signer/src/block_observer.rs
@@ -181,8 +181,8 @@ where
                         tracing::error!(%error, "could not process bitcoin blocks");
                     }
 
-                    let Ok(chain_tip) = self.get_bitcoin_chain_tip(block_hash).await else {
-                        tracing::error!("could not get bitcoin chain tip");
+                    let Ok(chain_tip) = self.resolve_block_ref(block_hash).await else {
+                        tracing::error!("could not get bitcoin block ref from the block hash");
                         continue;
                     };
 
@@ -458,7 +458,7 @@ impl<C: Context, B> BlockObserver<C, B> {
     }
 
     /// Get a bitcoin block ref from a block hash.
-    async fn get_bitcoin_chain_tip(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
+    async fn resolve_block_ref(&self, chain_tip: BlockHash) -> Result<BitcoinBlockRef, Error> {
         self.context
             .get_storage()
             .get_bitcoin_block(&chain_tip.into())

--- a/signer/src/context/signer_state.rs
+++ b/signer/src/context/signer_state.rs
@@ -30,9 +30,8 @@ pub struct SignerState {
     // The current bitcoin chain tip. This gets updated at the end of the
     // block observer's duties when it observes a new bitcoin block.
     bitcoin_chain_tip: RwLock<Option<BitcoinBlockRef>>,
-    // The current stacks chain tip that is anchored to the current bitcoin
-    // chain tip. This gets updated at the end of the block observer's
-    // duties when it observes a new bitcoin block.
+    // The current stacks chain tip according to stacks-core. This gets
+    // updated in the block observer when it fetches new stacks blocks.
     stacks_chain_tip: RwLock<Option<StacksBlockRef>>,
 }
 

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -82,6 +82,7 @@ pub trait DbRead {
 
     /// Get the stacks chain tip, defined as the highest stacks block
     /// confirmed by the bitcoin chain tip.
+    #[cfg(any(test, feature = "testing"))]
     fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/storage/postgres/read.rs
+++ b/signer/src/storage/postgres/read.rs
@@ -783,6 +783,7 @@ impl PgRead {
         .map_err(Error::SqlxQuery)
     }
 
+    #[cfg(any(test, feature = "testing"))]
     pub async fn get_stacks_chain_tip<'e, E>(
         executor: &'e mut E,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
@@ -2613,6 +2614,7 @@ impl DbRead for PgStore {
         PgRead::get_bitcoin_canonical_chain_tip_ref(self.get_connection().await?.as_mut()).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,
@@ -3059,6 +3061,7 @@ impl DbRead for PgTransaction<'_> {
         PgRead::get_bitcoin_canonical_chain_tip_ref(tx.as_mut()).await
     }
 
+    #[cfg(any(test, feature = "testing"))]
     async fn get_stacks_chain_tip(
         &self,
         bitcoin_chain_tip: &model::BitcoinBlockHash,

--- a/signer/src/testing/stacks.rs
+++ b/signer/src/testing/stacks.rs
@@ -1,10 +1,13 @@
 //! Test utilities from the stacks module
 //!
 
+use std::sync::LazyLock;
+
 use blockstack_lib::chainstate::nakamoto::NakamotoBlockHeader;
 use blockstack_lib::net::api::getsortition::SortitionInfo;
 use stacks_common::types::chainstate::BurnchainHeaderHash;
 use stacks_common::types::chainstate::SortitionId;
+use stacks_common::types::chainstate::StacksBlockId;
 
 use crate::error::Error;
 use crate::stacks::api::GetTenureInfoResponse;
@@ -32,21 +35,22 @@ pub const DUMMY_SORTITION_INFO: SortitionInfo = SortitionInfo {
     vrf_seed: None,
 };
 
-/// Some dummy tenure info
-pub const DUMMY_TENURE_INFO: GetTenureInfoResponse = GetTenureInfoResponse {
-    consensus_hash: ConsensusHash::new([0; 20]),
-    tenure_start_block_id: StacksBlockHash::new([0; 32]),
-    parent_consensus_hash: ConsensusHash::new([0; 20]),
-    // The following bytes are the ones returned by StacksBlockId::first_mined()
-    parent_tenure_start_block_id: StacksBlockHash::new([
-        0x55, 0xc9, 0x86, 0x1b, 0xe5, 0xcf, 0xf9, 0x84, 0xa2, 0x0c, 0xe6, 0xd9, 0x9d, 0x4a, 0xa6,
-        0x59, 0x41, 0x41, 0x28, 0x89, 0xbd, 0xc6, 0x65, 0x09, 0x41, 0x36, 0x42, 0x9b, 0x84, 0xf8,
-        0xc2, 0xee,
-    ]),
-    tip_block_id: StacksBlockHash::new([0; 32]),
-    tip_height: StacksBlockHeight::new(0u64),
-    reward_cycle: 0,
-};
+/// Dummy tenure info whose tip matches [`NakamotoBlockHeader::empty`], which is
+/// what [`TenureBlockHeaders::nearly_empty`] / [`TenureBlockHeaders::from_anchor`]
+/// write into the database.
+pub static DUMMY_TENURE_INFO: LazyLock<GetTenureInfoResponse> = LazyLock::new(|| {
+    let header = NakamotoBlockHeader::empty();
+    let tip_block_id = StacksBlockHash::from(header.block_id());
+    GetTenureInfoResponse {
+        consensus_hash: ConsensusHash::from(header.consensus_hash.clone()),
+        tenure_start_block_id: tip_block_id,
+        parent_consensus_hash: ConsensusHash::new([0; 20]),
+        parent_tenure_start_block_id: StacksBlockHash::from(StacksBlockId::first_mined()),
+        tip_block_id,
+        tip_height: StacksBlockHeight::from(header.chain_length),
+        reward_cycle: 0,
+    }
+});
 
 impl TenureBlockHeaders {
     /// Create a TenureBlockHeaders struct that is basically empty.


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2095

## Changes

* Use the Stacks chain tip provided by `GET /v3/tenures/info` and store it in the signer state.
* Make the `get_stacks_chain_tip` function optional.

## Testing Information

This has been tested on devenv, and everything seemed fine.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
