### PR TITLE
feat: remove the unused merkle root from the signature type wsts enum

### DIFF
--- a/signer/src/dkg/testing.rs
+++ b/signer/src/dkg/testing.rs
@@ -75,7 +75,7 @@ pub fn nonce_request(dkg_id: u64, sign_id: u64, sign_iter_id: u64) -> Message {
         sign_id,
         sign_iter_id,
         message: vec![0; 5],
-        signature_type: SignatureType::Taproot(None),
+        signature_type: SignatureType::Taproot,
     })
 }
 
@@ -102,7 +102,7 @@ pub fn signature_share_request(
         sign_id,
         sign_iter_id,
         message: vec![0; 5],
-        signature_type: SignatureType::Taproot(None),
+        signature_type: SignatureType::Taproot,
         nonce_responses,
     })
 }

--- a/signer/src/error.rs
+++ b/signer/src/error.rs
@@ -245,6 +245,20 @@ pub enum Error {
     #[error("the given sighash is unknown: {0}")]
     UnknownSigHash(SigHash),
 
+    /// This happens when the coordinator requested a WSTS signature type
+    /// that does not match the prevout type this sighash was approved for.
+    #[error(
+        "signature type {signature_type:?} does not match prevout type {prevout_type} for sighash {sighash}"
+    )]
+    SignatureTypeMismatch {
+        /// The sighash the coordinator asked this signer to participate in.
+        sighash: SigHash,
+        /// The prevout type stored when this signer approved the sighash.
+        prevout_type: crate::storage::model::TxPrevoutType,
+        /// The signature type in the coordinator's WSTS request.
+        signature_type: wsts::net::SignatureType,
+    },
+
     /// This should never happen
     #[error("observed a tenure identified by a StacksBlockId with with no blocks")]
     EmptyStacksTenure,

--- a/signer/src/metrics.rs
+++ b/signer/src/metrics.rs
@@ -183,6 +183,7 @@ impl Metrics {
             Err(Error::SigHashConversion(_)) => "improper-sighash",
             Err(Error::UnknownSigHash(_)) => "unknown-sighash",
             Err(Error::InvalidSigHash(_)) => "invalid-sighash",
+            Err(Error::SignatureTypeMismatch { .. }) => "signature-type-mismatch",
             Err(_) => "unexpected-failure",
         };
 

--- a/signer/src/proto/convert.rs
+++ b/signer/src/proto/convert.rs
@@ -841,9 +841,9 @@ impl From<SignatureType> for proto::SignatureType {
             SignatureType::Schnorr => {
                 proto::signature_type::SignatureType::Schnorr(proto::SchnorrSignatureType {})
             }
-            SignatureType::Taproot(root) => {
+            SignatureType::Taproot => {
                 proto::signature_type::SignatureType::Taproot(proto::TaprootSignatureType {
-                    merkle_root: root.map(|v| proto::MerkleRoot { root: Some(v.into()) }),
+                    merkle_root: None,
                 })
             }
         };
@@ -859,12 +859,7 @@ impl TryFrom<proto::SignatureType> for SignatureType {
         Ok(match value.signature_type.required()? {
             proto::signature_type::SignatureType::Frost(_) => SignatureType::Frost,
             proto::signature_type::SignatureType::Schnorr(_) => SignatureType::Schnorr,
-            proto::signature_type::SignatureType::Taproot(taproot) => SignatureType::Taproot(
-                taproot
-                    .merkle_root
-                    .map(|v| Ok::<_, Error>(v.root.required()?.into()))
-                    .transpose()?,
-            ),
+            proto::signature_type::SignatureType::Taproot(_) => SignatureType::Taproot,
         })
     }
 }

--- a/signer/src/storage/memory/read.rs
+++ b/signer/src/storage/memory/read.rs
@@ -674,13 +674,13 @@ impl DbRead for SharedStore {
     async fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
-    ) -> Result<Option<(bool, PublicKeyXOnly)>, Error> {
+    ) -> Result<Option<(bool, PublicKeyXOnly, model::TxPrevoutType)>, Error> {
         Ok(self
             .lock()
             .await
             .bitcoin_sighashes
             .get(sighash)
-            .map(|s| (s.will_sign, s.aggregate_key)))
+            .map(|s| (s.will_sign, s.aggregate_key, s.prevout_type)))
     }
 
     // The postgres implementation uses a timestamp to figure out when a
