### PR TITLE
feat: add a command that computes the current sbtc signers' address

### DIFF
--- a/sbtc/README.md
+++ b/sbtc/README.md
@@ -4,7 +4,9 @@ A library for creating Bitcoin deposit transactions that can be handled by the s
 
 ## CLI
 
-The `sbtc` binary computes a Bitcoin address for an sBTC deposit. This is useful for independent verification of deposit addresses. Before sending Bitcoin to a computed address, users are strongly encouraged to use the [bridge](https://sbtc.stacks.co), which registers the deposit with Emily as required to complete the deposit and obtain sBTC.
+The `sbtc` binary provides utilities for working with sBTC Bitcoin addresses. It
+can independently construct deposit addresses and retrieve the current signers'
+Bitcoin address from the sBTC registry.
 
 Build the CLI with the `cli` feature enabled from the root of this repository:
 
@@ -12,14 +14,29 @@ Build the CLI with the `cli` feature enabled from the root of this repository:
 $ cargo build --release -p sbtc --features cli
 ```
 
-The official Stacks guide to [pegging BTC into sBTC](https://docs.stacks.co/more-guides/sbtc/bridging-bitcoin/btc-to-sbtc) is another source for constructing sBTC deposit addresses and integrating the complete deposit flow.
-
-Display the available commands, or detailed help for `compute-deposit-address`, with:
+Display the available commands or detailed help for either command with:
 
 ```console
 $ ./target/release/sbtc --help
 $ ./target/release/sbtc compute-deposit-address --help
+$ ./target/release/sbtc signers-address --help
 ```
+
+### Signers address
+
+Return the current sBTC signers' Bitcoin address with:
+
+```console
+$ ./target/release/sbtc signers-address
+```
+
+This fetches the current aggregate public key from the sBTC registry and derives the signers' key-path Taproot address. Use `--network` to select the Bitcoin network, `--stacks-api-url` to query a different Stacks API endpoint, and `--deployer` to select a different sBTC registry deployer.
+
+### Deposit address construction
+
+The official Stacks guide to [pegging BTC into sBTC](https://docs.stacks.co/more-guides/sbtc/bridging-bitcoin/btc-to-sbtc) is another source for constructing sBTC deposit addresses and integrating the complete deposit flow.
+
+Constructing an address is useful for independent verification. Before sending Bitcoin to a computed address, users are strongly encouraged to use the [bridge](https://sbtc.stacks.co), which registers the deposit with Emily as required to complete the deposit and obtain sBTC.
 
 Run the command from the repository root with:
 

--- a/sbtc/src/main.rs
+++ b/sbtc/src/main.rs
@@ -1,12 +1,14 @@
-//! Command-line utility for constructing sBTC deposit addresses.
+//! Command-line utilities for working with sBTC Bitcoin addresses.
 
 use std::str::FromStr as _;
 use std::time::Duration;
 
+use bitcoin::Address;
 use bitcoin::Network;
 use bitcoin::ScriptBuf;
 use bitcoin::XOnlyPublicKey;
 use bitcoin::opcodes::all as opcodes;
+use bitcoin::secp256k1::Secp256k1;
 use clap::Args;
 use clap::Parser;
 use clap::Subcommand;
@@ -55,6 +57,24 @@ struct Cli {
 enum Command {
     /// Compute the Bitcoin address for an sBTC deposit.
     ComputeDepositAddress(ComputeDepositAddress),
+    /// Return the current sBTC signers' Bitcoin address.
+    SignersAddress(SignersAddress),
+}
+
+#[derive(Debug, Args)]
+struct SignersAddress {
+    /// The Bitcoin network for the resulting address.
+    #[arg(long, value_enum, default_value_t = BitcoinNetwork::Mainnet)]
+    network: BitcoinNetwork,
+
+    /// Base URL for the Stacks API used to query the sBTC registry smart
+    /// contract.
+    #[arg(long, default_value = DEFAULT_STACKS_API_URL)]
+    stacks_api_url: String,
+
+    /// The Stacks address that deployed the sBTC registry smart contract.
+    #[arg(long, default_value = DEFAULT_DEPLOYER)]
+    deployer: String,
 }
 
 #[derive(Debug, Args)]
@@ -133,7 +153,17 @@ struct DataVarResponse {
 async fn main() -> Result<(), Error> {
     match Cli::parse().command {
         Command::ComputeDepositAddress(args) => compute_deposit_address(args).await,
+        Command::SignersAddress(args) => signers_address(args).await,
     }
+}
+
+async fn signers_address(args: SignersAddress) -> Result<(), Error> {
+    let aggregate_key = fetch_aggregate_key(&args.stacks_api_url, &args.deployer).await?;
+    let secp = Secp256k1::verification_only();
+    let network: Network = args.network.into();
+    let address = Address::p2tr(&secp, aggregate_key, None, network);
+    println!("{address}");
+    Ok(())
 }
 
 async fn compute_deposit_address(args: ComputeDepositAddress) -> Result<(), Error> {
@@ -237,7 +267,9 @@ mod tests {
             KEY,
         ])
         .unwrap();
-        let Command::ComputeDepositAddress(args) = cli.command;
+        let Command::ComputeDepositAddress(args) = cli.command else {
+            panic!("expected compute-deposit-address command");
+        };
 
         assert_eq!(args.max_fee, DEFAULT_MAX_FEE);
         assert_eq!(args.lock_time, DEFAULT_LOCK_TIME);
@@ -245,6 +277,40 @@ mod tests {
         assert_eq!(args.deployer, DEFAULT_DEPLOYER);
         assert!(args.signers_aggregate_pubkey.is_none());
         assert!(matches!(args.network, BitcoinNetwork::Mainnet));
+    }
+
+    #[test]
+    fn signers_address_defaults() {
+        let cli = Cli::try_parse_from(["sbtc", "signers-address"]).unwrap();
+        let Command::SignersAddress(args) = cli.command else {
+            panic!("expected signers-address command");
+        };
+
+        assert_eq!(args.stacks_api_url, DEFAULT_STACKS_API_URL);
+        assert_eq!(args.deployer, DEFAULT_DEPLOYER);
+        assert!(matches!(args.network, BitcoinNetwork::Mainnet));
+    }
+
+    #[test]
+    fn signers_address_options_are_accepted() {
+        let cli = Cli::try_parse_from([
+            "sbtc",
+            "signers-address",
+            "--network",
+            "regtest",
+            "--stacks-api-url",
+            "http://localhost:3999/",
+            "--deployer",
+            "ST000000000000000000002AMW42H",
+        ])
+        .unwrap();
+        let Command::SignersAddress(args) = cli.command else {
+            panic!("expected signers-address command");
+        };
+
+        assert_eq!(args.stacks_api_url, "http://localhost:3999/");
+        assert_eq!(args.deployer, "ST000000000000000000002AMW42H");
+        assert!(matches!(args.network, BitcoinNetwork::Regtest));
     }
 
     #[test]
@@ -259,7 +325,9 @@ mod tests {
             KEY,
         ])
         .unwrap();
-        let Command::ComputeDepositAddress(args) = cli.command;
+        let Command::ComputeDepositAddress(args) = cli.command else {
+            panic!("expected compute-deposit-address command");
+        };
 
         assert_eq!(args.signers_aggregate_pubkey.as_deref(), Some(KEY));
     }


### PR DESCRIPTION
## Description

Closes #?

I want this CLI command so we can more easily automate getting the sBTC signer's current address without duplicating any code.

## Changes

* Add a command for computing the current sBTC signers' address.

## Testing Information

I tried this locally, and it worked.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
