### PR TITLE
chore: more logging in Emily

### DIFF
--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -3,7 +3,6 @@
 use crate::common::error::ErrorResponse;
 
 use std::convert::Infallible;
-use tracing::error;
 use warp::{Rejection, Reply, http::StatusCode};
 
 /// Chainstate handlers.
@@ -28,7 +27,7 @@ pub mod withdrawal;
 
 /// Central error handler for Warp rejections, converting them to appropriate HTTP responses.
 pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
-    error!(error = ?err, "Emily request rejected");
+    tracing::debug!(error = ?err, "Emily request rejected");
     if err.is_not_found() {
         let json = warp::reply::json(&ErrorResponse {
             message: format!("Not Found {err:?}"),

--- a/emily/handler/src/api/handlers/mod.rs
+++ b/emily/handler/src/api/handlers/mod.rs
@@ -28,6 +28,7 @@ pub mod withdrawal;
 
 /// Central error handler for Warp rejections, converting them to appropriate HTTP responses.
 pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> {
+    error!(error = ?err, "Emily request rejected");
     if err.is_not_found() {
         let json = warp::reply::json(&ErrorResponse {
             message: format!("Not Found {err:?}"),
@@ -52,7 +53,6 @@ pub async fn handle_rejection(err: Rejection) -> Result<impl Reply, Infallible> 
         ));
     }
 
-    error!("Unhandled error: {:?}", err);
     let json = warp::reply::json(&ErrorResponse {
         message: format!("Internal Server Error: {err:?}"),
     });

--- a/emily/handler/src/bin/emily-lambda.rs
+++ b/emily/handler/src/bin/emily-lambda.rs
@@ -45,7 +45,13 @@ async fn main() {
                 .get("x-amzn-trace-id")
                 .and_then(|v| v.to_str().ok())
                 .unwrap_or("unknown");
-            info_span!("request", request_id = tracing::field::Empty, trace_id = %trace_id)
+            info_span!(
+                "request",
+                request_id = tracing::field::Empty,
+                trace_id = %trace_id,
+                method = %info.method(),
+                path = info.path(),
+            )
         }))
         .with(warp::log("api"))
         .with(cors);

--- a/emily/handler/src/bin/emily-server.rs
+++ b/emily/handler/src/bin/emily-server.rs
@@ -89,6 +89,9 @@ async fn main() {
 
     let routes = api::routes::routes(context)
         .recover(api::handlers::handle_rejection)
+        .with(warp::trace(
+            |info| tracing::info_span!("request", method = %info.method(), path = info.path()),
+        ))
         .with(warp::log("api"))
         .with(cors);
 

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -411,13 +411,14 @@ impl Reject for Error {}
 /// provided directly from Warp as a reply.
 impl Reply for Error {
     /// Convert self into a warp response.
-    #[cfg(not(feature = "testing"))]
-    fn into_response(self: Error) -> warp::reply::Response {
-        self.into_production_error().into_response()
-    }
-    /// Convert self into a warp response.
-    #[cfg(feature = "testing")]
     fn into_response(self) -> warp::reply::Response {
-        self.into_response()
+        // Log before production sanitization discards the underlying error.
+        // Debug includes nested SDK error details that Display can omit.
+        tracing::error!(error = ?self, "Emily request failed");
+        #[cfg(not(feature = "testing"))]
+        let error = self.into_production_error();
+        #[cfg(feature = "testing")]
+        let error = self;
+        error.into_response()
     }
 }

--- a/emily/handler/src/common/error.rs
+++ b/emily/handler/src/common/error.rs
@@ -419,6 +419,6 @@ impl Reply for Error {
         let error = self.into_production_error();
         #[cfg(feature = "testing")]
         let error = self;
-        error.into_response()
+        Error::into_response(error)
     }
 }


### PR DESCRIPTION
## Description

Closes https://github.com/stacks-sbtc/sbtc/issues/2117

## Changes

* Include the request method and path in our logs.
* Always log the original error when converting an `Error` into a `Reply`.

## Testing Information

Well, Emily is built in CI and run during our integration tests, so if those pass, we are good. I also looked at Emily in devenv, and she was fine.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have had an AI agent review my code