@@ -1167,7 +1167,7 @@ impl DbRead for InMemoryTransaction {
     async fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
-    ) -> Result<Option<(bool, PublicKeyXOnly)>, Error> {
+    ) -> Result<Option<(bool, PublicKeyXOnly, model::TxPrevoutType)>, Error> {
         self.store.will_sign_bitcoin_tx_sighash(sighash).await
     }
 

--- a/signer/src/storage/mod.rs
+++ b/signer/src/storage/mod.rs
@@ -462,11 +462,12 @@ pub trait DbRead {
         output_index: u32,
     ) -> impl Future<Output = Result<Option<model::DepositRequest>, Error>> + Send;
 
-    /// Get the bitcoin sighash output.
+    /// Get whether this signer will sign the given bitcoin sighash, the
+    /// aggregate key locking the prevout, and the prevout type.
     fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
-    ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly)>, Error>> + Send;
+    ) -> impl Future<Output = Result<Option<(bool, PublicKeyXOnly, model::TxPrevoutType)>, Error>> + Send;
 
     /// Returns the list of stored peers.
     fn get_p2p_peers(&self) -> impl Future<Output = Result<Vec<model::P2PPeer>, Error>> + Send;

--- a/signer/src/storage/postgres/read.rs
+++ b/signer/src/storage/postgres/read.rs
@@ -2472,15 +2472,16 @@ impl PgRead {
     async fn will_sign_bitcoin_tx_sighash<'e, E>(
         executor: &'e mut E,
         sighash: &model::SigHash,
-    ) -> Result<Option<(bool, PublicKeyXOnly)>, Error>
+    ) -> Result<Option<(bool, PublicKeyXOnly, model::TxPrevoutType)>, Error>
     where
         &'e mut E: sqlx::PgExecutor<'e>,
     {
-        sqlx::query_as::<_, (bool, PublicKeyXOnly)>(
+        sqlx::query_as::<_, (bool, PublicKeyXOnly, model::TxPrevoutType)>(
             r#"
             SELECT
                 will_sign
               , x_only_public_key
+              , prevout_type
             FROM sbtc_signer.bitcoin_tx_sighashes
             WHERE sighash = $1
             "#,
@@ -2992,7 +2993,7 @@ impl DbRead for PgStore {
     async fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
-    ) -> Result<Option<(bool, PublicKeyXOnly)>, Error> {
+    ) -> Result<Option<(bool, PublicKeyXOnly, model::TxPrevoutType)>, Error> {
         PgRead::will_sign_bitcoin_tx_sighash(self.get_connection().await?.as_mut(), sighash).await
     }
 
@@ -3465,7 +3466,7 @@ impl DbRead for PgTransaction<'_> {
     async fn will_sign_bitcoin_tx_sighash(
         &self,
         sighash: &model::SigHash,
-    ) -> Result<Option<(bool, crate::keys::PublicKeyXOnly)>, Error> {
+    ) -> Result<Option<(bool, crate::keys::PublicKeyXOnly, model::TxPrevoutType)>, Error> {
         let mut tx = self.tx.lock().await;
         PgRead::will_sign_bitcoin_tx_sighash(tx.as_mut(), sighash).await
     }

--- a/signer/src/testing/dummy.rs
+++ b/signer/src/testing/dummy.rs
@@ -988,11 +988,7 @@ impl Dummy<Unit> for SignatureType {
         match rng.gen_range(0..3usize) {
             0 => SignatureType::Frost,
             1 => SignatureType::Schnorr,
-            2 => SignatureType::Taproot(if rng.gen_bool(0.5) {
-                None
-            } else {
-                Some(Faker.fake_with_rng(rng))
-            }),
+            2 => SignatureType::Taproot,
             _ => unreachable!(),
         }
     }

--- a/signer/src/transaction_coordinator.rs
+++ b/signer/src/transaction_coordinator.rs
@@ -1241,7 +1241,7 @@ where
             &mut frost_coordinator,
             WstsMessageId::DkgVerification(*aggregate_key),
             tap_sighash.as_byte_array(),
-            SignatureType::Taproot(None),
+            SignatureType::Taproot,
         )
         .await
         .inspect_err(|error| {
@@ -1594,7 +1594,7 @@ where
                 &mut fire_coordinator,
                 message_id,
                 &msg,
-                SignatureType::Taproot(None),
+                SignatureType::Taproot,
             )
             .await?;
 

--- a/signer/src/transaction_signer.rs
+++ b/signer/src/transaction_signer.rs
@@ -60,6 +60,7 @@ use lru::LruCache;
 use wsts::net::DkgEnd;
 use wsts::net::DkgStatus;
 use wsts::net::Message as WstsNetMessage;
+use wsts::net::SignatureType;
 
 /// LRU cache max size for the stacks signature requests. This is the number of
 /// bitcoin tenures for which we keep track of the signed stacks transactions.
@@ -167,6 +168,14 @@ pub struct AcceptedSigHash {
     sighash: SigHash,
     /// The public key that is used to lock the above signature hash.
     public_key: PublicKeyXOnly,
+}
+
+/// The WSTS signature type required for an approved bitcoin prevout.
+fn expected_signature_type(prevout_type: model::TxPrevoutType) -> SignatureType {
+    match prevout_type {
+        model::TxPrevoutType::SignersInput => SignatureType::Taproot,
+        model::TxPrevoutType::Deposit => SignatureType::Schnorr,
+    }
 }
 
 /// An enum identifying requests for which we can sign for on stacks only once
@@ -850,8 +859,12 @@ where
                     WstsMessageId::Sweep(txid) => {
                         span.record("txid", txid.to_string());
 
-                        let accepted_sighash =
-                            Self::validate_bitcoin_sign_request(&db, &request.message).await;
+                        let accepted_sighash = Self::validate_bitcoin_sign_request(
+                            &db,
+                            &request.message,
+                            request.signature_type,
+                        )
+                        .await;
 
                         Metrics::increment_bitcoin_validation(&accepted_sighash);
 
@@ -939,10 +952,14 @@ where
 
                         // Validate the sighash and upon success, convert it to
                         // a state machine ID.
-                        Self::validate_bitcoin_sign_request(&db, &request.message)
-                            .await?
-                            .sighash
-                            .into()
+                        Self::validate_bitcoin_sign_request(
+                            &db,
+                            &request.message,
+                            request.signature_type,
+                        )
+                        .await?
+                        .sighash
+                        .into()
                     }
 
                     // This is a DKG verification signing round. The data
@@ -1197,8 +1214,13 @@ where
     }
 
     /// Check whether we will sign the message, which is supposed to be a
-    /// bitcoin sighash
-    async fn validate_bitcoin_sign_request<D>(db: &D, msg: &[u8]) -> Result<AcceptedSigHash, Error>
+    /// bitcoin sighash, and that the requested signature type matches the
+    /// prevout this sighash was approved for.
+    async fn validate_bitcoin_sign_request<D>(
+        db: &D,
+        msg: &[u8],
+        signature_type: SignatureType,
+    ) -> Result<AcceptedSigHash, Error>
     where
         D: DbRead,
     {
@@ -1207,8 +1229,17 @@ where
             .into();
 
         match db.will_sign_bitcoin_tx_sighash(&sighash).await? {
-            Some((true, public_key)) => Ok(AcceptedSigHash { public_key, sighash }),
-            Some((false, _)) => Err(Error::InvalidSigHash(sighash)),
+            Some((true, public_key, prevout_type)) => {
+                if signature_type != expected_signature_type(prevout_type) {
+                    return Err(Error::SignatureTypeMismatch {
+                        sighash,
+                        prevout_type,
+                        signature_type,
+                    });
+                }
+                Ok(AcceptedSigHash { public_key, sighash })
+            }
+            Some((false, ..)) => Err(Error::InvalidSigHash(sighash)),
             None => Err(Error::UnknownSigHash(sighash)),
         }
     }
@@ -1684,6 +1715,88 @@ mod tests {
             num_signers: 7,
             test_model_parameters,
         }
+    }
+
+    type MemorySigner = TxSignerEventLoop<
+        TestContext<
+            SharedStore,
+            WrappedMock<MockBitcoinInteract>,
+            WrappedMock<MockStacksInteract>,
+            WrappedMock<MockEmilyInteract>,
+        >,
+        network::in_memory::MpmcBroadcaster,
+    >;
+
+    async fn check_bitcoin_sign_request(
+        prevout_type: model::TxPrevoutType,
+        signature_type: SignatureType,
+    ) -> (SigHash, Result<AcceptedSigHash, Error>) {
+        let context = TestContext::builder()
+            .with_in_memory_storage()
+            .with_mocked_clients()
+            .build();
+        let db = context.get_storage_mut();
+        let mut rng = get_rng();
+        let sighash: SigHash = Faker.fake_with_rng(&mut rng);
+        db.write_bitcoin_txs_sighashes(&[model::BitcoinTxSigHash {
+            txid: Faker.fake_with_rng(&mut rng),
+            chain_tip: Faker.fake_with_rng(&mut rng),
+            prevout_txid: Faker.fake_with_rng(&mut rng),
+            prevout_output_index: 0,
+            sighash,
+            prevout_type,
+            validation_result: crate::bitcoin::validation::InputValidationResult::Ok,
+            is_valid_tx: true,
+            will_sign: true,
+            aggregate_key: Faker.fake_with_rng(&mut rng),
+        }])
+        .await
+        .unwrap();
+        let result = MemorySigner::validate_bitcoin_sign_request(
+            &db,
+            sighash.as_byte_array(),
+            signature_type,
+        )
+        .await;
+        (sighash, result)
+    }
+
+    #[test_case(model::TxPrevoutType::Deposit, SignatureType::Schnorr ; "deposit-schnorr")]
+    #[test_case(model::TxPrevoutType::SignersInput, SignatureType::Taproot ; "signers-input-taproot")]
+    #[tokio::test]
+    async fn bitcoin_sign_request_accepts_matching_signature_type(
+        prevout_type: model::TxPrevoutType,
+        signature_type: SignatureType,
+    ) {
+        let (sighash, result) = check_bitcoin_sign_request(prevout_type, signature_type).await;
+        let accepted = result.expect("matching signature type should be accepted");
+        assert_eq!(accepted.sighash, sighash);
+    }
+
+    #[test_case(model::TxPrevoutType::Deposit, SignatureType::Taproot ; "deposit-taproot")]
+    #[test_case(model::TxPrevoutType::SignersInput, SignatureType::Schnorr ; "signers-input-schnorr")]
+    #[test_case(model::TxPrevoutType::Deposit, SignatureType::Frost ; "deposit-frost")]
+    #[test_case(model::TxPrevoutType::SignersInput, SignatureType::Frost ; "signers-input-frost")]
+    #[tokio::test]
+    async fn bitcoin_sign_request_rejects_mismatched_signature_type(
+        prevout_type: model::TxPrevoutType,
+        signature_type: SignatureType,
+    ) {
+        let (sighash, result) = check_bitcoin_sign_request(prevout_type, signature_type).await;
+        let error = match result {
+            Err(error) => error,
+            Ok(_) => panic!("mismatched signature type should be rejected"),
+        };
+        assert!(matches!(
+            error,
+            Error::SignatureTypeMismatch {
+                sighash: rejected,
+                prevout_type: rejected_prevout,
+                signature_type: rejected_type,
+            } if rejected == sighash
+                && rejected_prevout == prevout_type
+                && rejected_type == signature_type
+        ));
     }
 
     #[ignore = "we have a test for this"]

--- a/signer/tests/integration/postgres.rs
+++ b/signer/tests/integration/postgres.rs
@@ -4881,8 +4881,9 @@ async fn can_write_and_get_multiple_bitcoin_txs_sighashes() {
     let results = join_all(withdrawal_outputs_futures).await;
 
     for (output, result) in sighashes.iter().zip(results) {
-        let (result, _) = result.unwrap().unwrap();
-        assert_eq!(result, output.will_sign);
+        let (will_sign, _, prevout_type) = result.unwrap().unwrap();
+        assert_eq!(will_sign, output.will_sign);
+        assert_eq!(prevout_type, output.prevout_type);
     }
     signer::testing::storage::drop_db(db).await;
 }

--- a/signer/tests/integration/transaction_signer.rs
+++ b/signer/tests/integration/transaction_signer.rs
@@ -658,14 +658,14 @@ async fn assert_should_be_able_to_handle_sbtc_requests() {
 
     // Check that the intentions to sign the requests sighashes
     // are stored in the database
-    let (will_sign, _) = db
+    let (will_sign, ..) = db
         .will_sign_bitcoin_tx_sighash(&signer_digest.sighash.into())
         .await
         .expect("query to check if signer sighash is stored failed")
         .expect("signer sighash not stored");
 
     assert!(will_sign);
-    let (will_sign, _) = db
+    let (will_sign, ..) = db
         .will_sign_bitcoin_tx_sighash(&deposit_digest.sighash.into())
         .await
         .expect("query to check if deposit sighash is stored failed")

--- a/wsts/src/net.rs
+++ b/wsts/src/net.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
 
 use crate::{
-    common::{MerkleRoot, PolyCommitment, PublicNonce, SignatureShare, TupleProof},
+    common::{PolyCommitment, PublicNonce, SignatureShare, TupleProof},
     curve::point::Point,
 };
 
@@ -209,8 +209,8 @@ pub enum SignatureType {
     Frost,
     /// BIP-340 Schnorr proof
     Schnorr,
-    /// BIP-341 Taproot style schnorr proof with a merkle root
-    Taproot(Option<MerkleRoot>),
+    /// BIP-341 Taproot style schnorr proof without a merkle root
+    Taproot,
 }
 
 #[derive(Clone, PartialEq)]

--- a/wsts/src/state_machine/coordinator/fire.rs
+++ b/wsts/src/state_machine/coordinator/fire.rs
@@ -176,7 +176,7 @@ impl Coordinator {
                         return Ok((None, None));
                     } else if self.state == State::Idle {
                         // We are done with the DKG round! Return the operation result
-                        if let SignatureType::Taproot(_) = signature_type {
+                        if let SignatureType::Taproot = signature_type {
                             if let Some(schnorr_proof) = &self.schnorr_proof {
                                 return Ok((
                                     None,
@@ -837,13 +837,13 @@ impl Coordinator {
 
             self.aggregator.init(&self.party_polynomials)?;
 
-            if let SignatureType::Taproot(merkle_root) = signature_type {
+            if let SignatureType::Taproot = signature_type {
                 let schnorr_proof = self.aggregator.sign_taproot(
                     &self.message,
                     &nonces,
                     &shares,
                     &key_ids,
-                    merkle_root,
+                    None,
                 )?;
                 debug!("SchnorrProof ({}, {})", schnorr_proof.r, schnorr_proof.s);
                 self.schnorr_proof = Some(schnorr_proof);
@@ -1156,13 +1156,7 @@ pub mod test {
     fn check_signature_shares_v2() {
         check_signature_shares::<FireCoordinator>(5, 2, SignatureType::Frost, vec![0]);
         check_signature_shares::<FireCoordinator>(5, 2, SignatureType::Schnorr, vec![0]);
-        check_signature_shares::<FireCoordinator>(5, 2, SignatureType::Taproot(None), vec![0]);
-        check_signature_shares::<FireCoordinator>(
-            5,
-            2,
-            SignatureType::Taproot(Some([23u8; 32])),
-            vec![0],
-        );
+        check_signature_shares::<FireCoordinator>(5, 2, SignatureType::Taproot, vec![0]);
     }
 
     #[test]

--- a/wsts/src/state_machine/coordinator/frost.rs
+++ b/wsts/src/state_machine/coordinator/frost.rs
@@ -168,7 +168,7 @@ impl Coordinator {
                         return Ok((None, None));
                     } else if self.state == State::Idle {
                         // We are done with the DKG round! Return the operation result
-                        if let SignatureType::Taproot(_) = signature_type {
+                        if let SignatureType::Taproot = signature_type {
                             let schnorr_proof = self
                                 .schnorr_proof
                                 .as_ref()
@@ -607,14 +607,10 @@ impl Coordinator {
 
             self.aggregator.init(&self.party_polynomials)?;
 
-            if let SignatureType::Taproot(merkle_root) = signature_type {
-                let schnorr_proof = self.aggregator.sign_taproot(
-                    &self.message,
-                    &nonces,
-                    shares,
-                    &key_ids,
-                    merkle_root,
-                )?;
+            if let SignatureType::Taproot = signature_type {
+                let schnorr_proof =
+                    self.aggregator
+                        .sign_taproot(&self.message, &nonces, shares, &key_ids, None)?;
                 debug!(
                     r = %schnorr_proof.r,
                     s = %schnorr_proof.s,
@@ -916,13 +912,7 @@ pub mod test {
     fn check_signature_shares_v2() {
         check_signature_shares::<FrostCoordinator>(5, 2, SignatureType::Frost, vec![0]);
         check_signature_shares::<FrostCoordinator>(5, 2, SignatureType::Schnorr, vec![0]);
-        check_signature_shares::<FrostCoordinator>(5, 2, SignatureType::Taproot(None), vec![0]);
-        check_signature_shares::<FrostCoordinator>(
-            5,
-            2,
-            SignatureType::Taproot(Some([23u8; 32])),
-            vec![0],
-        );
+        check_signature_shares::<FrostCoordinator>(5, 2, SignatureType::Taproot, vec![0]);
     }
 
     #[test]

--- a/wsts/src/state_machine/coordinator/mod.rs
+++ b/wsts/src/state_machine/coordinator/mod.rs
@@ -627,13 +627,13 @@ pub mod test {
                 }
             }
             OperationResult::SignTaproot(sig) => {
-                if let SignatureType::Taproot(merkle_root) = signature_type {
+                if let SignatureType::Taproot = signature_type {
                     for coordinator in coordinators.iter() {
                         let tweaked_public_key = compute::tweaked_public_key(
                             &coordinator
                                 .get_aggregate_public_key()
                                 .expect("No aggregate public key set!"),
-                            merkle_root,
+                            None,
                         );
 
                         assert!(sig.verify(&tweaked_public_key.x(), msg));
@@ -667,13 +667,7 @@ pub mod test {
             &mut coordinators,
             &mut signers,
             &msg,
-            SignatureType::Taproot(None),
-        );
-        run_sign::<Coordinator>(
-            &mut coordinators,
-            &mut signers,
-            &msg,
-            SignatureType::Taproot(Some([128u8; 32])),
+            SignatureType::Taproot,
         );
     }
 

--- a/wsts/src/state_machine/signer/mod.rs
+++ b/wsts/src/state_machine/signer/mod.rs
@@ -607,9 +607,9 @@ impl Signer {
             let signer_ids = signer_id_set.into_iter().collect::<Vec<_>>();
             let msg = &sign_request.message;
             let signature_shares = match sign_request.signature_type {
-                SignatureType::Taproot(merkle_root) => {
+                SignatureType::Taproot => {
                     self.signer
-                        .sign_taproot(msg, &signer_ids, &key_ids, &nonces, merkle_root)?
+                        .sign_taproot(msg, &signer_ids, &key_ids, &nonces, None)?
                 }
                 SignatureType::Schnorr => {
                     self.signer


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2107

## Changes

* We do not use the Merkle root of the Taproot signature type, so this PR removes it.
* We should also check that the signature type that we get matches the one that we expect. This PR does that.

## Testing Information

I added some unit tests. I also tested the signer in the main devenv, and everything worked as expected.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
