### PR TITLE
fix: friendlier bitcoin node url handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,7 +529,7 @@ dependencies = [
  "hyper-rustls",
  "hyper-util",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.35",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -1015,7 +1015,7 @@ dependencies = [
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.35",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -2231,7 +2231,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pki-types",
 ]
 
@@ -2767,7 +2767,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.35",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
@@ -3724,7 +3724,7 @@ dependencies = [
  "quinn",
  "rand 0.8.5",
  "ring",
- "rustls",
+ "rustls 0.23.35",
  "socket2 0.5.7",
  "thiserror 2.0.11",
  "tokio",
@@ -3809,8 +3809,8 @@ dependencies = [
  "libp2p-identity",
  "rcgen",
  "ring",
- "rustls",
- "rustls-webpki",
+ "rustls 0.23.35",
+ "rustls-webpki 0.103.10",
  "thiserror 2.0.11",
  "x509-parser",
  "yasna",
@@ -4095,8 +4095,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fdef521c74c2884a4f3570bcdb6d2a77b3c533feb6b27ac2ae72673cc221c64"
 dependencies = [
  "log",
+ "once_cell",
+ "rustls 0.21.12",
+ "rustls-webpki 0.101.7",
  "serde",
  "serde_json",
+ "webpki-roots 0.25.4",
 ]
 
 [[package]]
@@ -5236,7 +5240,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.35",
  "socket2 0.5.7",
  "thiserror 2.0.11",
  "tokio",
@@ -5257,7 +5261,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash 2.1.1",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.11",
@@ -5502,7 +5506,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -5674,6 +5678,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
@@ -5683,7 +5699,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -5731,10 +5747,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.35",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.10",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -5746,6 +5762,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -5840,6 +5866,16 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sec1"
@@ -6209,6 +6245,7 @@ dependencies = [
  "lru",
  "metrics",
  "metrics-exporter-prometheus",
+ "minreq",
  "mockall",
  "mockito",
  "more-asserts",
@@ -6390,7 +6427,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pemfile",
  "serde",
  "serde_json",
@@ -6986,7 +7023,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.35",
  "tokio",
 ]
 
@@ -7437,7 +7474,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.35",
  "rustls-pki-types",
  "ureq-proto",
  "utf-8",
@@ -7719,6 +7756,12 @@ checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,9 @@ bitcoin = { version = "0.32.5", default-features = false, features = ["serde", "
 bitcoinconsensus = { version = "0.106.0", default-features = false }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }
 bitcoincore-rpc-json = { version = "0.19.0", default-features = false }
-jsonrpc = { version = "0.18.0", default-features = false }
+jsonrpc = { version = "0.18.0", default-features = false, features = ["minreq_http"] }
+# Enables TLS for jsonrpc's minreq_http transport, which jsonrpc does not turn.
+minreq = { version = "2.11.2", default-features = false, features = ["https"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["serde"] }
 cfg-if = { version = "1.0.0", default-features = false }
 chrono = { version = "0.4.41", default-features = false, features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ bitcoinconsensus = { version = "0.106.0", default-features = false }
 bitcoincore-rpc = { version = "0.19.0", default-features = false }
 bitcoincore-rpc-json = { version = "0.19.0", default-features = false }
 jsonrpc = { version = "0.18.0", default-features = false, features = ["minreq_http"] }
-# Enables TLS for jsonrpc's minreq_http transport, which jsonrpc does not turn.
+# Enables TLS for jsonrpc's minreq_http transport, which jsonrpc does not enable.
 minreq = { version = "2.11.2", default-features = false, features = ["https"] }
 bitvec = { version = "1.0.1", default-features = false, features = ["serde"] }
 cfg-if = { version = "1.0.0", default-features = false }

--- a/signer/Cargo.toml
+++ b/signer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [package.metadata.cargo-machete]
-ignored = ["tonic", "tonic-build", "stackslib"]
+ignored = ["minreq", "tonic", "tonic-build", "stackslib"]
 
 [[bin]]
 name = "demo-cli"
@@ -41,6 +41,7 @@ libp2p-identity.workspace = true
 lru.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
+minreq.workspace = true
 p256k1.workspace = true
 polynomial.workspace = true
 prost.workspace = true

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -3,10 +3,10 @@
 //! Here's some info about the Bitcoin Core RPC client errors:
 //!
 //! - Example when the node is not running/unreachable:
-//!   JsonRpc(Transport(SocketError(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
+//!   JsonRpc(Transport(IoError(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })))
 //!
 //! - Example when authentication fails:
-//!   JsonRpc(Transport(HttpErrorCode(401)))
+//!   JsonRpc(Transport(HttpError { status_code: 401, body: "Unauthorized" }))
 //!
 //! - Example when trying to estimate fees but the node doesn't have enough data:
 //!   EstimateSmartFeeResponse(Some(["Insufficient data or no feerate found"]), 1)

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -36,10 +36,7 @@ use super::rpc::OutPointSummary;
 impl TryFrom<Vec<BitcoinCoreClientParams>> for ApiFallbackClient<BitcoinCoreClient> {
     type Error = Error;
     fn try_from(urls: Vec<BitcoinCoreClientParams>) -> Result<Self, Self::Error> {
-        let clients = urls
-            .iter()
-            .map(BitcoinCoreClient::try_from)
-            .collect::<Result<Vec<_>, _>>()?;
+        let clients = urls.iter().map(BitcoinCoreClient::from).collect::<Vec<_>>();
 
         Self::new(clients).map_err(Into::into)
     }

--- a/signer/src/bitcoin/client.rs
+++ b/signer/src/bitcoin/client.rs
@@ -36,7 +36,7 @@ use super::rpc::OutPointSummary;
 impl TryFrom<Vec<BitcoinCoreClientParams>> for ApiFallbackClient<BitcoinCoreClient> {
     type Error = Error;
     fn try_from(urls: Vec<BitcoinCoreClientParams>) -> Result<Self, Self::Error> {
-        let clients = urls.iter().map(BitcoinCoreClient::from).collect::<Vec<_>>();
+        let clients = urls.into_iter().map(BitcoinCoreClient::from).collect();
 
         Self::new(clients).map_err(Into::into)
     }

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -20,7 +20,6 @@ use bitcoincore_rpc_json::GetMempoolEntryResult;
 use bitcoincore_rpc_json::GetNetworkInfoResult;
 use bitcoincore_rpc_json::GetTxOutResult;
 use futures::future::try_join_all;
-use jsonrpc::simple_http;
 use serde::Deserialize;
 use url::Url;
 
@@ -343,29 +342,41 @@ pub struct BitcoinCoreClientParams {
     pub timeout: Duration,
 }
 
+/// Strip userinfo from a Bitcoin RPC URL and return optional basic-auth
+/// credentials.
+fn strip_credentials(url: &Url) -> Result<(Url, Option<(String, String)>), Error> {
+    if url.host_str().is_none() {
+        return Err(Error::InvalidUrl(url::ParseError::EmptyHost));
+    }
+
+    let credentials = if url.username().is_empty() {
+        None
+    } else {
+        let username = url.username().to_string();
+        let password = url.password().unwrap_or_default().to_string();
+        Some((username, password))
+    };
+
+    let mut endpoint = url.clone();
+    let _ = endpoint.set_username("");
+    let _ = endpoint.set_password(None);
+    Ok((endpoint, credentials))
+}
+
 /// Implement TryFrom for Url to allow for easy conversion from a URL to a
 /// BitcoinCoreClient.
 impl TryFrom<&BitcoinCoreClientParams> for BitcoinCoreClient {
     type Error = Error;
 
     fn try_from(params: &BitcoinCoreClientParams) -> Result<Self, Self::Error> {
-        let timeout = params.timeout;
-        let url = &params.url;
-        let username = url.username().to_string();
-        let password = url.password().unwrap_or_default().to_string();
-        let host = url
-            .host_str()
-            .ok_or(Error::InvalidUrl(url::ParseError::EmptyHost))?;
-        let port = url.port().ok_or(Error::PortRequired)?;
-
-        let endpoint = format!("{}://{host}:{port}", url.scheme());
-
-        Self::new(&endpoint, username, password, timeout)
+        let username = params.url.username().to_string();
+        let password = params.url.password().unwrap_or_default().to_string();
+        Self::new(params.url.as_str(), username, password, params.timeout)
     }
 }
 
 impl BitcoinCoreClient {
-    /// Return a bitcoin-core RPC client. Will error if the URL is an invalid URL.
+    /// Return a bitcoin-core RPC client. Will error if the URL is invalid.
     ///
     /// # Notes
     ///
@@ -376,13 +387,24 @@ impl BitcoinCoreClient {
         password: String,
         timeout: Duration,
     ) -> Result<Self, Error> {
-        let transport = simple_http::Builder::new()
-            .url(url)
-            .map_err(|error| Error::BitcoinCoreRpcClient(error, url.to_string()))?
-            .auth(username, Some(password))
-            .timeout(timeout)
-            .build();
+        let parsed = Url::parse(url).map_err(Error::InvalidUrl)?;
+        let (endpoint, url_credentials) = strip_credentials(&parsed)?;
+        let credentials = if username.is_empty() {
+            url_credentials
+        } else {
+            Some((username, password))
+        };
 
+        let mut builder = jsonrpc::minreq_http::MinreqHttpTransport::builder()
+            .timeout(timeout)
+            .url(endpoint.as_str())
+            .map_err(|error| Error::BitcoinCoreRpcClient(error, endpoint.to_string()))?;
+
+        if let Some((user, pass)) = credentials {
+            builder = builder.basic_auth(user, Some(pass));
+        }
+
+        let transport = builder.build();
         let client = Arc::new(bitcoincore_rpc::Client::from_jsonrpc(transport.into()));
         Ok(Self { inner: client })
     }
@@ -1002,5 +1024,81 @@ mod tests {
         // did for the vin field. Things should validate now.
         tx_info.tx.input.reverse();
         tx_info.validate().unwrap();
+    }
+
+    #[test]
+    fn sanitize_preserves_path_and_strips_basic_auth() {
+        let url: Url = "http://devnet:devnet123@127.0.0.1:18443/wallet/foo"
+            .parse()
+            .unwrap();
+        let (endpoint, credentials) = strip_credentials(&url).unwrap();
+
+        assert_eq!(endpoint.as_str(), "http://127.0.0.1:18443/wallet/foo");
+        assert_eq!(
+            credentials,
+            Some(("devnet".to_string(), "devnet123".to_string()))
+        );
+    }
+
+    #[test]
+    fn sanitize_accepts_https_path_token_without_port() {
+        let url: Url = "https://example.btc.node.pro/abc123/".parse().unwrap();
+        let (endpoint, credentials) = strip_credentials(&url).unwrap();
+
+        assert_eq!(endpoint.as_str(), "https://example.btc.node.pro/abc123/");
+        assert!(credentials.is_none());
+        assert!(endpoint.port().is_none());
+    }
+
+    #[test]
+    fn path_token_url_posts_to_path_without_basic_auth() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/abc123/")
+            .match_header("authorization", mockito::Matcher::Missing)
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":"0000000000000000000000000000000000000000000000000000000000000000"}"#,
+            )
+            .create();
+
+        let url: Url = format!("{}/abc123/", server.url()).parse().unwrap();
+        let client = BitcoinCoreClient::new(
+            url.as_str(),
+            String::new(),
+            String::new(),
+            Duration::from_secs(5),
+        )
+        .unwrap();
+
+        client.get_best_block_hash().unwrap();
+        mock.assert();
+    }
+
+    #[test]
+    fn userinfo_url_sends_basic_auth() {
+        let mut server = mockito::Server::new();
+        let mock = server
+            .mock("POST", "/")
+            .match_header("authorization", mockito::Matcher::Regex("Basic .*".into()))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":"0000000000000000000000000000000000000000000000000000000000000000"}"#,
+            )
+            .create();
+
+        let url: Url = format!("http://devnet:devnet@{}", server.socket_address())
+            .parse()
+            .unwrap();
+        let client = BitcoinCoreClient::try_from(&BitcoinCoreClientParams {
+            url,
+            timeout: Duration::from_secs(5),
+        })
+        .unwrap();
+
+        client.get_best_block_hash().unwrap();
+        mock.assert();
     }
 }

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -344,11 +344,7 @@ pub struct BitcoinCoreClientParams {
 
 /// Strip userinfo from a Bitcoin RPC URL and return optional basic-auth
 /// credentials.
-fn strip_credentials(mut url: Url) -> Result<(Url, Option<(String, String)>), Error> {
-    if url.host_str().is_none() {
-        return Err(Error::InvalidUrl(url::ParseError::EmptyHost));
-    }
-
+fn strip_credentials(mut url: Url) -> (Url, Option<(String, String)>) {
     let credentials = if url.username().is_empty() {
         None
     } else {
@@ -359,18 +355,15 @@ fn strip_credentials(mut url: Url) -> Result<(Url, Option<(String, String)>), Er
 
     let _ = url.set_username("");
     let _ = url.set_password(None);
-    Ok((url, credentials))
+    (url, credentials)
 }
 
-/// Implement TryFrom for Url to allow for easy conversion from a URL to a
-/// BitcoinCoreClient.
-impl TryFrom<&BitcoinCoreClientParams> for BitcoinCoreClient {
-    type Error = Error;
-
-    fn try_from(params: &BitcoinCoreClientParams) -> Result<Self, Self::Error> {
-        let username = params.url.username().to_string();
-        let password = params.url.password().unwrap_or_default().to_string();
-        Self::new(params.url.as_str(), username, password, params.timeout)
+/// Implement TryFrom for BitcoinCoreClientParams to allow for easy
+/// conversion from a URL to a BitcoinCoreClient.
+impl From<&BitcoinCoreClientParams> for BitcoinCoreClient {
+    fn from(params: &BitcoinCoreClientParams) -> Self {
+        let (url, basic_auth) = strip_credentials(params.url.clone());
+        Self::from_url(url, basic_auth, params.timeout)
     }
 }
 
@@ -387,25 +380,35 @@ impl BitcoinCoreClient {
         timeout: Duration,
     ) -> Result<Self, Error> {
         let parsed = Url::parse(url).map_err(Error::InvalidUrl)?;
-        let (endpoint, url_credentials) = strip_credentials(parsed)?;
-        let credentials = if username.is_empty() {
-            url_credentials
+        let basic_auth = if username.is_empty() {
+            None
         } else {
             Some((username, password))
         };
 
+        Ok(Self::from_url(parsed, basic_auth, timeout))
+    }
+
+    /// Return a bitcoin-core RPC client.
+    ///
+    /// # Notes
+    ///
+    /// This function does not attempt to establish a connection to bitcoin-core.
+    pub fn from_url(url: Url, basic_auth: Option<(String, String)>, timeout: Duration) -> Self {
+        // The expect below cannot panic. The minreq_http::Builder::url
+        // method always returns a Result::Ok.
         let mut builder = jsonrpc::minreq_http::MinreqHttpTransport::builder()
             .timeout(timeout)
-            .url(endpoint.as_str())
-            .map_err(|error| Error::BitcoinCoreRpcClient(error, endpoint.to_string()))?;
+            .url(url.as_str())
+            .expect("jsonrpc 0.18 MinreqHttpTransport::url is infallible");
 
-        if let Some((user, pass)) = credentials {
+        if let Some((user, pass)) = basic_auth {
             builder = builder.basic_auth(user, Some(pass));
         }
 
         let transport = builder.build();
         let client = Arc::new(bitcoincore_rpc::Client::from_jsonrpc(transport.into()));
-        Ok(Self { inner: client })
+        Self { inner: client }
     }
 
     /// Return a reference to the inner bitcoin-core RPC client.
@@ -1030,7 +1033,7 @@ mod tests {
         let url: Url = "http://devnet:devnet123@127.0.0.1:18443/wallet/foo"
             .parse()
             .unwrap();
-        let (endpoint, credentials) = strip_credentials(url).unwrap();
+        let (endpoint, credentials) = strip_credentials(url);
 
         assert_eq!(endpoint.as_str(), "http://127.0.0.1:18443/wallet/foo");
         assert_eq!(
@@ -1043,7 +1046,7 @@ mod tests {
     fn sanitize_accepts_https_path_token_without_port() {
         let url_str = "https://example.btc.node.pro/abc123/";
         let url: Url = url_str.parse().unwrap();
-        let (endpoint, credentials) = strip_credentials(url).unwrap();
+        let (endpoint, credentials) = strip_credentials(url);
 
         assert_eq!(endpoint.as_str(), url_str);
         assert!(credentials.is_none());
@@ -1092,11 +1095,10 @@ mod tests {
         let url: Url = format!("http://devnet:devnet@{}", server.socket_address())
             .parse()
             .unwrap();
-        let client = BitcoinCoreClient::try_from(&BitcoinCoreClientParams {
+        let client = BitcoinCoreClient::from(&BitcoinCoreClientParams {
             url,
             timeout: Duration::from_secs(5),
-        })
-        .unwrap();
+        });
 
         client.get_best_block_hash().unwrap();
         mock.assert();

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -358,11 +358,9 @@ fn strip_credentials(mut url: Url) -> (Url, Option<(String, String)>) {
     (url, credentials)
 }
 
-/// Implement TryFrom for BitcoinCoreClientParams to allow for easy
-/// conversion from a URL to a BitcoinCoreClient.
-impl From<&BitcoinCoreClientParams> for BitcoinCoreClient {
-    fn from(params: &BitcoinCoreClientParams) -> Self {
-        let (url, basic_auth) = strip_credentials(params.url.clone());
+impl From<BitcoinCoreClientParams> for BitcoinCoreClient {
+    fn from(params: BitcoinCoreClientParams) -> Self {
+        let (url, basic_auth) = strip_credentials(params.url);
         Self::from_url(url, basic_auth, params.timeout)
     }
 }
@@ -1095,7 +1093,7 @@ mod tests {
         let url: Url = format!("http://devnet:devnet@{}", server.socket_address())
             .parse()
             .unwrap();
-        let client = BitcoinCoreClient::from(&BitcoinCoreClientParams {
+        let client = BitcoinCoreClient::from(BitcoinCoreClientParams {
             url,
             timeout: Duration::from_secs(5),
         });

--- a/signer/src/bitcoin/rpc.rs
+++ b/signer/src/bitcoin/rpc.rs
@@ -344,7 +344,7 @@ pub struct BitcoinCoreClientParams {
 
 /// Strip userinfo from a Bitcoin RPC URL and return optional basic-auth
 /// credentials.
-fn strip_credentials(url: &Url) -> Result<(Url, Option<(String, String)>), Error> {
+fn strip_credentials(mut url: Url) -> Result<(Url, Option<(String, String)>), Error> {
     if url.host_str().is_none() {
         return Err(Error::InvalidUrl(url::ParseError::EmptyHost));
     }
@@ -357,10 +357,9 @@ fn strip_credentials(url: &Url) -> Result<(Url, Option<(String, String)>), Error
         Some((username, password))
     };
 
-    let mut endpoint = url.clone();
-    let _ = endpoint.set_username("");
-    let _ = endpoint.set_password(None);
-    Ok((endpoint, credentials))
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    Ok((url, credentials))
 }
 
 /// Implement TryFrom for Url to allow for easy conversion from a URL to a
@@ -388,7 +387,7 @@ impl BitcoinCoreClient {
         timeout: Duration,
     ) -> Result<Self, Error> {
         let parsed = Url::parse(url).map_err(Error::InvalidUrl)?;
-        let (endpoint, url_credentials) = strip_credentials(&parsed)?;
+        let (endpoint, url_credentials) = strip_credentials(parsed)?;
         let credentials = if username.is_empty() {
             url_credentials
         } else {
@@ -1031,7 +1030,7 @@ mod tests {
         let url: Url = "http://devnet:devnet123@127.0.0.1:18443/wallet/foo"
             .parse()
             .unwrap();
-        let (endpoint, credentials) = strip_credentials(&url).unwrap();
+        let (endpoint, credentials) = strip_credentials(url).unwrap();
 
         assert_eq!(endpoint.as_str(), "http://127.0.0.1:18443/wallet/foo");
         assert_eq!(
@@ -1042,10 +1041,11 @@ mod tests {
 
     #[test]
     fn sanitize_accepts_https_path_token_without_port() {
-        let url: Url = "https://example.btc.node.pro/abc123/".parse().unwrap();
-        let (endpoint, credentials) = strip_credentials(&url).unwrap();
+        let url_str = "https://example.btc.node.pro/abc123/";
+        let url: Url = url_str.parse().unwrap();
+        let (endpoint, credentials) = strip_credentials(url).unwrap();
 
-        assert_eq!(endpoint.as_str(), "https://example.btc.node.pro/abc123/");
+        assert_eq!(endpoint.as_str(), url_str);
         assert!(credentials.is_none());
         assert!(endpoint.port().is_none());
     }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -185,10 +185,6 @@ pub enum Error {
     #[error("failed to retrieve the raw transaction for txid {1} from bitcoin-core. {0}")]
     BitcoinCoreGetTransaction(#[source] bitcoincore_rpc::Error, bitcoin::Txid),
 
-    /// Error when creating an RPC client to bitcoin-core
-    #[error("could not create RPC client to {1}: {0}")]
-    BitcoinCoreRpcClient(#[source] jsonrpc::minreq_http::Error, String),
-
     /// The bitcoin transaction was not found in the mempool or on the
     /// bitcoin blockchain. This is thrown when we expect the transaction
     /// to exist in bitcoin core, but it does not.

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -187,7 +187,7 @@ pub enum Error {
 
     /// Error when creating an RPC client to bitcoin-core
     #[error("could not create RPC client to {1}: {0}")]
-    BitcoinCoreRpcClient(#[source] jsonrpc::http::simple_http::Error, String),
+    BitcoinCoreRpcClient(#[source] jsonrpc::minreq_http::Error, String),
 
     /// The bitcoin transaction was not found in the mempool or on the
     /// bitcoin blockchain. This is thrown when we expect the transaction
@@ -442,10 +442,6 @@ pub enum Error {
     /// This is thrown when failing to parse a hex string into an integer.
     #[error("could not parse the hex string into an integer")]
     ParseHexInt(#[source] std::num::ParseIntError),
-
-    /// Error when the port is not provided
-    #[error("a port must be specified")]
-    PortRequired,
 
     /// This is thrown when failing to parse a hex string into bytes.
     #[error("could not decode the hex string into bytes: {0}")]

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -804,7 +804,7 @@ where
         let url = config.settings.bitcoin.rpc_endpoints.first().unwrap();
         let timeout = config.settings.bitcoin.timeout;
         let bitcoin_client =
-            crate::bitcoin::rpc::BitcoinCoreClient::from(&BitcoinCoreClientParams {
+            crate::bitcoin::rpc::BitcoinCoreClient::from(BitcoinCoreClientParams {
                 url: url.clone(),
                 timeout,
             });

--- a/signer/src/testing/context.rs
+++ b/signer/src/testing/context.rs
@@ -804,11 +804,10 @@ where
         let url = config.settings.bitcoin.rpc_endpoints.first().unwrap();
         let timeout = config.settings.bitcoin.timeout;
         let bitcoin_client =
-            crate::bitcoin::rpc::BitcoinCoreClient::try_from(&BitcoinCoreClientParams {
+            crate::bitcoin::rpc::BitcoinCoreClient::from(&BitcoinCoreClientParams {
                 url: url.clone(),
                 timeout,
-            })
-            .unwrap();
+            });
         ContextBuilder {
             config: ContextConfig {
                 settings: config.settings,

--- a/signer/tests/integration/bitcoin_client.rs
+++ b/signer/tests/integration/bitcoin_client.rs
@@ -29,7 +29,7 @@ mod serial {
             timeout: Duration::from_secs(10),
         };
 
-        let client = BitcoinCoreClient::try_from(&bitcoin_client_params).unwrap();
+        let client = BitcoinCoreClient::from(&bitcoin_client_params);
         let result = client.inner_client().get_block(&BlockHash::all_zeros());
 
         // This will return: JsonRpc(Rpc(RpcError { code: -5, message: "Block not found", data: None }))
@@ -59,9 +59,9 @@ mod serial {
             timeout: Duration::from_secs(10),
         };
 
-        let client = ApiFallbackClient::<BitcoinCoreClient>::new(vec![
-            BitcoinCoreClient::try_from(&bitcoin_client_params).unwrap(),
-        ])
+        let client = ApiFallbackClient::<BitcoinCoreClient>::new(vec![BitcoinCoreClient::from(
+            &bitcoin_client_params,
+        )])
         .unwrap();
 
         // Double-check that an all-zero block doesn't return an error or something else unexpected.

--- a/signer/tests/integration/bitcoin_client.rs
+++ b/signer/tests/integration/bitcoin_client.rs
@@ -29,7 +29,7 @@ mod serial {
             timeout: Duration::from_secs(10),
         };
 
-        let client = BitcoinCoreClient::from(&bitcoin_client_params);
+        let client = BitcoinCoreClient::from(bitcoin_client_params);
         let result = client.inner_client().get_block(&BlockHash::all_zeros());
 
         // This will return: JsonRpc(Rpc(RpcError { code: -5, message: "Block not found", data: None }))
@@ -60,7 +60,7 @@ mod serial {
         };
 
         let client = ApiFallbackClient::<BitcoinCoreClient>::new(vec![BitcoinCoreClient::from(
-            &bitcoin_client_params,
+            bitcoin_client_params,
         )])
         .unwrap();
 

--- a/signer/tests/integration/bitcoin_rpc.rs
+++ b/signer/tests/integration/bitcoin_rpc.rs
@@ -62,9 +62,10 @@ mod serial {
         else {
             panic!("wrong error format")
         };
-        assert_eq!(
-            format!("{}", transport_error),
-            "Couldn't connect to host: connection timed out".to_string(),
+        let message = transport_error.to_string().to_lowercase();
+        assert!(
+            message.contains("timed out") || message.contains("timeout"),
+            "unexpected transport error: {transport_error}"
         )
     }
 

--- a/signer/tests/integration/containers.rs
+++ b/signer/tests/integration/containers.rs
@@ -27,7 +27,7 @@ impl BitcoinContainerExt for BitcoinContainer {
             url: self.url().clone(),
             timeout: Duration::from_secs(10),
         };
-        BitcoinCoreClient::from(&params)
+        BitcoinCoreClient::from(params)
     }
 
     async fn start_chain_tip_poller(&self) -> BitcoinChainTipPoller {

--- a/signer/tests/integration/containers.rs
+++ b/signer/tests/integration/containers.rs
@@ -23,11 +23,11 @@ pub trait BitcoinContainerExt {
 
 impl BitcoinContainerExt for BitcoinContainer {
     fn get_client(&self) -> BitcoinCoreClient {
-        let params = &BitcoinCoreClientParams {
+        let params = BitcoinCoreClientParams {
             url: self.url().clone(),
             timeout: Duration::from_secs(10),
         };
-        params.try_into().expect("cannot create bitcoin client")
+        BitcoinCoreClient::from(&params)
     }
 
     async fn start_chain_tip_poller(&self) -> BitcoinChainTipPoller {

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -511,7 +511,7 @@ mod serial {
             url: settings.bitcoin.rpc_endpoints[0].clone(),
             timeout: settings.bitcoin.timeout,
         };
-        let client = BitcoinCoreClient::from(&bitcoin_params);
+        let client = BitcoinCoreClient::from(bitcoin_params);
         let tx_info = client
             .get_tx_info(&unsigned.tx.compute_txid(), &sweep_block_hash)
             .unwrap()

--- a/signer/tests/integration/utxo_construction.rs
+++ b/signer/tests/integration/utxo_construction.rs
@@ -511,7 +511,7 @@ mod serial {
             url: settings.bitcoin.rpc_endpoints[0].clone(),
             timeout: settings.bitcoin.timeout,
         };
-        let client = BitcoinCoreClient::try_from(&bitcoin_params).unwrap();
+        let client = BitcoinCoreClient::from(&bitcoin_params);
         let tx_info = client
             .get_tx_info(&unsigned.tx.compute_txid(), &sweep_block_hash)
             .unwrap()

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -159,6 +159,21 @@ who = "djordon <dan.jordon@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.6.0 -> 0.7.0"
 
+[[audits.rustls]]
+who = "djordon-stacks <236454686+djordon-stacks@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.21.6 -> 0.21.8"
+
+[[audits.rustls-webpki]]
+who = "djordon-stacks <236454686+djordon-stacks@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.101.4 -> 0.101.7"
+
+[[audits.sct]]
+who = "djordon-stacks <236454686+djordon-stacks@users.noreply.github.com>"
+criteria = "safe-to-deploy"
+delta = "0.7.0 -> 0.7.1"
+
 [[audits.serdect]]
 who = "djordon <dan.jordon@gmail.com>"
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -499,10 +499,6 @@ criteria = "safe-to-deploy"
 version = "2.1.1"
 criteria = "safe-to-deploy"
 
-[[exemptions.either]]
-version = "1.12.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.elliptic-curve]]
 version = "0.13.8"
 criteria = "safe-to-deploy"
@@ -529,14 +525,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.fake]]
 version = "3.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-iterator]]
-version = "0.3.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.fallible-streaming-iterator]]
-version = "0.1.9"
 criteria = "safe-to-deploy"
 
 [[exemptions.ferroid]]
@@ -1141,10 +1129,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.num-complex]]
 version = "0.4.6"
-criteria = "safe-to-deploy"
-
-[[exemptions.num-conv]]
-version = "0.2.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.num_cpus]]
@@ -1826,10 +1810,6 @@ criteria = "safe-to-deploy"
 [[exemptions.uint]]
 version = "0.10.0"
 criteria = "safe-to-deploy"
-
-[[exemptions.unarray]]
-version = "0.1.4"
-criteria = "safe-to-run"
 
 [[exemptions.unicase]]
 version = "2.7.0"

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -532,6 +532,16 @@ who = "Dan Gohman <dev@sunfishcode.online>"
 criteria = "safe-to-deploy"
 delta = "0.3.9 -> 0.3.10"
 
+[[audits.bytecodealliance.audits.fallible-iterator]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.3.0"
+notes = """
+This major version update has a few minor breaking changes but everything
+this crate has to do with iterators and `Result` and such. No `unsafe` or
+anything like that, all looks good.
+"""
+
 [[audits.bytecodealliance.audits.fastrand]]
 who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
@@ -712,6 +722,12 @@ criteria = "safe-to-deploy"
 version = "0.46.0"
 notes = "one use of unsafe to call windows specific api to get console handle."
 
+[[audits.bytecodealliance.audits.num-conv]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.2.1"
+notes = "Minor update, nothing major"
+
 [[audits.bytecodealliance.audits.num-traits]]
 who = "Andrew Brown <andrew.brown@intel.com>"
 criteria = "safe-to-deploy"
@@ -872,6 +888,15 @@ who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
 version = "0.2.4"
 notes = "Implements a concurrency primitive with atomics, and is not obviously incorrect"
+
+[[audits.bytecodealliance.audits.unarray]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+version = "0.1.4"
+notes = """
+Crate is sound, albeit leaky, and not actively malicious. Probably not the best
+crate to use in practice but it's suitable for testing dependencies.
+"""
 
 [[audits.bytecodealliance.audits.unicode-bidi]]
 who = "Alex Crichton <alex@alexcrichton.com>"
@@ -1756,6 +1781,11 @@ who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.10.6 -> 0.10.7"
 
+[[audits.isrg.audits.either]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+version = "1.6.1"
+
 [[audits.isrg.audits.fiat-crypto]]
 who = "David Cook <dcook@divviup.org>"
 criteria = "safe-to-deploy"
@@ -2014,7 +2044,7 @@ who = "Manish Goregaokar <manishsmail@gmail.com>"
 criteria = "safe-to-deploy"
 user-id = 1139 # Manish Goregaokar (Manishearth)
 start = "2019-11-06"
-end = "2026-02-01"
+end = "2027-04-23"
 notes = "All code written or reviewed by Manish"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
@@ -2224,11 +2254,59 @@ criteria = "safe-to-deploy"
 delta = "0.2.3 -> 0.2.4"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.6.1 -> 1.7.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.7.0 -> 1.8.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Mike Hommey <mh+mozilla@glandium.org>"
+criteria = "safe-to-deploy"
+delta = "1.8.0 -> 1.8.1"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.8.1 -> 1.9.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.9.0 -> 1.10.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.either]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "1.10.0 -> 1.12.0"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
 [[audits.mozilla.audits.errno]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 delta = "0.3.1 -> 0.3.3"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.fallible-streaming-iterator]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.9"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.fastrand]]
 who = "Mike Hommey <mh+mozilla@glandium.org>"
@@ -2544,6 +2622,23 @@ aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-ch
 who = "Erich Gubler <erichdongubler@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.4.26 -> 0.4.29"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Alex Franchuk <afranchuk@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.1.0"
+notes = """
+Very straightforward, simple crate. No dependencies, unsafe, extern,
+side-effectful std functions, etc.
+"""
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.num-conv]]
+who = "Lars Eggert <lars@eggert.org>"
+criteria = "safe-to-deploy"
+delta = "0.1.0 -> 0.2.0"
+notes = "Revision only removes code"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.num-integer]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -792,6 +792,33 @@ who = "Chris Fallin <chris@cfallin.org>"
 criteria = "safe-to-deploy"
 version = "1.0.4"
 
+[[audits.bytecodealliance.audits.rustls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.21.0"
+notes = "no unsafe code, ambient capabilities only used in tests"
+
+[[audits.bytecodealliance.audits.rustls]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.21.0 -> 0.21.6"
+
+[[audits.bytecodealliance.audits.rustls-webpki]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.100.1"
+
+[[audits.bytecodealliance.audits.rustls-webpki]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+delta = "0.100.1 -> 0.101.4"
+
+[[audits.bytecodealliance.audits.sct]]
+who = "Pat Hickey <phickey@fastly.com>"
+criteria = "safe-to-deploy"
+version = "0.7.0"
+notes = "no unsafe, no build, no ambient capabilities"
+
 [[audits.bytecodealliance.audits.semver]]
 who = "Pat Hickey <phickey@fastly.com>"
 criteria = "safe-to-deploy"
@@ -3385,6 +3412,48 @@ who = "Sean Bowe <ewillbefull@gmail.com>"
 criteria = "safe-to-deploy"
 version = "0.3.0"
 aggregated-from = "https://raw.githubusercontent.com/zcash/zcash/master/qa/supply-chain/audits.toml"
+
+[[audits.zcash.audits.rustls]]
+who = "Daira-Emma Hopwood <daira@jacaranda.org>"
+criteria = "safe-to-deploy"
+delta = "0.21.8 -> 0.21.12"
+notes = """
+A comment in get_sni_extension asks whether the behaviour of parsing an IPv4 or IPv6 address
+in a host_name field of a server_name extension, but then ignoring the extension (because
+'Literal IPv4 and IPv6 addresses are not permitted in "HostName"'), as the server, is
+compliant with RFC 6066. As an original author of RFC 3546 which has very similar wording,
+I can speak to the intent: yes this is fine. The client is clearly nonconformant in this
+case, but the server isn't.
+
+RFC 3546 said "If the server understood the client hello extension but does not recognize
+the server name, it SHOULD send an "unrecognized_name" alert (which MAY be fatal)."
+This wording was preserved in RFC 5746, and then updated in RFC 6066 to:
+
+   If the server understood the ClientHello extension but
+   does not recognize the server name, the server SHOULD take one of two
+   actions: either abort the handshake by sending a fatal-level
+   unrecognized_name(112) alert or continue the handshake.  It is NOT
+   RECOMMENDED to send a warning-level unrecognized_name(112) alert,
+   because the client's behavior in response to warning-level alerts is
+   unpredictable.  If there is a mismatch between the server name used
+   by the client application and the server name of the credential
+   chosen by the server, this mismatch will become apparent when the
+   client application performs the server endpoint identification, at
+   which point the client application will have to decide whether to
+   proceed with the communication.
+
+To me it's clear that it is reasonable to consider an IP address as a name that the
+server does not recognize. And so the server SHOULD *either* send a fatal unrecognized_name
+alert, *or* continue the handshake and let the client application decide when it "performs
+the server endpoint identification". There's no conformance requirement for the server to
+take any notice of a host_name that is "not permitted". (It would have been clearer to
+express this by specifying the allowed client and server behaviour separately, i.e. saying
+that the client MUST NOT send an IP address in host_name, and then explicitly specifying
+the server behaviour if it does so anyway. That's how I would write it now. But honestly
+this extension was one of the most bikeshedded parts of RFC 3546, to a much greater extent
+than I'd anticipated, and I was tired.)
+"""
+aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
 
 [[audits.zcash.audits.semver]]
 who = "Jack Grigg <jack@electriccoin.co>"


### PR DESCRIPTION
## Description

Closes #?

## Changes

* Leave URLs for Bitcoin nodes unchanged if they do not contain a username or password.
* Only strip the username and password from the Bitcoin node URL when it is present.

## Testing Information

I tested that the `BitcoinCoreClient` now works when Bitcoin Core is reachable via HTTPS.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
